### PR TITLE
feat(plugins+webui): parallel-worktree-conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ Spec/
 # Iterate 12.0 helper lock files (append_changelog_entry, append_phase_history)
 *.md.lock
 *.json.lock
+
+# Git worktrees (per Shipwright parallel-iterate convention — see /shipwright-iterate B1a)
+.worktrees/

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1298,6 +1298,111 @@ Shipwright runs a CLAUDE.md drift check automatically at every session start (vi
 
 ---
 
+## 8.5 Parallel Development with Worktrees
+
+**When you want this:** you are mid-iterate on one topic and an unrelated fix or feature surfaces. Blocking the new work until the current iterate ships is wasteful; creating a second branch in the same working tree requires stashing uncommitted work. Git worktrees give you a second checkout of the same repo, on a different branch, in a sibling directory — same git history, isolated files.
+
+Shipwright embeds the conventions for this directly in `/shipwright-iterate` B1 (the "Parallel" option) and in `/shipwright-build` Step E. This chapter is the hands-on walkthrough and pitfall reference.
+
+### Mental model
+
+- A worktree is a second working directory bound to the same `.git`. Commits, branches, tags, remotes are shared.
+- Each worktree has its own checked-out branch. Two worktrees cannot share a branch.
+- `.worktrees/<slug>/` inside the repo is the Shipwright convention (the folder is `.gitignore`'d so it never gets committed).
+- Branches for parallel iterates always start from the project's **default branch** (resolved dynamically via `git symbolic-ref refs/remotes/origin/HEAD`, fallback `main`), never from another `iterate/*`.
+
+### Setup walkthrough
+
+Run this from the main repo root:
+
+```bash
+# Resolve default branch (no hardcoded `main`):
+DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@' || echo main)
+
+# Check preconditions:
+SLUG=parallel-fix-xyz
+git worktree list | grep -q ".worktrees/$SLUG" && { echo "worktree exists"; exit 1; }
+git branch --list "iterate/$SLUG" | grep -q . && { echo "branch exists"; exit 1; }
+
+# Create worktree + branch from default:
+git worktree add ".worktrees/$SLUG" -b "iterate/$SLUG" "$DEFAULT_BRANCH"
+cd ".worktrees/$SLUG"
+
+# Re-hydrate ENVs and dependencies (worktrees carry neither):
+[ -f ../../.env.local ]          && cp ../../.env.local .env.local
+[ -f ../../.env ]                && cp ../../.env .env
+[ -f package.json ]              && npm install
+[ -f webui/client/package.json ] && (cd webui/client && npm install)
+[ -f webui/server/package.json ] && (cd webui/server && npm install)
+[ -f pyproject.toml ]            && uv sync
+```
+
+Open a new Claude Code session (or editor window) inside `.worktrees/$SLUG` and run `/shipwright-iterate` fresh. B1 will detect the original iterate branch, but since you are now on `iterate/$SLUG` inside the worktree, the Resume/Parallel prompt resolves cleanly (self-exclusion via `git rev-parse --show-toplevel`).
+
+### Dev-server workflow
+
+By default the Shipwright WebUI dev server binds fixed ports: Hono `3847`, Vite `5173`, Vite alt `5177`. Only one instance can run. For parallel worktrees with two dev-server stacks:
+
+```bash
+# Main worktree (defaults):
+cd webui/server && npm run dev          # Hono 3847
+cd webui/client && npm run dev          # Vite 5173 (proxies /api → 3847)
+
+# Parallel worktree (overrides):
+PORT=3848 (cd webui/server && npm run dev)                   # Hono 3848
+PORT=3848 VITE_PORT=5174 (cd webui/client && npm run dev)    # Vite 5174, proxies /api → 3848
+```
+
+The `PORT` env var controls Hono only; `VITE_PORT` controls Vite only. The Vite proxy dynamically reads `process.env.PORT` so it routes to the right Hono instance. `strictPort: true` ensures Vite fails loud if the port is taken, rather than silently falling back to `port+1` and breaking the restart helper.
+
+If only one dev server is acceptable, leave the parallel worktree running tests and build only (`npm run test`, `npm run build`, `npm run typecheck`) — no dev-server required for most iterate work.
+
+### Pitfalls
+
+1. **CHANGELOG.md `[Unreleased]` merge hotspot.** Every iterate's F4 step appends to the same section. Two parallel iterates → merge conflict on the second PR. Workflow today: the second PR rebases and resolves the bullet merge manually (usually trivial). Structural fix (`CHANGELOG-unreleased.d/` drop pattern) is tracked under the iterate_history refactor.
+2. **`iterate_history[]` merge conflict on adopted projects.** `shipwright_run_config.json` has an `iterate_history` array that the finalize hook appends to. Parallel iterates produce a merge conflict here too. Use the parallel workflow on adopted projects only if you accept manual resolution. Structural fix (file-per-iterate) must land before adopting the shipwright monorepo itself.
+3. **`shipwright_run_config.json` is not multi-writer safe.** Several phase configs write to this file. Avoid concurrent writes on the same target project from parallel worktrees.
+4. **`.env*` and `node_modules` do not transfer.** Worktrees carry tracked files only. The setup snippet above re-hydrates both — do not skip it.
+5. **Editor / VSCode.** Open the worktree as a separate workspace window, not as a subfolder of the main repo workspace. File-watcher noise and project-wide search behave poorly on nested worktrees.
+6. **Hot-module-reload (HMR).** Vite's HMR uses the same port as the dev server by default; two instances with different `VITE_PORT` values each get their own HMR port automatically. Do **not** pin `server.hmr.port` explicitly — that would force both instances onto one HMR port and create the exact collision this chapter aims to avoid.
+7. **Stale iterate branches.** `/shipwright-iterate` B1 detection filters branches already merged into the default branch (via `git merge-base --is-ancestor`). If B1 still prompts on a branch you thought was gone, delete it: `git branch -D iterate/<stale-slug>`.
+
+### Cleanup
+
+Worktree removal does **not** delete the branch. Both steps are needed after PR merge:
+
+```bash
+# From the main repo (not from inside the worktree):
+git worktree remove .worktrees/parallel-fix-xyz
+git branch -D iterate/parallel-fix-xyz
+```
+
+For an unmerged worktree you want to discard:
+
+```bash
+git worktree remove --force .worktrees/parallel-fix-xyz
+git branch -D iterate/parallel-fix-xyz
+```
+
+For a dormant worktree that is no longer listed but leaves a stale entry in `git worktree list`:
+
+```bash
+git worktree prune
+```
+
+### When to use which approach
+
+| Situation | Approach |
+|-----------|----------|
+| Unrelated fix that blocks nothing | Parallel worktree — keep the original iterate running |
+| Related follow-up on the same topic | Stay in the current iterate; add a sub-task |
+| Conflicting change on the same files | Serialize — parallelize only disjoint file scopes |
+| Quick one-line doc fix | Commit directly on the current branch or a tiny standalone branch; worktree overhead not worth it |
+
+See also: the embedded conventions in `plugins/shipwright-iterate/skills/iterate/SKILL.md` section **B1a**, and `plugins/shipwright-build/skills/build/SKILL.md` section **E** for the skill-level enforcement.
+
+---
+
 ## 9. Quality and Safety
 
 Shipwright enforces quality through **mechanical enforcement** -- hooks that block or warn deterministically, not advisory prose that agents may ignore. This follows the "linters over instructions" principle.

--- a/docs/hooks-and-pipeline.md
+++ b/docs/hooks-and-pipeline.md
@@ -427,6 +427,13 @@ promoted, even if their id hypothetically coincides with a gate id.
 | Stop | — | `audit_phase_quality_on_stop.py` (shared) | Phase-quality audit (canon C1-C5 + W2/W3 iterate workflow + I1-I4 infrastructure + T1/T2 traceability + Q1 ADR substance + S2 iterate-spec for medium+ + S3 miniplan Tier-2 + S4 FR-preservation Tier-2 + S5 FR-coherence Tier-2 + S9 README-freshness Tier-2 + S10 CLAUDE.md-sync Tier-2) — runs **after** finalize so F5a/F5b/F7/F11 evidence is on disk |
 | Stop | — | `write_terminal_marker.py` | Writes `.shipwright/runs/<loop_id>/<unit_id>/DONE` (no-op without loop env vars) |
 
+**B1 parallel-iterate detection (2026-04-23):** `/shipwright-iterate` reads git metadata at startup to decide whether to offer the Parallel option:
+(1) `git branch --list "iterate/*"` for candidate branches,
+(2) `git symbolic-ref refs/remotes/origin/HEAD` for the project's default branch,
+(3) `git merge-base --is-ancestor` to filter already-merged stale branches (surface as cleanup hint, not in-progress run),
+(4) `git rev-parse --show-toplevel` + worktree-path check to exclude the current branch when running inside a secondary worktree (prevents infinite Parallel-prompt loop).
+No new hook is registered; detection runs as part of B1. Corresponding conventions live in SKILL.md B1a. `/shipwright-build` Step E picked up the same default-branch anchor via conditional `git show-ref --quiet` bifurcation (Resume path unchanged).
+
 ### shipwright-changelog
 
 | Event | Matcher | Script | What It Does |

--- a/plugins/shipwright-build/skills/build/SKILL.md
+++ b/plugins/shipwright-build/skills/build/SKILL.md
@@ -202,16 +202,24 @@ Parse the JSON output:
 
 **Always create a feature branch before making changes.**
 
-The setup script (Step D) returns `branch_name` in its JSON output. Use it directly:
+The setup script (Step D) returns `branch_name` in its JSON output. The create path must anchor the new branch on the project's default branch (not whatever HEAD happens to be — ad-hoc `/shipwright-build --from <section>` can be invoked from any branch). The resume path is unchanged:
 
 ```bash
-git checkout -b {branch_name}
+if git show-ref --quiet refs/heads/{branch_name}; then
+  # Resume path — unchanged
+  git checkout {branch_name}
+else
+  # Create path — anchor on default branch for deterministic base
+  DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@' || echo main)
+  git checkout "$DEFAULT_BRANCH"
+  git checkout -b {branch_name}
+fi
 ```
 
 Branch naming pattern: `build/{project-slug}-{session-id}` (e.g., `build/my-app-20260411-120000`).
 Fallback without run config: `build/{session-id}`. Fallback without session-id: `build/{section-name}`.
 
-If branch already exists (resume): `git checkout {branch_name}`
+For parallel build runs on different sections, the same worktree conventions from `/shipwright-iterate` B1a apply (branch from default, `.worktrees/<slug>` inside repo, disjoint file scopes). The pipeline default (sequential builds) is not affected.
 
 ### F. Load Config
 

--- a/plugins/shipwright-changelog/skills/changelog/SKILL.md
+++ b/plugins/shipwright-changelog/skills/changelog/SKILL.md
@@ -190,6 +190,15 @@ gh pr create \
   --base main
 ```
 
+> **Parallel Iterate Handling**
+>
+> - Multiple open PRs against the same default branch: rebase per PR is expected — no skill-logic change required.
+> - `gh pr merge --merge` vs `--squash`: the default stays `--merge`; `--squash` is optional for parallel-iterate PRs when linear history matters.
+> - Tag creation is single-writer (only the release-iterate tags a version) — no concurrency change needed.
+> - Conventional-Commit sort is deterministic: merge order does not affect changelog ordering.
+> - **`CHANGELOG.md [Unreleased]` is a merge hotspot.** Every iterate F4 appends to `[Unreleased]`. Two parallel iterates conflict on merge — the second PR rebases and resolves the bullet merge manually. Structural fix tracked as a `CHANGELOG-unreleased.d/` drop pattern bundled with the iterate_history file-per-iterate refactor.
+> - Full parallel-iterate conventions live in `/shipwright-iterate` B1a.
+
 **Autonomous mode:** After creating the PR, merge it immediately:
 ```bash
 gh pr merge --merge --delete-branch

--- a/plugins/shipwright-iterate/skills/iterate/SKILL.md
+++ b/plugins/shipwright-iterate/skills/iterate/SKILL.md
@@ -89,10 +89,19 @@ Before starting fresh, check if a previous iterate run was interrupted:
    ```bash
    git branch --list "iterate/*"
    ```
+   **Filter stale branches:** exclude any branch already merged into the default
+   branch (`git merge-base --is-ancestor <branch> <default>` returns 0) AND
+   without a matching `agent_docs/session_handoff.md`. Stale branches are cleanup
+   candidates, not in-progress runs — print a one-line hint:
+   `stale iterate branch iterate/X found; run "git branch -D iterate/X" to remove`.
 2. Check if `agent_docs/session_handoff.md` exists and references an iterate run_id
 3. Check current git branch — if already on an `iterate/` branch
+4. **Worktree self-exclusion:** if running inside a secondary worktree
+   (`git rev-parse --show-toplevel` differs from the main repo path), exclude the
+   current branch from the candidate list — otherwise B1 would always offer
+   "Parallel" on the current branch, creating an infinite loop.
 
-**If an in-progress run is detected:**
+**If an in-progress run is detected (any of 1–3 matches after filtering):**
 
 ```
 ================================================================================
@@ -104,9 +113,17 @@ Phase:      {last phase from handoff, or "unknown"}
 Files:      {modified files count from git status}
 
 Options:
-  1. Resume — continue from where we left off
-  2. Abandon — discard and start fresh (branch will be deleted)
+  1. Resume   — continue from where we left off
+  2. Abandon  — discard and start fresh (branch will be deleted)
   3. Complete — skip to finalization (F1-F11)
+  4. Parallel — start different work alongside the current run
+                (new worktree, current run stays untouched)
+
+Decision guide:
+  - Continue the same topic?           → Resume
+  - Completely different topic now?    → Parallel
+  - Discard current and start over?    → Abandon
+  - Finalize the current run?          → Complete
 ================================================================================
 ```
 
@@ -136,8 +153,53 @@ Options:
   current handoff generator does not write one).
 - **Abandon:** Delete the iterate branch (`git branch -D iterate/{name}`), remove `agent_docs/session_handoff.md`, proceed with fresh run from Step B2.
 - **Complete:** Read handoff for context, skip to Finalization (F1-F11) to commit, record event, and merge what's already been built. **Same replay check applies** — run External Review / Self-Review first if markers are missing, before F1.
+- **Parallel:** Leave the detected run completely untouched. Exit this session with status `parallel_setup` (not `abandoned` or `failed` — no work is lost). Print the worktree setup commands below and stop. The new iterate is started in a **new Claude Code session inside the worktree**, not in this session.
+
+  ```bash
+  # Resolve default branch dynamically (do NOT hardcode `main`):
+  DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@' || echo main)
+
+  # Precondition checks — refuse if worktree/branch already exists:
+  git worktree list | grep -q ".worktrees/<slug>" && { echo "Worktree already exists"; exit 1; }
+  git branch --list iterate/<slug> | grep -q . && { echo "Branch already exists — pick a different slug or clean up first"; exit 1; }
+
+  # Create worktree inside repo (so .gitignore applies):
+  git worktree add .worktrees/<slug> -b iterate/<slug> "$DEFAULT_BRANCH"
+  cd .worktrees/<slug>
+
+  # Re-hydrate dependencies + env — worktrees copy neither node_modules nor .env files.
+  # Emit ONLY the lines whose precondition matches the target project's shape:
+  [ -f ../../.env.local ]          && cp ../../.env.local .env.local
+  [ -f ../../.env ]                && cp ../../.env .env
+  [ -f package.json ]              && npm install
+  [ -f webui/package.json ]        && (cd webui && npm install)
+  [ -f webui/client/package.json ] && (cd webui/client && npm install)
+  [ -f webui/server/package.json ] && (cd webui/server && npm install)
+  [ -f client/package.json ]       && (cd client && npm install)
+  [ -f pyproject.toml ]            && uv sync
+
+  # Then: open a new Claude Code session in .worktrees/<slug> and run /shipwright-iterate fresh.
+  ```
+
+  **Skill guidance:** probe file existence before emitting each install line — print only what applies to the target project's shape. A Python-only project should not see `npm install`, a repo without `webui/` should not see the webui lines.
 
 **If no in-progress run detected:** Continue to B2 normally.
+
+### B1a. Parallel Iterate Conventions
+
+These rules apply to the **Parallel** option in B1 and to any manual worktree-based parallel iterate work. They keep PRs independent and avoid merge conflicts.
+
+- **Branch base:** always the project's default branch (resolved via `git symbolic-ref refs/remotes/origin/HEAD`, fallback `main`). **Never** branch from another `iterate/*` — chains iterates and muddles the PR/changelog.
+- **Worktree path:** `.worktrees/<slug>` **inside the repo** (hidden folder, `.gitignore`'d). Verify with `git check-ignore .worktrees/`.
+- **Worktree init:** git-worktrees do NOT carry `node_modules` or `.env*`. The Parallel setup snippet above copies env files and runs the project's install commands — adapt for the project shape.
+- **Disjoint file scopes:** if two iterates touch the same file, serialize rather than parallelize. Overlap = manual merge conflicts.
+- **Dev server:** default is one at a time. Parallel worktrees require explicit port overrides (e.g. `PORT` for Hono + `VITE_PORT` for Vite in the Shipwright webui). Use intentionally, not as a default.
+- **One PR per iterate, one changelog entry per iterate.** Conventional-Commit sort is merge-order-independent. Rebase per PR is expected when multiple are open against the default branch.
+- **WARNING — race on adopted target projects:** on any project with `shipwright_run_config.json`, parallel iterates produce a merge conflict in `iterate_history[]`. Use this workflow today only if manual conflict resolution is acceptable. Structural fix tracked as `iterate-history-file-per-iterate` (must land before `/shipwright-adopt` on the shipwright monorepo itself).
+- **WARNING — CHANGELOG.md `[Unreleased]` is a merge hotspot today.** F4 appends to `[Unreleased]` for every iterate. Two parallel iterates conflict on merge — the second PR must rebase and resolve the bullet merge manually. Structural fix bundled with the iterate_history refactor as a `CHANGELOG-unreleased.d/` drop pattern.
+- **Cleanup:** `git worktree remove .worktrees/<slug>` removes the worktree but **not** the branch. After PR merge: also `git branch -D iterate/<slug>`.
+
+See also: `docs/guide.md` chapter "Parallel Development with Worktrees" for the full walkthrough.
 
 ### B2. Load Project Context (MANDATORY)
 
@@ -421,7 +483,7 @@ See `references/iteration-planning.md` for invocation.
 See `references/design-and-testing.md` for 2-tier protocol.
 
 ### Step 6: Build (TDD — Red-Green-Refactor)
-1. Create feature branch: `iterate/{short-description}`
+1. Create feature branch `iterate/{short-description}` **branched from the project's default branch** (resolved via `git symbolic-ref refs/remotes/origin/HEAD`, fallback `main`). Never from another `iterate/*` branch — chains iterates and muddles the PR/changelog. See B1a for parallel-iterate conventions.
 2. **RED — Write failing tests first**, at minimum one test per Acceptance Criteria:
    - Tests assert on **outcomes, not internal state**
    - At least one **happy-path AND one error-path** test per AC
@@ -539,7 +601,7 @@ If yes → escalate to Mid-Flight Escalation (Section 7).
 See `references/iteration-planning.md`.
 
 ### Step 5: Fix
-1. Create feature branch: `iterate/fix-{short-description}`
+1. Create feature branch `iterate/fix-{short-description}` **branched from the project's default branch** (resolved via `git symbolic-ref refs/remotes/origin/HEAD`, fallback `main`). Never from another `iterate/*` branch — chains iterates and muddles the PR/changelog. See B1a for parallel-iterate conventions.
 2. **Fix the root cause** — targeted change, minimal scope. Do not fix symptoms.
 3. Run reproducing test to verify it passes
 4. Run related tests to verify no regressions

--- a/webui/CLAUDE.md
+++ b/webui/CLAUDE.md
@@ -129,8 +129,11 @@ npm run typecheck             # tsc --noEmit
 
 ### Key Environment Variables
 ```
-PORT=3847                     # Server port
+PORT=3847                     # Hono server port (override via env)
+VITE_PORT=5173                # Vite dev server port (override via env)
 ```
+
+Default is a single dev-server stack. For parallel worktrees set both vars explicitly — see `docs/guide.md` chapter 8.5 "Parallel Development with Worktrees". The Vite proxy reads `PORT` at startup so `/api` routes to the matching Hono instance.
 
 ### Conventions
 - TypeScript strict mode everywhere.
@@ -192,5 +195,11 @@ taskkill //F //PID <pid>
 cd webui/server && npm run dev
 ```
 
-`npm run dev:fresh` (the dev-restart.js helper) has a known Windows bug and
-is not recommended until fixed.
+If `npm run dev` fails with `EADDRINUSE`, another worktree's dev server may be
+running on the same port. Either kill it via `npm run dev:fresh` (same kill
+scope applies — with `PORT`/`VITE_PORT` overrides it kills those) or override
+`PORT` / `VITE_PORT` for this worktree.
+
+`npm run dev:fresh` (the dev-restart.js helper) now reads `PORT` and
+`VITE_PORT` from the environment, so kill scope is worktree-local when both
+are overridden.

--- a/webui/client/vite.config.ts
+++ b/webui/client/vite.config.ts
@@ -11,9 +11,10 @@ export default defineConfig({
     },
   },
   server: {
-    port: 5173,
+    port: parseInt(process.env.VITE_PORT || '5173', 10),
+    strictPort: true,
     proxy: {
-      '/api': 'http://localhost:3847',
+      '/api': `http://localhost:${process.env.PORT || '3847'}`,
     },
   },
 });

--- a/webui/scripts/dev-restart.js
+++ b/webui/scripts/dev-restart.js
@@ -3,8 +3,18 @@
  * Dev-server restart helper.
  *
  * Kills every stale `tsx watch`, `vite`, or node process that owns webui
- * ports (3847 = Hono server, 5173 = vite default, 5177 = vite alt) and then
- * respawns `npm run dev`. Cross-platform (Windows / macOS / Linux).
+ * ports (Hono server, vite current, vite alt) and then respawns
+ * `npm run dev`. Cross-platform (Windows / macOS / Linux).
+ *
+ * Port discovery:
+ *   - PORT env       -> Hono   (default 3847)
+ *   - VITE_PORT env  -> Vite   (default 5173)
+ *   - Vite alt port  -> 5177   (fixed, legacy cleanup only)
+ *
+ * Parallel-worktree scenario: set PORT + VITE_PORT to non-default values in
+ * the secondary worktree so the two dev-server stacks do not collide. Kill
+ * scope is restricted to finite positive integers to prevent malformed env
+ * values (empty, negative, NaN) from terminating unrelated processes.
  *
  * Motivation: on long-running dev sessions, tsx watch on Windows + chokidar
  * can miss file-change events after git merges, leaving the server running
@@ -21,7 +31,12 @@
 const { execSync, spawn } = require('node:child_process');
 const path = require('node:path');
 
-const WEBUI_PORTS = [3847, 5173, 5177];
+const HONO_PORT = parseInt(process.env.PORT || '3847', 10);
+const VITE_PORT = parseInt(process.env.VITE_PORT || '5173', 10);
+const VITE_ALT_PORT = 5177;
+const WEBUI_PORTS = [HONO_PORT, VITE_PORT, VITE_ALT_PORT].filter(
+  (p) => Number.isFinite(p) && p > 0,
+);
 const isWin = process.platform === 'win32';
 
 function log(msg) {


### PR DESCRIPTION
## Summary

Embeds parallel-iterate Worktree conventions directly in the Shipwright skills so git-worktree-based parallel work is guided automatically (B1 detects and offers the "Parallel" option), plus makes the WebUI dev server stack support parallel instances via PORT/VITE_PORT env vars.

## What changed

- `/shipwright-iterate` SKILL.md — new B1 option "Parallel" with decision guide + setup snippet; new B1a subsection consolidating branch-base, path, init, disjoint-scope, dev-server, PR-per-iterate, cleanup rules with prominent warnings for `iterate_history` + CHANGELOG merge hotspots. Step 6 + Step 5 (Fix) branch creation now explicitly anchors on the project's default branch (dynamically resolved).
- `/shipwright-build` SKILL.md — Step E makes Create/Resume bifurcation explicit via `git show-ref --quiet` and anchors Create path on default branch.
- `/shipwright-changelog` SKILL.md — sidebar documenting CHANGELOG merge hotspot + multiple-open-PRs rebase expectation.
- `webui/client/vite.config.ts` — reads `VITE_PORT` via `parseInt()`, adds `strictPort: true`, dynamic `/api` proxy target reads `process.env.PORT`.
- `webui/scripts/dev-restart.js` — derives `WEBUI_PORTS` from `PORT`/`VITE_PORT` env with `Number.isFinite` guard against malformed input.
- `webui/CLAUDE.md` — documents `VITE_PORT` + parallel-worktree troubleshooting.
- `docs/guide.md` — new chapter 8.5 "Parallel Development with Worktrees" with setup walkthrough + 7 pitfalls + cleanup.
- `docs/hooks-and-pipeline.md` — iterate-section B1 context-loading note per CLAUDE.md rule.
- Root `.gitignore` — adds `.worktrees/`.

## Test plan
- [x] node --check dev-restart.js + port-logic smoke (defaults, override, empty-env fallback, malformed rejection)
- [x] Grep consistency check: 0 residual `../.worktrees/` paths
- [x] Self-review diff of iterate SKILL.md for additivity
- [x] Two external LLM review passes (GPT-5.4 + Gemini-3.1 via OpenRouter) with 15 findings applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)