### PR TITLE
feat(adopt): multi-service dev-server support — v0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "shipwright",
   "description": "Shipwright SDLC — AI-powered software delivery lifecycle framework",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "owner": {
     "name": "svenroth.ai",
     "url": "https://github.com/svenroth-ai"
@@ -107,7 +107,7 @@
     {
       "name": "shipwright-adopt",
       "description": "Onboard an existing (brownfield) repository into the Shipwright SDLC — analyze stack + routes + conventions, generate CLAUDE.md + agent_docs + configs + E2E baseline",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "source": "./plugins/shipwright-adopt",
       "category": "development",
       "tags": ["adoption", "onboarding", "brownfield", "legacy", "documentation"]

--- a/.gitignore
+++ b/.gitignore
@@ -49,9 +49,9 @@ e2e-results.json
 shipwright_*_config.json
 shipwright_events.jsonl
 shipwright_events.jsonl.lock
-agent_docs/session_handoff.md
-agent_docs/build_dashboard.md
-agent_docs/current_sprint.md
+agent_docs/
+planning/
+.shipwright/
 .shipwright_toolcall_count
 compliance/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-service dev-server support.** Stack profiles can now declare a
+  `services: [...]` array (each: `{name, command, port, host?, scheme?,
+  ready_path?, ready_timeout_seconds?, depends_on?, primary?}`).
+  `shared/scripts/dev_server.py` starts every declared service in
+  topological order, waits per-service for liveness + port-open + optional
+  HTTP `ready_path` (2xx/3xx, IPv4+IPv6 dual-probe), and atomically writes
+  v2 state only after every service is healthy. Partial failure rolls back
+  in reverse start order. Legacy single-service `dev_server: {...}` profiles
+  continue to work via internal normalization. New CLI fallback flag
+  `--services-json '<inline>'` lets adopt pass an inline services array
+  when no profile matches. Closes the `--skip-crawl` workaround for split
+  frontend+backend repos.
+- **`shared/profiles/vite-hono.json`** — first-class profile for split
+  Vite+React frontend + Hono backend (Node + tsx). Derived from
+  shipwright-webui's shape (Hono :3847 with `/api/diagnostics` health,
+  Vite :5173 with frontend depends_on backend). Demonstrates the new
+  `services: [...]` schema in a real profile.
+- **Multi-service detector** in `shipwright-adopt` — detects split
+  frontend/backend layouts (`client/server`, `frontend/backend`,
+  `web/api`) with framework-signal requirement and Vite-proxy
+  high-confidence promotion. Surfaces `stack.multi_service: {detected,
+  confidence, services, evidence}` in the adopt snapshot.
+- **`shipwright-adopt` Step B.5 hierarchy** (SKILL.md): three-branch
+  resolution order — matched profile (any non-generic) wins; else
+  multi-service detector with high-confidence auto / medium-confidence
+  interactive / non-interactive fallback to single-service; else legacy
+  single-service. Autonomous adopt never spawns extra services on a
+  guess.
+- **`stack_detector` signature merge** (AC12): when a project has no
+  root `package.json` (or root has empty deps + devDeps) AND the
+  multi-service detector fires, per-service package.json deps are merged
+  into the matcher signature so Jaccard scoring can pick a multi-service
+  profile (e.g. vite-hono).
+
+### Changed
+
+- `dev_server.py` JSON output is additive: top-level `pid`/`url`/
+  `running`/`ready`/`started_by_us` continue to reflect the primary
+  service for legacy callers; new top-level `services: [...]` is added.
+  Multi-service `cmd_status` returns `pid`/`url=None` when the primary
+  is not alive (avoids advertising a URL that points to nothing).
+- Port-probe function renamed `_is_port_in_use` → `_is_port_in_use_for_host`
+  (the legacy name remains as a dual-stack convenience wrapper).
+- `cmd_start` no longer treats "port in use without a state file" as
+  "already running" — it returns an error and never claims ownership of
+  unowned processes (Round-1 review BLOCKER fix). Stale state pointing
+  to a different service set with live PIDs is rejected with a clear
+  error rather than silently overwritten.
+
 ## [0.4.0] - 2026-04-24
 
 **Breaking change:** the Shipwright Command Center WebUI has been

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1097,6 +1097,8 @@ When using skills individually, provide the input artifact (spec file, section f
 
 **Local Preview.** `/shipwright-preview` starts the development server and shows the URL (e.g., `http://localhost:3000`). Available after at least one build split is complete. The preview uses the `dev_server` configuration from the stack profile -- new stack profiles must define `dev_server.command`, `dev_server.port`, and `dev_server.ready_path` in their profile JSON.
 
+**Multi-service profiles (v0.5.0+).** Stack profiles can declare a `services: [...]` array instead of `dev_server: {...}` to manage projects with split frontend + backend (Vite+Hono, Next.js+separate API, Rails+Vue, …). Each entry: `{name, command, port, host?, scheme?, ready_path?, ready_timeout_seconds?, depends_on?, primary?}`. Topo order is enforced via `depends_on`; partial-failure rollback kills every started service in reverse. The `primary` flag (or first-declared) determines which service's URL appears as top-level `url` in the dev_server JSON output. See `shared/profiles/vite-hono.json` for a working example. Legacy single-service `dev_server: {...}` profiles continue to work via internal normalization. For projects without a matching profile, `/shipwright-adopt` can also pass an inline `--services-json '<array>'` to `dev_server.py`, derived from the multi-service detector's snapshot output.
+
 ### 7.4 Session Recovery and Handoff
 
 Claude Code has a finite context window. During long builds, Shipwright monitors context pressure and, when the window is filling up, automatically generates a **session handoff** document (`agent_docs/session_handoff.md`) containing the current phase, split, section, completed work, and next steps.

--- a/plugins/shipwright-adopt/.claude-plugin/plugin.json
+++ b/plugins/shipwright-adopt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-adopt",
   "description": "Onboard an existing repository (brownfield) into the Shipwright SDLC — analyze codebase, generate docs, configs, compliance artifacts, and an E2E baseline",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-adopt/pyproject.toml
+++ b/plugins/shipwright-adopt/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shipwright-adopt"
-version = "0.1.0"
+version = "0.2.0"
 description = "Claude Code plugin for onboarding existing repositories into the Shipwright SDLC"
 requires-python = ">=3.11"
 readme = "../../README.md"

--- a/plugins/shipwright-adopt/scripts/lib/multi_service_detector.py
+++ b/plugins/shipwright-adopt/scripts/lib/multi_service_detector.py
@@ -1,0 +1,195 @@
+"""Detect 'split frontend/backend' layouts in a project root.
+
+Used by /shipwright-adopt's Layer-1 codebase analysis. Surfaces
+`stack.multi_service` in the snapshot so adopt's Step B.5 can decide
+whether to start multiple services for the Playwright crawl, and so the
+stack matcher can pick a multi-service profile (e.g. vite-hono).
+
+Decision matrix (single source of truth, mirrors AC7):
+    Layout pair  | Both-sides framework signal | Vite proxy | detected | confidence
+    -------------+-----------------------------+------------+----------+-----------
+    yes          | yes                         | yes        | true     | high
+    yes          | yes                         | no         | true     | medium
+    yes          | one-sided OR none           | any        | false    | low
+    no           | n/a                         | any        | false    | low
+
+In every `detected: false` case, evidence is still recorded so adopt's
+interview can ask the user.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+# Sibling-pair candidate roots (frontend, backend), ordered by specificity
+LAYOUT_PAIRS: list[tuple[str, str]] = [
+    ("client", "server"),
+    ("frontend", "backend"),
+    ("web", "api"),
+]
+
+FRONTEND_FRAMEWORKS = {
+    "vite", "react", "react-dom", "vue", "next", "svelte", "astro",
+    "nuxt", "solid-js", "@sveltejs/kit", "@remix-run/react",
+}
+
+BACKEND_FRAMEWORKS = {
+    "hono", "express", "fastify", "koa", "@nestjs/core",
+    "@hono/node-server",
+}
+
+VITE_CONFIG_NAMES = ("vite.config.ts", "vite.config.js", "vite.config.mjs", "vite.config.cjs")
+
+# Multiline regex for `proxy: { '/api': { target: '...' } }`
+PROXY_RE = re.compile(
+    r"""proxy\s*:\s*\{[^{}]*?['"]/api['"]\s*:\s*(?:['"]([^'"]+)['"]|\{[^{}]*?target\s*:\s*['"]([^'"]+)['"])""",
+    re.DOTALL,
+)
+
+
+def _read_pkg(path: Path) -> dict | None:
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _all_pkg_deps(pkg: dict) -> set[str]:
+    deps = pkg.get("dependencies") or {}
+    dev = pkg.get("devDependencies") or {}
+    return set(deps.keys()) | set(dev.keys())
+
+
+def _has_frontend_framework(pkg: dict) -> tuple[bool, str | None]:
+    deps = _all_pkg_deps(pkg)
+    for fw in FRONTEND_FRAMEWORKS:
+        if fw in deps:
+            return True, fw
+    return False, None
+
+
+def _has_backend_framework(pkg: dict) -> tuple[bool, str | None]:
+    deps = _all_pkg_deps(pkg)
+    for fw in BACKEND_FRAMEWORKS:
+        if fw in deps:
+            return True, fw
+    # `dev` script counts as backend signal for plain Node-style backends
+    scripts = pkg.get("scripts") or {}
+    if scripts.get("dev"):
+        return True, "node-dev-script"
+    return False, None
+
+
+def _find_vite_proxy_target(project_root: Path, candidate_frontend_roots: list[Path]) -> str | None:
+    """Search vite.config in candidate frontend roots + project root for `proxy: /api: target`."""
+    search_roots = list(candidate_frontend_roots) + [project_root]
+    for root in search_roots:
+        for name in VITE_CONFIG_NAMES:
+            cfg = root / name
+            if cfg.is_file():
+                try:
+                    text = cfg.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+                m = PROXY_RE.search(text)
+                if m:
+                    return m.group(1) or m.group(2)
+    return None
+
+
+def _detect_pair(
+    project_root: Path, frontend_dir: str, backend_dir: str
+) -> dict | None:
+    """Probe one layout pair. Returns a partial result dict if package.jsons
+    exist on both sides (regardless of framework signal); else None."""
+    fe_root = project_root / frontend_dir
+    be_root = project_root / backend_dir
+    fe_pkg_path = fe_root / "package.json"
+    be_pkg_path = be_root / "package.json"
+    if not fe_pkg_path.is_file() or not be_pkg_path.is_file():
+        return None
+    fe_pkg = _read_pkg(fe_pkg_path) or {}
+    be_pkg = _read_pkg(be_pkg_path) or {}
+    fe_has, fe_fw = _has_frontend_framework(fe_pkg)
+    be_has, be_fw = _has_backend_framework(be_pkg)
+    fe_dev_cmd = (fe_pkg.get("scripts") or {}).get("dev")
+    be_dev_cmd = (be_pkg.get("scripts") or {}).get("dev")
+    return {
+        "frontend": {
+            "name": "frontend",
+            "root": frontend_dir,
+            "framework": fe_fw,
+            "dev_command": f"npm --prefix {frontend_dir} run dev" if fe_dev_cmd else None,
+            "proxy_target": None,
+        },
+        "backend": {
+            "name": "backend",
+            "root": backend_dir,
+            "framework": be_fw,
+            "dev_command": f"npm --prefix {backend_dir} run dev" if be_dev_cmd else None,
+            "proxy_target": None,
+        },
+        "fe_has_framework": fe_has,
+        "be_has_framework": be_has,
+        "frontend_root_path": fe_root,
+    }
+
+
+def detect_multi_service_layout(project_root: Path) -> dict[str, Any]:
+    """Detect split frontend/backend layout in `project_root`.
+
+    Returns: {detected: bool, confidence: str, services: list, evidence: list}
+    """
+    evidence: list[str] = []
+    for fe_dir, be_dir in LAYOUT_PAIRS:
+        result = _detect_pair(project_root, fe_dir, be_dir)
+        if result is None:
+            continue
+        evidence.append(f"sibling package.jsons found at {fe_dir}/ + {be_dir}/")
+        services = [result["frontend"], result["backend"]]
+        # Vite proxy probe (broadens confidence to `high`)
+        proxy_target = _find_vite_proxy_target(
+            project_root, [result["frontend_root_path"]]
+        )
+        if proxy_target:
+            evidence.append(f"vite proxy /api → {proxy_target}")
+            services[1]["proxy_target"] = proxy_target
+
+        # Apply decision matrix
+        both_have_framework = result["fe_has_framework"] and result["be_has_framework"]
+        if not both_have_framework:
+            if result["fe_has_framework"]:
+                evidence.append(f"frontend framework signal: {result['frontend']['framework']}")
+            elif result["be_has_framework"]:
+                evidence.append(f"backend framework signal: {result['backend']['framework']}")
+            else:
+                evidence.append("no framework signal on either side")
+            return {
+                "detected": False,
+                "confidence": "low",
+                "services": services,
+                "evidence": evidence,
+            }
+        evidence.append(f"frontend framework signal: {result['frontend']['framework']}")
+        evidence.append(f"backend framework signal: {result['backend']['framework']}")
+        confidence = "high" if proxy_target else "medium"
+        return {
+            "detected": True,
+            "confidence": confidence,
+            "services": services,
+            "evidence": evidence,
+        }
+
+    # No layout pair matched
+    return {
+        "detected": False,
+        "confidence": "low",
+        "services": [],
+        "evidence": evidence,
+    }

--- a/plugins/shipwright-adopt/scripts/lib/stack_detector.py
+++ b/plugins/shipwright-adopt/scripts/lib/stack_detector.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 
-# Frontend frameworks (matched against npm deps)
+# Frontend frameworks / build tools (matched against npm deps)
 _FRONTEND_HINTS = {
     "next": "Next.js",
     "react": "React",
@@ -24,6 +24,7 @@ _FRONTEND_HINTS = {
     "nuxt": "Nuxt",
     "astro": "Astro",
     "solid-js": "SolidJS",
+    "vite": "Vite",
 }
 
 # Backend / server frameworks
@@ -31,9 +32,11 @@ _BACKEND_HINTS_JS = {
     "express": "Express",
     "fastify": "Fastify",
     "hono": "Hono",
+    "@hono/node-server": "Hono Node Server",
     "koa": "Koa",
     "@nestjs/core": "NestJS",
     "next": "Next.js (API routes)",
+    "tsx": "tsx (TypeScript runner)",
 }
 _BACKEND_HINTS_PY = {
     "fastapi": "FastAPI",
@@ -141,7 +144,14 @@ def _extract_pyproject_deps(content: str) -> dict[str, str]:
 
 
 def detect_stack(project_root: Path, excludes: set[str] | None = None) -> dict[str, Any]:
-    """Detect stack signature from manifest files. Returns a JSON-serializable dict."""
+    """Detect stack signature from manifest files. Returns a JSON-serializable dict.
+
+    AC12 (iterate-20260425 multi-service): when the multi_service detector
+    fires AND the project root has no package.json (or root pkg.json has
+    empty deps + devDeps), per-service package.jsons are read and merged
+    into the signature so the Jaccard matcher can pick a multi-service
+    profile (e.g. vite-hono).
+    """
     excludes = excludes or set()
     signatures: list[str] = []
     runtime: dict[str, str] = {}
@@ -150,6 +160,7 @@ def detect_stack(project_root: Path, excludes: set[str] | None = None) -> dict[s
     database: dict[str, str] = {}
     auth: dict[str, str] = {}
     primary_language = "unknown"
+    root_has_real_deps = False  # Set during root pkg.json parsing
 
     # Skip files under excluded paths
     def _is_excluded(p: Path) -> bool:
@@ -164,6 +175,8 @@ def detect_stack(project_root: Path, excludes: set[str] | None = None) -> dict[s
         if engines.get("node"):
             runtime["node"] = engines["node"]
         deps = {**data.get("dependencies", {}), **data.get("devDependencies", {})}
+        if deps:
+            root_has_real_deps = True
         if "typescript" in deps:
             runtime["typescript"] = deps["typescript"]
             primary_language = "typescript"
@@ -241,7 +254,49 @@ def detect_stack(project_root: Path, excludes: set[str] | None = None) -> dict[s
         if data.get("compilerOptions", {}).get("strict") is True:
             signatures.append("has-tsconfig-strict")
 
-    return {
+    # AC12 — multi-service signature merge
+    # Always probe for multi-service layout; record signal if detected.
+    # Only merge sub-package.json deps when root has no real deps (avoids
+    # distorting Jaccard scoring on workspace monorepos with rich roots).
+    multi_service: dict[str, Any] | None = None
+    try:
+        from multi_service_detector import detect_multi_service_layout  # type: ignore
+    except ImportError:
+        try:
+            from .multi_service_detector import detect_multi_service_layout  # type: ignore
+        except ImportError:
+            detect_multi_service_layout = None  # type: ignore
+
+    if detect_multi_service_layout is not None:
+        multi_service = detect_multi_service_layout(project_root)
+        if multi_service.get("detected") or multi_service.get("services"):
+            signatures.append("has-multi-service-layout")
+        if multi_service.get("detected") and not root_has_real_deps:
+            for svc in multi_service.get("services", []):
+                svc_root = project_root / svc.get("root", "")
+                svc_pkg = _read_json(svc_root / "package.json") or {}
+                svc_deps = {
+                    **svc_pkg.get("dependencies", {}),
+                    **svc_pkg.get("devDependencies", {}),
+                }
+                if not svc_deps:
+                    continue
+                # Promote primary_language if still unknown
+                if "typescript" in svc_deps and not runtime.get("typescript"):
+                    runtime["typescript"] = svc_deps["typescript"]
+                if primary_language == "unknown":
+                    primary_language = "typescript" if "typescript" in svc_deps else "javascript"
+                # Merge into category blocks WITHOUT overwriting root values
+                for k, v in _match_hints(svc_deps, _FRONTEND_HINTS).items():
+                    frontend.setdefault(k, v)
+                for k, v in _match_hints(svc_deps, _BACKEND_HINTS_JS).items():
+                    backend.setdefault(k, v)
+                for k, v in _match_hints(svc_deps, _DB_HINTS_JS).items():
+                    database.setdefault(k, v)
+                for k, v in _match_hints(svc_deps, _AUTH_HINTS_JS).items():
+                    auth.setdefault(k, v)
+
+    result = {
         "primary_language": primary_language,
         "runtime": runtime,
         "frontend": frontend,
@@ -250,3 +305,6 @@ def detect_stack(project_root: Path, excludes: set[str] | None = None) -> dict[s
         "auth": auth,
         "signals": signatures,
     }
+    if multi_service is not None:
+        result["multi_service"] = multi_service
+    return result

--- a/plugins/shipwright-adopt/skills/adopt/SKILL.md
+++ b/plugins/shipwright-adopt/skills/adopt/SKILL.md
@@ -86,24 +86,78 @@ summary, nested projects. Pure read-only.
 language (`typescript`, `javascript`, `python`, `ruby`, `php`), a
 `dev`-command was detected, and `--skip-crawl` was not passed.
 
-Use the existing Shipwright infrastructure:
+**Service-resolution hierarchy** (introduced 2026-04-25 with multi-
+service `dev_server.py` v0.5.0). Choose ONE of three branches:
+
+**Branch 1 — matched profile (any non-generic).** If
+`snapshot.profile.matched != "generic"`, the matched profile is
+authoritative. It knows what to start (single-service via `dev_server`
+block, or multi-service via `services: [...]` array). Run:
+
+```bash
+uv run ${CLAUDE_PLUGIN_ROOT}/../../shared/scripts/dev_server.py start \
+  --cwd <cwd> --profile <matched>
+```
+
+The detector's `multi_service` signal is informational here; the
+profile's intent wins.
+
+**Branch 2 — generic match + multi-service detected.** If
+`snapshot.profile.matched == "generic"` AND
+`snapshot.stack.multi_service.detected == true`, build a transient
+services array from the detector's output and pass it inline:
+
+- `confidence: high` → proceed without prompting.
+- `confidence: medium` + interactive run → ask via `AskUserQuestion`:
+  *"Detected multi-service layout: <names>. Run all of them for the
+  crawl?"* Default Yes. On Yes → inline path. On No → fall through to
+  Branch 3.
+- `confidence: medium` + non-interactive run (autonomous adopt,
+  `--non-interactive`, missing `AskUserQuestion`) → fall through to
+  Branch 3 silently. **Autonomous adopt never spawns extra services on
+  a guess.**
+
+```bash
+SERVICES_JSON='[
+  {"name":"<name>","command":"<dev_command>","port":<port>,
+   "host":"localhost","scheme":"http","ready_path":"/"},
+  ...
+]'
+uv run ${CLAUDE_PLUGIN_ROOT}/../../shared/scripts/dev_server.py start \
+  --cwd <cwd> --services-json "$SERVICES_JSON"
+```
+
+**Branch 3 — single-service / fallback.** Same as Branch 1 with
+whatever profile matched (`generic` if nothing else):
+
+```bash
+uv run ${CLAUDE_PLUGIN_ROOT}/../../shared/scripts/dev_server.py start \
+  --cwd <cwd> --profile <matched-or-generic>
+```
+
+After the dev server is up, run the crawl + stop sequence common to
+all branches:
 
 ```bash
 uv run ${CLAUDE_PLUGIN_ROOT}/../../shared/scripts/playwright_setup.py \
   --cwd <cwd> --profile <matched>
-uv run ${CLAUDE_PLUGIN_ROOT}/../../shared/scripts/dev_server.py start \
-  --cwd <cwd> --profile <matched>
+# (start command from one of the three branches above)
 uv run ${CLAUDE_PLUGIN_ROOT}/../../shared/scripts/route_crawler.py \
-  --cwd <cwd> --base-url http://localhost:<port> \
+  --cwd <cwd> --base-url <primary_url_from_dev_server_start_output> \
   --max-depth 3 --max-pages 50 \
   --output <cwd>/.shipwright/adopt/routes.json \
   --screenshots <cwd>/.shipwright/adopt/screenshots/
 uv run ${CLAUDE_PLUGIN_ROOT}/../../shared/scripts/dev_server.py stop --cwd <cwd>
 ```
 
-If the dev-server fails to become healthy within 60s, OR the crawl
-produces zero routes, **skip** and fall back to AST-based `features[]`
-from the snapshot. Document the skip reason in the eventual handoff.
+The `--base-url` is read from the `url` field in `dev_server.py
+start`'s JSON output (top-level — points to the primary service in
+multi-service mode).
+
+If the dev-server fails to become healthy within its profile's
+`ready_timeout_seconds`, OR the crawl produces zero routes, **skip**
+and fall back to AST-based `features[]` from the snapshot. Document
+the skip reason in the eventual handoff.
 
 ### Step B.8 — Semantic Enrichment (Layer 2, inline)
 

--- a/plugins/shipwright-adopt/tests/test_multi_service_detector.py
+++ b/plugins/shipwright-adopt/tests/test_multi_service_detector.py
@@ -1,0 +1,227 @@
+"""Tests for multi_service_detector — split frontend/backend layout detection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+from lib.multi_service_detector import detect_multi_service_layout
+
+
+def _make_pkg(deps: dict[str, str] | None = None,
+              dev_deps: dict[str, str] | None = None,
+              scripts: dict[str, str] | None = None,
+              name: str = "x") -> str:
+    return json.dumps({
+        "name": name,
+        "version": "0.1.0",
+        "dependencies": deps or {},
+        "devDependencies": dev_deps or {},
+        "scripts": scripts or {},
+    })
+
+
+def _make_vite_config(proxy_target: str = "http://localhost:3001") -> str:
+    return f"""
+import {{ defineConfig }} from 'vite';
+export default defineConfig({{
+  server: {{
+    port: 5173,
+    proxy: {{
+      '/api': {{
+        target: '{proxy_target}',
+        changeOrigin: true,
+      }},
+    }},
+  }},
+}});
+"""
+
+
+# ---------------------------------------------------------------------------
+# Layout detection
+# ---------------------------------------------------------------------------
+
+def test_detect_client_server_with_framework_signal(tmp_path: Path):
+    (tmp_path / "client").mkdir()
+    (tmp_path / "server").mkdir()
+    (tmp_path / "client" / "package.json").write_text(
+        _make_pkg(deps={"vite": "^5.0", "react": "^18.0"}), encoding="utf-8"
+    )
+    (tmp_path / "server" / "package.json").write_text(
+        _make_pkg(deps={"hono": "^4.0"}), encoding="utf-8"
+    )
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is True
+    assert result["confidence"] == "medium"
+    names = {s["name"] for s in result["services"]}
+    assert names == {"frontend", "backend"}
+
+
+def test_detect_client_server_with_vite_proxy_high_confidence(tmp_path: Path):
+    (tmp_path / "client").mkdir()
+    (tmp_path / "server").mkdir()
+    (tmp_path / "client" / "package.json").write_text(
+        _make_pkg(deps={"vite": "^5.0", "react": "^18.0"}), encoding="utf-8"
+    )
+    (tmp_path / "server" / "package.json").write_text(
+        _make_pkg(deps={"hono": "^4.0"}), encoding="utf-8"
+    )
+    (tmp_path / "client" / "vite.config.ts").write_text(
+        _make_vite_config("http://localhost:3001"), encoding="utf-8"
+    )
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is True
+    assert result["confidence"] == "high"
+    backend = next(s for s in result["services"] if s["name"] == "backend")
+    assert backend.get("proxy_target") is not None
+    assert "3001" in backend["proxy_target"]
+
+
+def test_detect_frontend_backend_layout(tmp_path: Path):
+    (tmp_path / "frontend").mkdir()
+    (tmp_path / "backend").mkdir()
+    (tmp_path / "frontend" / "package.json").write_text(
+        _make_pkg(deps={"vite": "^5.0", "vue": "^3.0"}), encoding="utf-8"
+    )
+    (tmp_path / "backend" / "package.json").write_text(
+        _make_pkg(deps={"express": "^4.0"}), encoding="utf-8"
+    )
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is True
+
+
+def test_detect_web_api_layout(tmp_path: Path):
+    (tmp_path / "web").mkdir()
+    (tmp_path / "api").mkdir()
+    (tmp_path / "web" / "package.json").write_text(
+        _make_pkg(deps={"next": "^14.0", "react": "^18.0"}), encoding="utf-8"
+    )
+    (tmp_path / "api" / "package.json").write_text(
+        _make_pkg(deps={"fastify": "^4.0"}), encoding="utf-8"
+    )
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is True
+
+
+def test_detect_vite_config_in_frontend_root(tmp_path: Path):
+    """vite.config in frontend/ root, not only client/."""
+    (tmp_path / "frontend").mkdir()
+    (tmp_path / "backend").mkdir()
+    (tmp_path / "frontend" / "package.json").write_text(
+        _make_pkg(deps={"vite": "^5.0", "react": "^18.0"}), encoding="utf-8"
+    )
+    (tmp_path / "backend" / "package.json").write_text(
+        _make_pkg(deps={"hono": "^4.0"}), encoding="utf-8"
+    )
+    (tmp_path / "frontend" / "vite.config.ts").write_text(
+        _make_vite_config(), encoding="utf-8"
+    )
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is True
+    assert result["confidence"] == "high"
+
+
+def test_detect_vite_config_in_project_root(tmp_path: Path):
+    """vite.config at project root."""
+    (tmp_path / "client").mkdir()
+    (tmp_path / "server").mkdir()
+    (tmp_path / "client" / "package.json").write_text(
+        _make_pkg(deps={"vite": "^5.0", "react": "^18.0"}), encoding="utf-8"
+    )
+    (tmp_path / "server" / "package.json").write_text(
+        _make_pkg(deps={"hono": "^4.0"}), encoding="utf-8"
+    )
+    (tmp_path / "vite.config.ts").write_text(_make_vite_config(), encoding="utf-8")
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is True
+    assert result["confidence"] == "high"
+
+
+# ---------------------------------------------------------------------------
+# Negative / no-detection cases
+# ---------------------------------------------------------------------------
+
+def test_no_detection_for_single_service(tmp_path: Path):
+    (tmp_path / "package.json").write_text(
+        _make_pkg(deps={"next": "^14.0", "react": "^18.0"}), encoding="utf-8"
+    )
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is False
+
+
+def test_no_detection_for_unrelated_subfolders(tmp_path: Path):
+    """client/ exists but no package.json inside."""
+    (tmp_path / "client").mkdir()
+    (tmp_path / "client" / "README.md").write_text("hi", encoding="utf-8")
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is False
+
+
+def test_no_detection_without_framework_signal(tmp_path: Path):
+    """Sibling package.jsons exist but neither has framework deps."""
+    (tmp_path / "client").mkdir()
+    (tmp_path / "server").mkdir()
+    (tmp_path / "client" / "package.json").write_text(
+        _make_pkg(deps={"lodash": "^4.0"}), encoding="utf-8"
+    )
+    (tmp_path / "server" / "package.json").write_text(
+        _make_pkg(deps={"chalk": "^5.0"}), encoding="utf-8"
+    )
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is False
+    assert result["confidence"] == "low"
+    # Evidence still recorded for human review
+    assert len(result["evidence"]) > 0
+
+
+def test_no_detection_with_only_one_sided_framework(tmp_path: Path):
+    """One-sided framework signal NEVER yields detected:true (Round-2 fix)."""
+    (tmp_path / "client").mkdir()
+    (tmp_path / "server").mkdir()
+    (tmp_path / "client" / "package.json").write_text(
+        _make_pkg(deps={"vite": "^5.0", "react": "^18.0"}), encoding="utf-8"
+    )
+    (tmp_path / "server" / "package.json").write_text(
+        _make_pkg(deps={"lodash": "^4.0"}), encoding="utf-8"
+    )
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is False
+
+
+# ---------------------------------------------------------------------------
+# Evidence + result shape
+# ---------------------------------------------------------------------------
+
+def test_detector_evidence_listed(tmp_path: Path):
+    (tmp_path / "client").mkdir()
+    (tmp_path / "server").mkdir()
+    (tmp_path / "client" / "package.json").write_text(
+        _make_pkg(deps={"vite": "^5.0", "react": "^18.0"}), encoding="utf-8"
+    )
+    (tmp_path / "server" / "package.json").write_text(
+        _make_pkg(deps={"hono": "^4.0"}), encoding="utf-8"
+    )
+    result = detect_multi_service_layout(tmp_path)
+    assert isinstance(result["evidence"], list)
+    assert len(result["evidence"]) >= 1
+    # evidence is human-readable
+    assert all(isinstance(e, str) for e in result["evidence"])
+
+
+def test_backend_dev_script_counts_as_framework_signal(tmp_path: Path):
+    """Backend qualifies even without a framework dep, if it has a `dev` script."""
+    (tmp_path / "client").mkdir()
+    (tmp_path / "server").mkdir()
+    (tmp_path / "client" / "package.json").write_text(
+        _make_pkg(deps={"vite": "^5.0", "react": "^18.0"}), encoding="utf-8"
+    )
+    (tmp_path / "server" / "package.json").write_text(
+        _make_pkg(deps={"some-helper": "^1.0"}, scripts={"dev": "node index.js"}),
+        encoding="utf-8",
+    )
+    result = detect_multi_service_layout(tmp_path)
+    assert result["detected"] is True

--- a/plugins/shipwright-adopt/tests/test_stack_detector_multi_service.py
+++ b/plugins/shipwright-adopt/tests/test_stack_detector_multi_service.py
@@ -1,0 +1,219 @@
+"""Tests for AC12 — stack_detector merges sub-package.json deps when
+multi_service detector fires AND root has no real deps.
+
+Plus matcher behavior tests (AC11): vite-hono profile is preferred for
+split Vite+Hono repos, NOT preferred for Next.js+API monorepos.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+from lib.stack_detector import detect_stack
+from lib.profile_matcher import match_profile
+
+
+SHARED_PROFILES = (
+    Path(__file__).resolve().parent.parent.parent.parent / "shared" / "profiles"
+)
+
+
+def _make_pkg(deps=None, dev_deps=None, scripts=None, name="x") -> str:
+    return json.dumps({
+        "name": name,
+        "version": "0.1.0",
+        "dependencies": deps or {},
+        "devDependencies": dev_deps or {},
+        "scripts": scripts or {},
+    })
+
+
+def _build_webui_shape(root: Path, with_root_pkg: bool = False, with_proxy: bool = True):
+    (root / "client").mkdir(exist_ok=True)
+    (root / "server").mkdir(exist_ok=True)
+    (root / "client" / "package.json").write_text(
+        _make_pkg(
+            deps={
+                "vite": "^6.0",
+                "react": "^19.0",
+                "react-dom": "^19.0",
+            },
+            dev_deps={"typescript": "^5.6"},
+        ),
+        encoding="utf-8",
+    )
+    (root / "server" / "package.json").write_text(
+        _make_pkg(
+            deps={"hono": "^4.7", "@hono/node-server": "^1.14"},
+            dev_deps={"tsx": "^4.19", "typescript": "^5.7"},
+            scripts={"dev": "tsx watch src/index.ts"},
+        ),
+        encoding="utf-8",
+    )
+    if with_root_pkg:
+        (root / "package.json").write_text(_make_pkg(), encoding="utf-8")
+    if with_proxy:
+        (root / "client" / "vite.config.ts").write_text(
+            "export default { server: { proxy: { '/api': { target: 'http://localhost:3847' } } } };",
+            encoding="utf-8",
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC12 — signature merge
+# ---------------------------------------------------------------------------
+
+def test_detect_stack_merges_split_repo_deps_into_signature(tmp_path: Path):
+    _build_webui_shape(tmp_path, with_root_pkg=False)
+    sig = detect_stack(tmp_path)
+    # Frontend deps merged in
+    assert "vite" in sig["frontend"]
+    assert "react" in sig["frontend"]
+    # Backend deps merged in
+    assert "hono" in sig["backend"]
+    # TypeScript promoted to runtime
+    assert "typescript" in sig["runtime"]
+    # Signal flagged
+    assert "has-multi-service-layout" in sig["signals"]
+
+
+def test_detect_stack_skips_merge_when_root_has_real_deps(tmp_path: Path):
+    """Workspace-root with real deps → merge MUST NOT run (AC12 narrow trigger)."""
+    (tmp_path / "package.json").write_text(
+        _make_pkg(deps={"some-tool": "^1.0", "another-tool": "^2.0"}),
+        encoding="utf-8",
+    )
+    _build_webui_shape(tmp_path, with_root_pkg=False)  # adds client/server
+    sig = detect_stack(tmp_path)
+    # has-multi-service-layout flag is still set (we noticed the layout)
+    assert "has-multi-service-layout" in sig["signals"]
+    # But sub-deps NOT merged
+    assert "vite" not in sig["frontend"]
+    assert "hono" not in sig["backend"]
+
+
+def test_detect_stack_skips_merge_when_root_has_only_dev_deps(tmp_path: Path):
+    """Root has devDependencies only → still treated as "real deps", merge skipped."""
+    (tmp_path / "package.json").write_text(
+        _make_pkg(dev_deps={"prettier": "^3.0"}),
+        encoding="utf-8",
+    )
+    _build_webui_shape(tmp_path, with_root_pkg=False)
+    sig = detect_stack(tmp_path)
+    assert "vite" not in sig["frontend"]
+
+
+def test_detect_stack_root_pkg_empty_deps_allows_merge(tmp_path: Path):
+    """Empty deps + devDeps → merge runs (workspace tooling/orchestrator pattern)."""
+    (tmp_path / "package.json").write_text(_make_pkg(), encoding="utf-8")
+    _build_webui_shape(tmp_path, with_root_pkg=False)
+    sig = detect_stack(tmp_path)
+    assert "vite" in sig["frontend"]
+    assert "hono" in sig["backend"]
+
+
+def test_detect_stack_typescript_promoted_from_service(tmp_path: Path):
+    """Service declares typescript → runtime.typescript populated."""
+    _build_webui_shape(tmp_path)
+    sig = detect_stack(tmp_path)
+    assert "typescript" in sig["runtime"]
+
+
+def test_detect_stack_root_wins_on_conflict(tmp_path: Path):
+    """Root pkg with hono → root version wins, service merge skipped (root has real deps)."""
+    (tmp_path / "package.json").write_text(
+        _make_pkg(deps={"hono": "^3.0"}),  # root has older hono
+        encoding="utf-8",
+    )
+    _build_webui_shape(tmp_path)
+    sig = detect_stack(tmp_path)
+    # Root populated hono — services don't override (and don't even run merge)
+    assert "hono" in sig["backend"]
+    assert "^3.0" in sig["backend"]["hono"] or "3.0" in sig["backend"]["hono"]
+
+
+def test_detect_stack_no_change_for_single_service_repo(tmp_path: Path):
+    """Flat root-only project unaffected by AC12 changes (regression guard)."""
+    (tmp_path / "package.json").write_text(
+        _make_pkg(deps={"next": "^14.0", "react": "^18.0"}),
+        encoding="utf-8",
+    )
+    sig = detect_stack(tmp_path)
+    assert "next" in sig["frontend"]
+    assert "has-multi-service-layout" not in sig["signals"]
+
+
+# ---------------------------------------------------------------------------
+# AC11 — matcher prefers vite-hono for webui shape
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not (SHARED_PROFILES / "vite-hono.json").exists(),
+    reason="vite-hono.json not yet shipped",
+)
+def test_match_profile_picks_vite_hono_for_split_repo(tmp_path: Path):
+    _build_webui_shape(tmp_path)
+    sig = detect_stack(tmp_path)
+    result = match_profile(sig, SHARED_PROFILES)
+    assert result["matched"] == "vite-hono"
+    # Higher than supabase-nextjs
+    candidates = {c["name"]: c["score"] for c in result["candidates"]}
+    if "supabase-nextjs" in candidates:
+        assert candidates["vite-hono"] > candidates["supabase-nextjs"]
+
+
+@pytest.mark.skipif(
+    not (SHARED_PROFILES / "vite-hono.json").exists(),
+    reason="vite-hono.json not yet shipped",
+)
+def test_match_profile_does_not_pick_vite_hono_for_next_api_monorepo(tmp_path: Path):
+    """Next.js + Express API split repo MUST NOT match vite-hono."""
+    (tmp_path / "client").mkdir()
+    (tmp_path / "api").mkdir()
+    (tmp_path / "client" / "package.json").write_text(
+        _make_pkg(
+            deps={"next": "^14.0", "react": "^18.0", "react-dom": "^18.0"},
+            dev_deps={"typescript": "^5.0"},
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "api" / "package.json").write_text(
+        _make_pkg(deps={"express": "^4.18", "body-parser": "^1.20"}),
+        encoding="utf-8",
+    )
+    sig = detect_stack(tmp_path)
+    result = match_profile(sig, SHARED_PROFILES)
+    assert result["matched"] != "vite-hono"
+
+
+def test_match_profile_no_change_for_single_service_repo(tmp_path: Path):
+    """Single-service root-only React+Next match behavior unchanged."""
+    (tmp_path / "package.json").write_text(
+        _make_pkg(deps={"next": "^14.0", "react": "^18.0", "@supabase/supabase-js": "^2.0"}),
+        encoding="utf-8",
+    )
+    sig = detect_stack(tmp_path)
+    result = match_profile(sig, SHARED_PROFILES)
+    # supabase-nextjs should still match (no regression from AC12)
+    assert result["matched"] in {"supabase-nextjs", "generic"}
+
+
+# ---------------------------------------------------------------------------
+# Snapshot integration
+# ---------------------------------------------------------------------------
+
+def test_analyze_surfaces_multi_service_in_snapshot(tmp_path: Path):
+    """When detector fires, analyze() puts multi_service under stack."""
+    import sys
+    plugin_root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(plugin_root / "scripts" / "tools"))
+    from analyze_codebase import analyze  # type: ignore
+
+    _build_webui_shape(tmp_path)
+    snapshot = analyze(tmp_path, [], None)
+    assert "multi_service" in snapshot["stack"]
+    assert snapshot["stack"]["multi_service"]["detected"] is True

--- a/plugins/shipwright-adopt/uv.lock
+++ b/plugins/shipwright-adopt/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "shipwright-adopt"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shipwright"
-version = "0.4.0"
+version = "0.5.0"
 description = "AI-powered SDLC framework built on Claude Code"
 requires-python = ">=3.11"
 readme = "README.md"

--- a/shared/profiles/vite-hono.json
+++ b/shared/profiles/vite-hono.json
@@ -1,0 +1,78 @@
+{
+  "name": "vite-hono",
+  "description": "Split Vite+React frontend with Hono backend (npm/tsx). Two services managed in parallel by dev_server.py.",
+  "version": "1.0.0",
+
+  "stack": {
+    "runtime": {
+      "node": "20.x",
+      "typescript": "^5.6.0"
+    },
+    "frontend": {
+      "vite": "^6.0.0",
+      "react": "^19.0.0",
+      "react-dom": "^19.0.0"
+    },
+    "backend": {
+      "hono": "^4.7.0",
+      "@hono/node-server": "^1.14.0",
+      "tsx": "^4.19.0"
+    }
+  },
+
+  "services": [
+    {
+      "name": "backend",
+      "command": "npm --prefix server run dev",
+      "host": "localhost",
+      "scheme": "http",
+      "port": 3847,
+      "ready_path": "/api/diagnostics",
+      "ready_timeout_seconds": 60
+    },
+    {
+      "name": "frontend",
+      "command": "npm --prefix client run dev",
+      "host": "localhost",
+      "scheme": "http",
+      "port": 5173,
+      "ready_path": "/",
+      "ready_timeout_seconds": 60,
+      "depends_on": ["backend"],
+      "primary": true
+    }
+  ],
+
+  "testing": {
+    "unit": {
+      "framework": "vitest",
+      "version": "^3.0.0"
+    },
+    "e2e": {
+      "framework": "@playwright/test",
+      "version": "^1.59.1"
+    }
+  },
+
+  "linting": {
+    "eslint": "^9.0.0"
+  },
+
+  "package_manager": "npm",
+  "rules": ["tests", "components", "config"],
+
+  "folder_structure": {
+    "client/": "Vite frontend (React + TypeScript)",
+    "server/": "Hono backend (Node + TypeScript)",
+    "client/src/": "Frontend source",
+    "server/src/": "Backend source",
+    "e2e/": "Playwright E2E tests (created by /shipwright-adopt or /shipwright-iterate)"
+  },
+
+  "env_files": {
+    ".env.local": "Local development overrides (PORT, VITE_PORT, etc.) — not committed",
+    ".env.example": "Template (committed)"
+  },
+
+  "notes": "This profile assumes Node 20.x + npm 10+. Service commands use `npm --prefix <dir> run dev`; the `--prefix` flag MUST come before the subcommand for unambiguous parsing on modern npm. Frontend `depends_on: backend` ensures the Vite proxy target is up before the SPA shell is considered ready. Frontend is `primary: true` so dev_server.py's top-level `pid`/`url` reflect the browser-facing URL."
+}

--- a/shared/scripts/dev_server.py
+++ b/shared/scripts/dev_server.py
@@ -1,33 +1,64 @@
 #!/usr/bin/env python3
-"""Start/Stop/Status management for the target project's dev server.
+"""Start/Stop/Status management for the target project's dev server(s).
+
+Supports both single-service profiles (legacy `dev_server: {...}` block) and
+multi-service profiles (new `services: [...]` array). Single-service is
+internally represented as a one-element list named `"primary"`.
 
 Usage:
-    uv run dev_server.py start --profile supabase-nextjs --cwd /path/to/project
+    uv run dev_server.py start --profile vite-hono --cwd /path/to/project
+    uv run dev_server.py start --cwd /path --services-json '[{...}, {...}]'
     uv run dev_server.py stop --cwd /path/to/project
     uv run dev_server.py status --cwd /path/to/project
 
-Output (JSON):
-    {"running": true, "pid": 12345, "url": "http://localhost:3000", "ready": true}
+Output (JSON, single-service):
+    {"running": true, "pid": 12345, "url": "http://localhost:3000",
+     "ready": true, "services": [...]}
+
+Output (JSON, multi-service):
+    {"running": true, "pid": 101, "url": "http://localhost:5173",
+     "ready": true, "services": [{name, pid, port, ...}]}
+
+Top-level `pid`/`url` always reflect the **primary** service.
 """
+
+from __future__ import annotations
 
 import argparse
 import json
 import os
+import shlex
 import socket
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
 
-# Default dev server config (used if profile doesn't specify)
-DEFAULT_DEV_SERVER = {
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+STATE_FILE = "shipwright_dev_server.json"
+STATE_VERSION = 2
+LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+# Default service used if no profile / no build_config / no inline JSON.
+_DEFAULT_SERVICE = {
+    "name": "primary",
     "command": "npm run dev",
+    "host": "localhost",
+    "scheme": "http",
     "port": 3000,
-    "ready_timeout_seconds": 60,
     "ready_path": "/",
+    "ready_timeout_seconds": 60,
+    "primary": True,
 }
 
-# Profile-specific overrides
+# Profile-specific dev_server overrides (legacy single-service map).
 PROFILE_DEV_SERVERS: dict[str, dict] = {
     "supabase-nextjs": {
         "command": "npm run dev",
@@ -37,17 +68,434 @@ PROFILE_DEV_SERVERS: dict[str, dict] = {
     },
 }
 
-STATE_FILE = "shipwright_dev_server.json"
+
+# ---------------------------------------------------------------------------
+# Profile loading
+# ---------------------------------------------------------------------------
+
+def _profiles_dir() -> Path:
+    """Resolve the shared/profiles directory relative to this script."""
+    return Path(__file__).resolve().parent.parent / "profiles"
 
 
-def _is_port_in_use(port: int) -> bool:
-    """Check if a port is in use."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(("localhost", port)) == 0
+def _load_profile_data(profile_name: str | None) -> dict | None:
+    """Load <profiles_dir>/<name>.json. Falls back to PROFILE_DEV_SERVERS map."""
+    if not profile_name:
+        return None
+    profiles_dir = _profiles_dir()
+    candidate = profiles_dir / f"{profile_name}.json"
+    if candidate.exists():
+        try:
+            return json.loads(candidate.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+    # Fallback: legacy in-script map for very old callers
+    if profile_name in PROFILE_DEV_SERVERS:
+        return {"dev_server": PROFILE_DEV_SERVERS[profile_name]}
+    return None
 
+
+def _normalize_legacy_dev_server(block: dict) -> dict:
+    """Wrap a legacy `dev_server` block as a single-service entry."""
+    return {
+        "name": "primary",
+        "command": block.get("command", _DEFAULT_SERVICE["command"]),
+        "host": block.get("host", "localhost"),
+        "scheme": block.get("scheme", "http"),
+        "port": int(block.get("port", _DEFAULT_SERVICE["port"])),
+        "ready_path": block.get("ready_path", _DEFAULT_SERVICE["ready_path"]),
+        "ready_timeout_seconds": int(
+            block.get("ready_timeout_seconds", _DEFAULT_SERVICE["ready_timeout_seconds"])
+        ),
+        "primary": True,
+    }
+
+
+def _normalize_service_entry(entry: dict, default_primary: bool = False) -> dict:
+    """Apply defaults to a `services[]` entry.
+
+    Type coercion is intentionally minimal — `_validate_services` raises
+    clear per-field errors before any dangerous coercion runs.
+    """
+    return {
+        "name": entry.get("name"),
+        "command": entry.get("command"),
+        "host": entry.get("host", "localhost"),
+        "scheme": entry.get("scheme", "http"),
+        "port": entry.get("port"),
+        "ready_path": entry.get("ready_path"),
+        "ready_timeout_seconds": entry.get("ready_timeout_seconds", 60),
+        "depends_on": entry.get("depends_on") or [],
+        "primary": bool(entry.get("primary", default_primary)),
+    }
+
+
+def _service_url(service: dict) -> str:
+    host = service.get("host", "localhost")
+    scheme = service.get("scheme", "http")
+    port = service["port"]
+    # IPv6 needs bracketing in URLs
+    host_part = f"[{host}]" if ":" in str(host) else host
+    return f"{scheme}://{host_part}:{port}"
+
+
+def _get_services(
+    profile_name: str | None, cwd: Path
+) -> tuple[list[dict], list[str]]:
+    """Resolve a normalized service list + warning messages.
+
+    Resolution chain:
+      1. profile JSON has `services: [...]` → use it (warn if `dev_server`
+         block also present).
+      2. profile JSON has only `dev_server: {...}` → wrap as single-service.
+      3. shipwright_build_config.json has `dev_url` → derive single service
+         from URL.
+      4. fallback to _DEFAULT_SERVICE.
+
+    Returns (services, warnings). Warnings are NOT printed here — top-level
+    `cmd_*` functions emit them once via stderr.
+    """
+    warnings: list[str] = []
+    profile_data = _load_profile_data(profile_name)
+    return _services_from_profile_data(profile_data, cwd, warnings)
+
+
+def _services_from_profile_data(
+    profile_data: dict | None, cwd: Path, warnings: list[str]
+) -> tuple[list[dict], list[str]]:
+    if profile_data and "services" in profile_data:
+        if "dev_server" in profile_data:
+            warnings.append(
+                "both 'services' and 'dev_server' present in profile; ignoring 'dev_server'"
+            )
+        raw = profile_data["services"]
+        if not isinstance(raw, list) or len(raw) == 0:
+            raise ValueError("profile 'services' must be a non-empty array")
+        services: list[dict] = []
+        for i, entry in enumerate(raw):
+            if not isinstance(entry, dict):
+                raise ValueError(f"services[{i}] must be an object")
+            services.append(_normalize_service_entry(entry))
+        return services, warnings
+
+    if profile_data and "dev_server" in profile_data:
+        return [_normalize_legacy_dev_server(profile_data["dev_server"])], warnings
+
+    # Build config fallback
+    build_config = cwd / "shipwright_build_config.json"
+    if build_config.exists():
+        try:
+            data = json.loads(build_config.read_text(encoding="utf-8"))
+            dev_url = data.get("dev_url")
+            if dev_url:
+                parsed = urlparse(dev_url)
+                host = parsed.hostname or "localhost"
+                scheme = parsed.scheme or "http"
+                port = parsed.port or 3000
+                return ([{
+                    **_DEFAULT_SERVICE,
+                    "host": host,
+                    "scheme": scheme,
+                    "port": port,
+                }], warnings)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return [dict(_DEFAULT_SERVICE)], warnings
+
+
+# Test-friendly accessor: lets tests pass profile_data inline instead of a name.
+def _get_services_for_test(
+    profile_data: dict | None, cwd: Path
+) -> tuple[list[dict], list[str]]:
+    warnings: list[str] = []
+    services, warnings = _services_from_profile_data(profile_data, cwd, warnings)
+    _validate_services(services)
+    return services, warnings
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+def _validate_services(services: list[dict]) -> None:
+    """Validate normalized service list. Raises ValueError on any defect."""
+    if not isinstance(services, list) or len(services) == 0:
+        raise ValueError("services must be a non-empty list")
+
+    names_seen: set[str] = set()
+    primaries = 0
+    for i, s in enumerate(services):
+        name = s.get("name")
+        if not name or not isinstance(name, str):
+            raise ValueError(f"services[{i}].name is empty or not a string")
+        if name in names_seen:
+            raise ValueError(f"duplicate service name: {name}")
+        names_seen.add(name)
+        cmd = s.get("command")
+        if not cmd or not isinstance(cmd, str):
+            raise ValueError(f"services[{i}].command is missing or not a string")
+        port = s.get("port")
+        if not isinstance(port, int) or isinstance(port, bool):
+            raise ValueError(
+                f"services[{i}].port must be an integer (got {type(port).__name__})"
+            )
+        rts = s.get("ready_timeout_seconds", 60)
+        if not isinstance(rts, int) or isinstance(rts, bool):
+            raise ValueError(
+                f"services[{i}].ready_timeout_seconds must be an integer "
+                f"(got {type(rts).__name__} {rts!r})"
+            )
+        deps = s.get("depends_on") or []
+        if not isinstance(deps, list):
+            raise ValueError(
+                f"services[{i}].depends_on must be a list of strings"
+            )
+        for j, d in enumerate(deps):
+            if not isinstance(d, str):
+                raise ValueError(
+                    f"services[{i}].depends_on[{j}] must be a string "
+                    f"(got {type(d).__name__} {d!r})"
+                )
+        host = s.get("host", "localhost")
+        if host not in LOOPBACK_HOSTS:
+            raise ValueError(
+                f"services[{i}].host must be a loopback address "
+                f"(localhost / 127.0.0.1 / ::1); got {host!r}"
+            )
+        if s.get("primary"):
+            primaries += 1
+
+    if primaries > 1:
+        raise ValueError("multiple services declare primary: true; at most one allowed")
+
+    # Default primary if no explicit one
+    if primaries == 0:
+        services[0]["primary"] = True
+
+    # depends_on validation
+    for s in services:
+        deps = s.get("depends_on") or []
+        for d in deps:
+            if d == s["name"]:
+                raise ValueError(f"service {s['name']!r} has self dependency")
+            if d not in names_seen:
+                raise ValueError(
+                    f"service {s['name']!r} depends_on missing target {d!r}"
+                )
+
+    # Cycle check via topo sort attempt
+    try:
+        _topo_sort(services)
+    except ValueError as e:
+        if "cycle" in str(e).lower():
+            raise
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Topological sort
+# ---------------------------------------------------------------------------
+
+def _topo_sort(services: list[dict]) -> list[list[dict]]:
+    """Return services grouped into layers; each layer can start in parallel.
+
+    Within a layer, declaration order is preserved as the deterministic
+    tiebreaker. Cycles raise ValueError.
+    """
+    by_name = {s["name"]: s for s in services}
+    remaining = {s["name"]: set(s.get("depends_on") or []) for s in services}
+    declaration_order = [s["name"] for s in services]
+
+    layers: list[list[dict]] = []
+    placed: set[str] = set()
+
+    while remaining:
+        # Names whose deps are all placed
+        ready = [
+            n for n in declaration_order
+            if n in remaining and remaining[n].issubset(placed)
+        ]
+        if not ready:
+            raise ValueError(
+                f"dependency cycle detected among services: {sorted(remaining.keys())}"
+            )
+        layers.append([by_name[n] for n in ready])
+        for n in ready:
+            placed.add(n)
+            del remaining[n]
+
+    return layers
+
+
+def _pick_primary(services: list[dict]) -> dict:
+    for s in services:
+        if s.get("primary"):
+            return s
+    return services[0]
+
+
+# ---------------------------------------------------------------------------
+# Probes (port + HTTP)
+# ---------------------------------------------------------------------------
+
+def _is_port_in_use_for_host(host: str, port: int) -> bool:
+    """Probe whether a TCP listener is accepting connections at host:port."""
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    try:
+        with socket.socket(family, socket.SOCK_STREAM) as s:
+            s.settimeout(1.0)
+            return s.connect_ex((host, port)) == 0
+    except OSError:
+        return False
+
+
+def _is_port_in_use(port: int) -> bool:  # legacy compat for tests/import sites
+    return _is_port_in_use_for_host("127.0.0.1", port) or _is_port_in_use_for_host("::1", port)
+
+
+def _probe_hosts_for(service_host: str) -> list[str]:
+    """Return the list of host literals to probe for a service's host."""
+    if service_host == "localhost":
+        return ["127.0.0.1", "::1"]
+    return [service_host]
+
+
+def _http_probe(url: str, timeout: float = 2.0) -> bool:
+    """Issue a GET; accept 2xx/3xx as ready. Errors / 4xx / 5xx → not ready."""
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = resp.status
+            return 200 <= status < 400
+    except urllib.error.HTTPError as e:
+        return 200 <= e.code < 400
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+
+
+def _wait_for_service(service: dict, proc, deadline: float) -> tuple[bool, str]:
+    """Poll until ready or deadline. See plan §AC3."""
+    host = service.get("host", "localhost")
+    port = service["port"]
+    ready_path = service.get("ready_path")
+    scheme = service.get("scheme", "http")
+    probe_hosts = _probe_hosts_for(host)
+
+    while True:
+        # 1. Liveness
+        if proc is not None and proc.poll() is not None:
+            return False, "process_exited"
+
+        # 2. Port probe
+        port_open_host = None
+        for ph in probe_hosts:
+            if _is_port_in_use_for_host(ph, port):
+                port_open_host = ph
+                break
+
+        if port_open_host is None:
+            if time.time() >= deadline:
+                return False, "timeout"
+            time.sleep(0.5)
+            continue
+
+        # 3. No ready_path → port-open is enough
+        if not ready_path:
+            return True, ""
+
+        # 4. HTTP probe
+        url_host = host if host == "localhost" else port_open_host
+        # IPv6 literal needs bracketing
+        url_host_part = f"[{url_host}]" if ":" in url_host else url_host
+        url = f"{scheme}://{url_host_part}:{port}{ready_path}"
+        if _http_probe(url, timeout=2.0):
+            return True, ""
+
+        if time.time() >= deadline:
+            return False, "timeout"
+        time.sleep(1.0)
+
+
+# ---------------------------------------------------------------------------
+# State file (v2 + v1 read compat)
+# ---------------------------------------------------------------------------
+
+def _load_state(cwd: Path) -> dict | None:
+    state_path = cwd / STATE_FILE
+    if not state_path.exists():
+        return None
+    try:
+        raw = json.loads(state_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    if isinstance(raw, dict) and raw.get("version") == STATE_VERSION:
+        return raw
+
+    # v1 compat: top-level pid/port → wrap as single-service v2 (in memory only)
+    if isinstance(raw, dict) and "pid" in raw and "port" in raw:
+        port = int(raw.get("port", 3000))
+        host = "localhost"
+        scheme = "http"
+        return {
+            "version": STATE_VERSION,
+            "profile": raw.get("profile"),
+            "services": [{
+                "name": "primary",
+                "pid": int(raw["pid"]),
+                "port": port,
+                "host": host,
+                "scheme": scheme,
+                "command": raw.get("command", _DEFAULT_SERVICE["command"]),
+                "url": f"{scheme}://{host}:{port}",
+                "ready_path": _DEFAULT_SERVICE["ready_path"],
+                "ready_timeout_seconds": _DEFAULT_SERVICE["ready_timeout_seconds"],
+                "primary": True,
+            }],
+        }
+    return None
+
+
+def _save_state(cwd: Path, state: dict) -> None:
+    """Non-atomic save (used for tests; production path uses _save_state_atomic)."""
+    state_path = cwd / STATE_FILE
+    state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+def _save_state_atomic(cwd: Path, state: dict) -> None:
+    """Atomic save: write to <state>.tmp in the same dir, then os.replace."""
+    final = cwd / STATE_FILE
+    tmp = cwd / (STATE_FILE + ".tmp")
+    try:
+        tmp.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+        os.replace(str(tmp), str(final))
+    except OSError:
+        # Best-effort cleanup of orphan tmp
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _clear_state(cwd: Path) -> None:
+    state_path = cwd / STATE_FILE
+    if state_path.exists():
+        try:
+            state_path.unlink()
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Per-service start/stop
+# ---------------------------------------------------------------------------
 
 def _is_pid_running(pid: int) -> bool:
-    """Check if a process with given PID is still running."""
+    if not pid:
+        return False
     if os.name == "nt":
         try:
             result = subprocess.run(
@@ -59,209 +507,382 @@ def _is_pid_running(pid: int) -> bool:
             return str(pid) in result.stdout
         except (subprocess.TimeoutExpired, OSError):
             return False
-    else:
-        try:
-            os.kill(pid, 0)
-            return True
-        except OSError:
-            return False
-
-
-def _load_state(cwd: Path) -> dict | None:
-    """Load dev server state from file."""
-    state_path = cwd / STATE_FILE
-    if not state_path.exists():
-        return None
     try:
-        return json.loads(state_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
 
 
-def _save_state(cwd: Path, state: dict) -> None:
-    """Save dev server state to file."""
-    state_path = cwd / STATE_FILE
-    state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
-
-
-def _clear_state(cwd: Path) -> None:
-    """Remove state file."""
-    state_path = cwd / STATE_FILE
-    if state_path.exists():
-        state_path.unlink()
-
-
-def _get_config(profile: str | None, cwd: Path | None = None) -> dict:
-    """Get dev server config for profile.
-
-    Falls back to shipwright_build_config.json for custom/unknown profiles.
-    """
-    if profile and profile in PROFILE_DEV_SERVERS:
-        return PROFILE_DEV_SERVERS[profile]
-    # Try build config for custom profiles (self-healing)
-    if cwd:
-        build_config = cwd / "shipwright_build_config.json"
-        if build_config.exists():
-            try:
-                data = json.loads(build_config.read_text(encoding="utf-8"))
-                dev_url = data.get("dev_url", "")
-                if dev_url:
-                    from urllib.parse import urlparse
-                    parsed = urlparse(dev_url)
-                    port = parsed.port or 3000
-                    return {**DEFAULT_DEV_SERVER, "port": port}
-            except (json.JSONDecodeError, OSError):
-                pass
-    return DEFAULT_DEV_SERVER
-
-
-def _wait_for_ready(port: int, timeout: int) -> bool:
-    """Poll until the server is accepting connections on the port."""
-    start = time.time()
-    while time.time() - start < timeout:
-        if _is_port_in_use(port):
-            return True
-        time.sleep(1)
-    return False
-
-
-def cmd_start(cwd: Path, profile: str | None) -> dict:
-    """Start the dev server."""
-    config = _get_config(profile, cwd=cwd)
-    port = config["port"]
-    timeout = config["ready_timeout_seconds"]
-
-    # Check if already running
-    if _is_port_in_use(port):
-        state = _load_state(cwd)
-        pid = state.get("pid") if state else None
-        return {
-            "running": True,
-            "pid": pid,
-            "url": f"http://localhost:{port}",
-            "ready": True,
-            "message": f"Dev server already running on port {port}",
-            "started_by_us": False,
-        }
-
-    # Start the dev server
-    cmd_parts = config["command"].split()
+def _start_one(service: dict, cwd: Path) -> tuple[Any, dict]:
+    """Spawn the service's process. Returns (proc, record)."""
+    # Always use POSIX-style shlex parsing — strips quotes from the command
+    # string. Windows Popen with a list calls list2cmdline() to re-quote
+    # safely, so the cross-platform contract is: profile authors write
+    # POSIX-quoted commands; subprocess handles platform-specific argv
+    # encoding.
+    cmd_parts = shlex.split(service["command"], posix=True)
     creation_flags = 0
     if os.name == "nt":
         creation_flags = subprocess.CREATE_NEW_PROCESS_GROUP
 
-    try:
-        proc = subprocess.Popen(
-            cmd_parts,
-            cwd=str(cwd),
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            creationflags=creation_flags,
-        )
-    except OSError as e:
-        return {
-            "running": False,
-            "error": f"Failed to start dev server: {e}",
-            "command": config["command"],
-        }
+    proc = subprocess.Popen(
+        cmd_parts,
+        cwd=str(cwd),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        creationflags=creation_flags,
+    )
 
-    # Save state
-    _save_state(cwd, {
+    record = {
+        "name": service["name"],
         "pid": proc.pid,
-        "port": port,
-        "command": config["command"],
-        "profile": profile,
-    })
-
-    # Wait for ready
-    ready = _wait_for_ready(port, timeout)
-
-    return {
-        "running": ready,
-        "pid": proc.pid,
-        "url": f"http://localhost:{port}",
-        "ready": ready,
-        "message": "Dev server started" if ready else f"Dev server started but not ready after {timeout}s",
-        "started_by_us": True,
+        "port": service["port"],
+        "host": service.get("host", "localhost"),
+        "scheme": service.get("scheme", "http"),
+        "command": service["command"],
+        "ready_path": service.get("ready_path"),
+        "ready_timeout_seconds": int(service.get("ready_timeout_seconds", 60)),
+        "url": _service_url(service),
+        "primary": bool(service.get("primary", False)),
     }
+    return proc, record
 
 
-def cmd_stop(cwd: Path) -> dict:
-    """Stop the dev server."""
-    state = _load_state(cwd)
-    if not state:
-        return {"running": False, "message": "No dev server state found"}
-
-    pid = state.get("pid")
+def _kill_one(record: dict) -> dict:
+    """Kill a single service's process tree. Non-fatal on 'not found'."""
+    pid = record.get("pid")
     if not pid:
-        _clear_state(cwd)
-        return {"running": False, "message": "No PID in state file"}
-
+        return {"name": record.get("name"), "pid": None, "killed": False, "reason": "no_pid"}
     if not _is_pid_running(pid):
-        _clear_state(cwd)
-        return {"running": False, "message": f"Process {pid} not running, cleaned up state"}
-
-    # Kill the process
+        return {"name": record.get("name"), "pid": pid, "killed": False, "reason": "not_running"}
     try:
         if os.name == "nt":
-            subprocess.run(
+            res = subprocess.run(
                 ["taskkill", "/F", "/T", "/PID", str(pid)],
                 capture_output=True,
                 timeout=10,
             )
+            killed = res.returncode == 0
+            reason = None if killed else f"taskkill_rc={res.returncode}"
+            return {"name": record.get("name"), "pid": pid, "killed": killed, "reason": reason}
         else:
-            import signal
-            os.kill(pid, signal.SIGTERM)
-            # Wait briefly for graceful shutdown
-            time.sleep(2)
+            import signal as _signal
+            os.kill(pid, _signal.SIGTERM)
+            time.sleep(0.5)
             if _is_pid_running(pid):
-                os.kill(pid, signal.SIGKILL)
-    except (OSError, subprocess.TimeoutExpired):
-        pass
+                os.kill(pid, _signal.SIGKILL)
+            return {"name": record.get("name"), "pid": pid, "killed": True}
+    except subprocess.TimeoutExpired:
+        return {"name": record.get("name"), "pid": pid, "killed": False, "reason": "taskkill_timeout"}
+    except OSError as e:
+        return {"name": record.get("name"), "pid": pid, "killed": False, "reason": str(e)}
 
-    _clear_state(cwd)
-    return {"running": False, "pid": pid, "message": f"Dev server (PID {pid}) stopped"}
 
+# ---------------------------------------------------------------------------
+# Already-running ownership check
+# ---------------------------------------------------------------------------
 
-def cmd_status(cwd: Path) -> dict:
-    """Check dev server status."""
-    state = _load_state(cwd)
+def _already_running_owned(services: list[dict], state: dict | None) -> bool:
+    """Strict ownership: every declared service's port is in use AND state's
+    PIDs are all alive AND the state's service set matches the declared set."""
     if not state:
-        return {"running": False, "message": "No dev server state"}
+        return False
+    state_services = {s["name"]: s for s in state.get("services", [])}
+    if set(state_services.keys()) != {s["name"] for s in services}:
+        return False
+    for svc in services:
+        rec = state_services.get(svc["name"])
+        if not rec:
+            return False
+        if not _is_pid_running(rec.get("pid", 0)):
+            return False
+        port_open = any(
+            _is_port_in_use_for_host(ph, svc["port"])
+            for ph in _probe_hosts_for(svc.get("host", "localhost"))
+        )
+        if not port_open:
+            return False
+    return True
 
-    pid = state.get("pid")
-    port = state.get("port", 3000)
 
-    pid_alive = _is_pid_running(pid) if pid else False
-    port_in_use = _is_port_in_use(port)
+# ---------------------------------------------------------------------------
+# Top-level commands
+# ---------------------------------------------------------------------------
 
-    if not pid_alive and not port_in_use:
-        _clear_state(cwd)
-        return {"running": False, "message": "Dev server not running, cleaned up stale state"}
+def _emit_warnings(warnings: list[str]) -> None:
+    for w in warnings:
+        print(f"[dev_server] {w}", file=sys.stderr)
 
+
+def cmd_start(cwd: Path, profile: str | None) -> dict:
+    """Resolve services from profile + start them. Backwards-compat entry point."""
+    services, warnings = _get_services(profile, cwd)
+    _emit_warnings(warnings)
+    try:
+        _validate_services(services)
+    except ValueError as e:
+        return {"running": False, "error": f"invalid services: {e}"}
+    return cmd_start_with_services(cwd, services, profile=profile)
+
+
+def cmd_start_with_services(
+    cwd: Path, services: list[dict], profile: str | None
+) -> dict:
+    """Start an explicit (validated) list of services. No warnings emitted."""
+    try:
+        _validate_services(services)
+    except ValueError as e:
+        return {"running": False, "error": f"invalid services: {e}"}
+
+    # Already-running ownership detection
+    state = _load_state(cwd)
+    if _already_running_owned(services, state):
+        primary = _pick_primary(services)
+        return {
+            "running": True,
+            "ready": True,
+            "started_by_us": False,
+            "pid": next(
+                (s["pid"] for s in state["services"] if s["name"] == primary["name"]),
+                None,
+            ),
+            "url": _service_url(primary),
+            "services": state["services"],
+            "message": "Dev server(s) already running",
+        }
+
+    # Stale state for a DIFFERENT service set with at least one PID still alive
+    # → refuse rather than silently overwrite (would orphan our own previously-
+    # tracked processes). Foreign processes are still never killed.
+    if state and state.get("services"):
+        declared_names = {svc["name"] for svc in services}
+        state_names = {s["name"] for s in state["services"]}
+        if state_names != declared_names:
+            stale_alive = [
+                rec for rec in state["services"]
+                if _is_pid_running(rec.get("pid", 0))
+            ]
+            if stale_alive:
+                stale_names = sorted(rec["name"] for rec in stale_alive)
+                return {
+                    "running": False,
+                    "error": (
+                        f"stale dev_server state for services {stale_names} "
+                        f"with live PIDs; run 'dev_server.py stop' first"
+                    ),
+                    "services": [],
+                }
+
+    # Refuse to act if any port is busy without proven ownership
+    for svc in services:
+        for ph in _probe_hosts_for(svc.get("host", "localhost")):
+            if _is_port_in_use_for_host(ph, svc["port"]):
+                return {
+                    "running": False,
+                    "error": (
+                        f"port {svc['port']} already in use (service {svc['name']!r}); "
+                        f"run 'dev_server.py stop' or free the port manually"
+                    ),
+                    "services": [],
+                }
+        # don't kill, don't claim ownership
+
+    # Topo-ordered start with rollback on failure
+    layers = _topo_sort(services)
+    started: list[tuple[Any, dict]] = []  # (proc, record)
+    try:
+        for layer in layers:
+            # Popen all in this layer (cheap), then wait per-service
+            spawned_in_layer: list[tuple[Any, dict, dict]] = []  # (proc, rec, svc)
+            for svc in layer:
+                proc, record = _start_one(svc, cwd)
+                started.append((proc, record))
+                spawned_in_layer.append((proc, record, svc))
+            for proc, record, svc in spawned_in_layer:
+                deadline = time.time() + int(svc.get("ready_timeout_seconds", 60))
+                ok, reason = _wait_for_service(svc, proc, deadline)
+                if not ok:
+                    raise _StartFailed(svc["name"], reason)
+        # All healthy → atomic state write
+        state_to_save = {
+            "version": STATE_VERSION,
+            "profile": profile,
+            "services": [rec for _, rec in started],
+        }
+        _save_state_atomic(cwd, state_to_save)
+        primary_record = next(
+            (rec for _, rec in started if rec.get("primary")),
+            started[0][1] if started else None,
+        )
+        return {
+            "running": True,
+            "ready": True,
+            "started_by_us": True,
+            "pid": primary_record["pid"] if primary_record else None,
+            "url": primary_record["url"] if primary_record else None,
+            "services": [rec for _, rec in started],
+        }
+    except _StartFailed as e:
+        return _rollback_and_report(started, error=str(e))
+    except OSError as e:
+        return _rollback_and_report(started, error=f"start error: {e}")
+
+
+class _StartFailed(Exception):
+    def __init__(self, service_name: str, reason: str):
+        super().__init__(f"service {service_name!r} failed: {reason}")
+        self.service_name = service_name
+        self.reason = reason
+
+
+def _rollback_and_report(
+    started: list[tuple[Any, dict]], error: str
+) -> dict:
+    """Kill every started service in reverse, return error JSON. State already absent."""
+    kill_results: list[dict] = []
+    for proc, record in reversed(started):
+        try:
+            kill_results.append(_kill_one(record))
+        except Exception as e:  # pragma: no cover — defensive
+            kill_results.append({
+                "name": record.get("name"), "pid": record.get("pid"),
+                "killed": False, "reason": f"exception: {e}",
+            })
     return {
-        "running": port_in_use,
-        "pid": pid,
-        "url": f"http://localhost:{port}",
-        "ready": port_in_use,
-        "pid_alive": pid_alive,
+        "running": False,
+        "error": error,
+        "services": [rec for _, rec in started],
+        "rollback": list(reversed(kill_results)),
     }
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Manage target project dev server")
+def cmd_stop(cwd: Path) -> dict:
+    state = _load_state(cwd)
+    if not state:
+        return {"running": False, "message": "no dev server state"}
+    services = state.get("services", [])
+    results: list[dict] = []
+    try:
+        for record in reversed(services):
+            try:
+                results.append(_kill_one(record))
+            except Exception as e:
+                results.append({
+                    "name": record.get("name"), "pid": record.get("pid"),
+                    "killed": False, "reason": f"exception: {e}",
+                })
+    finally:
+        _clear_state(cwd)
+    return {"running": False, "services": list(reversed(results))}
+
+
+def cmd_status(cwd: Path) -> dict:
+    state = _load_state(cwd)
+    if not state:
+        return {"running": False, "message": "no dev server state"}
+    services = state.get("services", [])
+    per_service = []
+    any_alive = False
+    all_alive = True
+    primary_record = None
+    for rec in services:
+        pid = rec.get("pid")
+        port = rec.get("port")
+        host = rec.get("host", "localhost")
+        pid_alive = _is_pid_running(pid) if pid else False
+        port_open = any(
+            _is_port_in_use_for_host(ph, port)
+            for ph in _probe_hosts_for(host)
+        )
+        per_alive = bool(pid_alive and port_open)
+        any_alive = any_alive or per_alive
+        all_alive = all_alive and per_alive
+        per_service.append({
+            **rec,
+            "pid_alive": pid_alive,
+            "port_in_use": port_open,
+            "ready": per_alive,
+        })
+        if rec.get("primary"):
+            primary_record = rec
+    if primary_record is None and services:
+        primary_record = services[0]
+
+    if not any_alive:
+        _clear_state(cwd)
+        return {"running": False, "message": "no service alive; cleaned up state"}
+
+    # Top-level pid/url reflect the primary IFF it's actually alive. If the
+    # stack is partially up (running=False) but primary is dead, do not
+    # advertise its pid/url — callers that read top-level keys would otherwise
+    # think a usable URL exists.
+    primary_alive = bool(
+        primary_record
+        and any(
+            ps.get("ready") and ps.get("name") == primary_record.get("name")
+            for ps in per_service
+        )
+    )
+    primary_pid = primary_record.get("pid") if primary_alive else None
+    primary_url = primary_record.get("url") if primary_alive else None
+    return {
+        "running": all_alive,
+        "ready": all_alive,
+        "pid": primary_pid,
+        "url": primary_url,
+        "services": per_service,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main_with_args(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Manage target project dev server(s)")
     parser.add_argument("action", choices=["start", "stop", "status"])
     parser.add_argument("--cwd", required=True, help="Target project directory")
-    parser.add_argument("--profile", help="Stack profile name (e.g., supabase-nextjs)")
-    args = parser.parse_args()
+    parser.add_argument("--profile", help="Stack profile name (e.g., supabase-nextjs, vite-hono)")
+    parser.add_argument(
+        "--services-json",
+        help="Inline services JSON array; takes precedence over --profile",
+    )
+    args = parser.parse_args(argv)
 
     cwd = Path(args.cwd).resolve()
     if not cwd.is_dir():
-        print(json.dumps({"error": f"Directory not found: {cwd}"}, indent=2))
+        print(json.dumps({"error": f"directory not found: {cwd}"}, indent=2))
         return 1
 
     if args.action == "start":
-        result = cmd_start(cwd, args.profile)
+        if args.services_json:
+            if args.profile:
+                print(
+                    "[dev_server] --services-json overrides --profile",
+                    file=sys.stderr,
+                )
+            try:
+                raw = json.loads(args.services_json)
+            except json.JSONDecodeError as e:
+                print(json.dumps({"running": False, "error": f"invalid --services-json: {e}"}, indent=2))
+                return 2
+            if not isinstance(raw, list):
+                print(json.dumps({"running": False, "error": "--services-json must be a JSON array"}, indent=2))
+                return 2
+            try:
+                services = [_normalize_service_entry(e) for e in raw]
+            except (TypeError, AttributeError) as e:
+                print(json.dumps({"running": False, "error": f"invalid services entry: {e}"}, indent=2))
+                return 2
+            try:
+                _validate_services(services)
+            except ValueError as e:
+                print(json.dumps({"running": False, "error": str(e)}, indent=2))
+                return 2
+            result = cmd_start_with_services(cwd, services, profile=None)
+        else:
+            result = cmd_start(cwd, args.profile)
     elif args.action == "stop":
         result = cmd_stop(cwd)
     else:
@@ -269,6 +890,58 @@ def main() -> int:
 
     print(json.dumps(result, indent=2))
     return 0 if result.get("error") is None else 1
+
+
+def main() -> int:
+    return main_with_args(sys.argv[1:])
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compat shims for legacy tests
+# ---------------------------------------------------------------------------
+
+def _get_config(profile: str | None, cwd: Path | None = None) -> dict:
+    """Legacy: return a single-service config dict.
+
+    Existing test_dev_server.py calls this with `_get_config("supabase-nextjs")`
+    and expects keys like `command`, `port`. We honor the legacy contract by
+    returning the dev_server block (or default).
+    """
+    if profile and profile in PROFILE_DEV_SERVERS:
+        return dict(PROFILE_DEV_SERVERS[profile])
+    if cwd:
+        build_config = cwd / "shipwright_build_config.json"
+        if build_config.exists():
+            try:
+                data = json.loads(build_config.read_text(encoding="utf-8"))
+                dev_url = data.get("dev_url", "")
+                if dev_url:
+                    parsed = urlparse(dev_url)
+                    port = parsed.port or 3000
+                    return {
+                        "command": _DEFAULT_SERVICE["command"],
+                        "port": port,
+                        "ready_timeout_seconds": _DEFAULT_SERVICE["ready_timeout_seconds"],
+                        "ready_path": _DEFAULT_SERVICE["ready_path"],
+                    }
+            except (json.JSONDecodeError, OSError):
+                pass
+    return {
+        "command": _DEFAULT_SERVICE["command"],
+        "port": _DEFAULT_SERVICE["port"],
+        "ready_timeout_seconds": _DEFAULT_SERVICE["ready_timeout_seconds"],
+        "ready_path": _DEFAULT_SERVICE["ready_path"],
+    }
+
+
+def _wait_for_ready(port: int, timeout: int) -> bool:
+    """Legacy: poll port until open or timeout."""
+    start = time.time()
+    while time.time() - start < timeout:
+        if _is_port_in_use_for_host("127.0.0.1", port) or _is_port_in_use_for_host("::1", port):
+            return True
+        time.sleep(1)
+    return False
 
 
 if __name__ == "__main__":

--- a/shared/tests/test_dev_server.py
+++ b/shared/tests/test_dev_server.py
@@ -1,4 +1,18 @@
-"""Tests for dev_server.py."""
+"""Tests for legacy/single-service dev_server.py behavior.
+
+These tests cover the back-compat surface used by build/test/preview/
+iterate/adopt callers: `start --profile X --cwd Y`, top-level `pid`/`url`
+in JSON output, single-service stop semantics. Multi-service behavior is
+covered in test_dev_server_multiservice.py.
+
+Internal helper API was refactored in iterate-20260425 (multi-service):
+- `_load_state` now returns a v2-normalized dict even for legacy v1 files.
+- Port probing function renamed `_is_port_in_use` → `_is_port_in_use_for_host`
+  (the legacy name still exists as a dual-stack convenience wrapper).
+- `cmd_start` no longer treats "port in use without a state file" as
+  "already running" (Round-1 BLOCKER fix: never claim ownership of
+  unowned processes).
+"""
 
 import json
 import sys
@@ -38,10 +52,17 @@ def test_get_config_none_profile():
 
 
 def test_save_and_load_state(tmp_path):
+    """v1 state on disk is read back as v2-normalized (single-service)."""
     state = {"pid": 12345, "port": 3000}
     _save_state(tmp_path, state)
     loaded = _load_state(tmp_path)
-    assert loaded == state
+    # v1 → v2 in-memory normalization
+    assert loaded is not None
+    assert loaded.get("version") == 2
+    assert len(loaded["services"]) == 1
+    assert loaded["services"][0]["pid"] == 12345
+    assert loaded["services"][0]["port"] == 3000
+    assert loaded["services"][0]["name"] == "primary"
 
 
 def test_load_state_no_file(tmp_path):
@@ -54,20 +75,41 @@ def test_clear_state(tmp_path):
     assert _load_state(tmp_path) is None
 
 
-@patch("dev_server._is_port_in_use", return_value=True)
-def test_start_already_running(mock_port, tmp_path):
+@patch("dev_server._is_pid_running", return_value=True)
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_start_already_running(mock_port, mock_pid, tmp_path):
+    """Port in use AND state file with matching live PID → already-running."""
+    # Pre-seed a v2 state file matching the supabase-nextjs single-service shape
+    state = {
+        "version": 2,
+        "profile": "supabase-nextjs",
+        "services": [{
+            "name": "primary",
+            "pid": 12345,
+            "port": 3000,
+            "host": "localhost",
+            "scheme": "http",
+            "command": "npm run dev",
+            "url": "http://localhost:3000",
+            "ready_path": "/",
+            "ready_timeout_seconds": 60,
+            "primary": True,
+        }],
+    }
+    _save_state(tmp_path, state)
     result = cmd_start(tmp_path, "supabase-nextjs")
     assert result["running"] is True
     assert result["started_by_us"] is False
-    assert "already running" in result["message"]
+    assert "already running" in result.get("message", "").lower()
 
 
-@patch("dev_server._is_port_in_use", return_value=False)
-@patch("dev_server._wait_for_ready", return_value=True)
+@patch("dev_server._is_port_in_use_for_host", return_value=False)
+@patch("dev_server._wait_for_service", return_value=(True, ""))
 @patch("dev_server.subprocess.Popen")
-def test_start_new_server(mock_popen, mock_ready, mock_port, tmp_path):
+def test_start_new_server(mock_popen, mock_wait, mock_port, tmp_path):
     mock_proc = MagicMock()
     mock_proc.pid = 99999
+    mock_proc.poll.return_value = None
     mock_popen.return_value = mock_proc
 
     result = cmd_start(tmp_path, "supabase-nextjs")
@@ -80,11 +122,12 @@ def test_start_new_server(mock_popen, mock_ready, mock_port, tmp_path):
 def test_stop_no_state(tmp_path):
     result = cmd_stop(tmp_path)
     assert result["running"] is False
-    assert "No dev server state" in result["message"]
+    assert "no dev server state" in result.get("message", "").lower()
 
 
 @patch("dev_server._is_pid_running", return_value=False)
 def test_stop_stale_pid(mock_pid, tmp_path):
+    """Stale PID is non-fatal; state still cleared."""
     _save_state(tmp_path, {"pid": 12345, "port": 3000})
     result = cmd_stop(tmp_path)
     assert result["running"] is False
@@ -97,7 +140,7 @@ def test_status_no_state(tmp_path):
 
 
 @patch("dev_server._is_pid_running", return_value=True)
-@patch("dev_server._is_port_in_use", return_value=True)
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
 def test_status_running(mock_port, mock_pid, tmp_path):
     _save_state(tmp_path, {"pid": 12345, "port": 3000})
     result = cmd_status(tmp_path)
@@ -107,7 +150,7 @@ def test_status_running(mock_port, mock_pid, tmp_path):
 
 
 @patch("dev_server._is_pid_running", return_value=False)
-@patch("dev_server._is_port_in_use", return_value=False)
+@patch("dev_server._is_port_in_use_for_host", return_value=False)
 def test_status_stale_cleans_up(mock_port, mock_pid, tmp_path):
     _save_state(tmp_path, {"pid": 12345, "port": 3000})
     result = cmd_status(tmp_path)

--- a/shared/tests/test_dev_server_multiservice.py
+++ b/shared/tests/test_dev_server_multiservice.py
@@ -1,0 +1,1078 @@
+"""Tests for the multi-service dev_server.py refactor (iterate-20260425).
+
+Covers AC1-AC10, AC13. Profile-loading tests for AC11 (vite-hono) live
+near the bottom. Tests for AC12 (signature merge) and AC14 (adopt
+SKILL.md prose) live in the shipwright-adopt plugin tests.
+
+All tests use mocks; no real subprocess is launched.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import dev_server  # type: ignore  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# AC1 / AC8 — schema loading + legacy compatibility
+# ---------------------------------------------------------------------------
+
+def _write_profile(tmp_path: Path, name: str, body: dict) -> Path:
+    profiles_dir = tmp_path / "profiles"
+    profiles_dir.mkdir(exist_ok=True)
+    p = profiles_dir / f"{name}.json"
+    p.write_text(json.dumps(body), encoding="utf-8")
+    return p
+
+
+def test_get_services_legacy_dev_server_block(tmp_path):
+    services, warnings = dev_server._get_services_for_test(
+        profile_data={"dev_server": {"command": "npm run dev", "port": 3000, "ready_path": "/"}},
+        cwd=tmp_path,
+    )
+    assert len(services) == 1
+    assert services[0]["name"] == "primary"
+    assert services[0]["primary"] is True
+    assert services[0]["host"] == "localhost"
+    assert services[0]["scheme"] == "http"
+    assert warnings == []
+
+
+def test_get_services_array_shape(tmp_path):
+    services, warnings = dev_server._get_services_for_test(
+        profile_data={
+            "services": [
+                {"name": "a", "command": "cmd-a", "port": 3000, "ready_path": "/"},
+                {"name": "b", "command": "cmd-b", "port": 3001},
+            ]
+        },
+        cwd=tmp_path,
+    )
+    assert [s["name"] for s in services] == ["a", "b"]
+    # First-declared default-primary
+    assert services[0]["primary"] is True
+    assert services[1].get("primary") in (False, None)
+    assert warnings == []
+
+
+def test_get_services_both_blocks_prefers_array_with_warning(tmp_path):
+    services, warnings = dev_server._get_services_for_test(
+        profile_data={
+            "dev_server": {"command": "legacy-cmd", "port": 9999, "ready_path": "/"},
+            "services": [{"name": "winner", "command": "new-cmd", "port": 3000}],
+        },
+        cwd=tmp_path,
+    )
+    assert len(services) == 1
+    assert services[0]["name"] == "winner"
+    assert any("services" in w and "dev_server" in w for w in warnings)
+
+
+def test_get_services_explicit_primary(tmp_path):
+    services, _ = dev_server._get_services_for_test(
+        profile_data={
+            "services": [
+                {"name": "a", "command": "x", "port": 3000},
+                {"name": "b", "command": "y", "port": 3001, "primary": True},
+            ]
+        },
+        cwd=tmp_path,
+    )
+    primary = dev_server._pick_primary(services)
+    assert primary["name"] == "b"
+
+
+def test_get_services_two_primaries_errors(tmp_path):
+    with pytest.raises(ValueError, match="multiple"):
+        dev_server._get_services_for_test(
+            profile_data={
+                "services": [
+                    {"name": "a", "command": "x", "port": 3000, "primary": True},
+                    {"name": "b", "command": "y", "port": 3001, "primary": True},
+                ]
+            },
+            cwd=tmp_path,
+        )
+
+
+def test_get_services_duplicate_names_errors(tmp_path):
+    with pytest.raises(ValueError, match="duplicate"):
+        dev_server._get_services_for_test(
+            profile_data={
+                "services": [
+                    {"name": "dupe", "command": "x", "port": 3000},
+                    {"name": "dupe", "command": "y", "port": 3001},
+                ]
+            },
+            cwd=tmp_path,
+        )
+
+
+def test_get_services_missing_depends_on_target_errors(tmp_path):
+    with pytest.raises(ValueError, match="depends_on"):
+        dev_server._get_services_for_test(
+            profile_data={
+                "services": [
+                    {"name": "a", "command": "x", "port": 3000, "depends_on": ["nonexistent"]},
+                ]
+            },
+            cwd=tmp_path,
+        )
+
+
+def test_get_services_self_dependency_errors(tmp_path):
+    with pytest.raises(ValueError, match="self"):
+        dev_server._get_services_for_test(
+            profile_data={
+                "services": [
+                    {"name": "a", "command": "x", "port": 3000, "depends_on": ["a"]},
+                ]
+            },
+            cwd=tmp_path,
+        )
+
+
+def test_get_services_dependency_cycle_errors(tmp_path):
+    with pytest.raises(ValueError, match="cycle"):
+        dev_server._get_services_for_test(
+            profile_data={
+                "services": [
+                    {"name": "a", "command": "x", "port": 3000, "depends_on": ["b"]},
+                    {"name": "b", "command": "y", "port": 3001, "depends_on": ["a"]},
+                ]
+            },
+            cwd=tmp_path,
+        )
+
+
+def test_get_services_malformed_entry_errors(tmp_path):
+    # Missing port
+    with pytest.raises(ValueError):
+        dev_server._get_services_for_test(
+            profile_data={"services": [{"name": "a", "command": "x"}]},
+            cwd=tmp_path,
+        )
+    # Empty name
+    with pytest.raises(ValueError):
+        dev_server._get_services_for_test(
+            profile_data={"services": [{"name": "", "command": "x", "port": 3000}]},
+            cwd=tmp_path,
+        )
+    # Non-int port
+    with pytest.raises(ValueError):
+        dev_server._get_services_for_test(
+            profile_data={"services": [{"name": "a", "command": "x", "port": "three-thousand"}]},
+            cwd=tmp_path,
+        )
+
+
+def test_get_services_size_one_backend_only(tmp_path):
+    services, _ = dev_server._get_services_for_test(
+        profile_data={
+            "services": [{"name": "api", "command": "node server.js", "port": 4000}]
+        },
+        cwd=tmp_path,
+    )
+    assert len(services) == 1
+    assert services[0]["ready_path"] is None or "ready_path" not in services[0] or services[0]["ready_path"] == ""
+
+
+def test_get_services_dev_url_preserves_host_scheme(tmp_path):
+    build_config = tmp_path / "shipwright_build_config.json"
+    build_config.write_text(
+        json.dumps({"dev_url": "https://127.0.0.1:4443/"}), encoding="utf-8"
+    )
+    # No profile match, no profile_data -> falls back to dev_url
+    services, _ = dev_server._get_services_for_test(profile_data=None, cwd=tmp_path)
+    assert len(services) == 1
+    s = services[0]
+    assert s["host"] == "127.0.0.1"
+    assert s["scheme"] == "https"
+    assert s["port"] == 4443
+
+
+def test_get_services_non_loopback_host_errors(tmp_path):
+    with pytest.raises(ValueError, match="loopback"):
+        dev_server._get_services_for_test(
+            profile_data={
+                "services": [
+                    {"name": "a", "command": "x", "port": 3000, "host": "192.168.1.5"}
+                ]
+            },
+            cwd=tmp_path,
+        )
+
+
+def test_get_services_dev_url_non_loopback_host_rejected_at_start(tmp_path):
+    """build_config dev_url with non-loopback host → cmd_start rejects."""
+    build_config = tmp_path / "shipwright_build_config.json"
+    build_config.write_text(
+        json.dumps({"dev_url": "http://my-dev-machine.local:3000/"}),
+        encoding="utf-8",
+    )
+    result = dev_server.cmd_start(tmp_path, profile=None)
+    assert result["running"] is False
+    assert "loopback" in result.get("error", "").lower()
+
+
+def test_get_services_depends_on_non_string_errors(tmp_path):
+    with pytest.raises(ValueError, match="depends_on"):
+        dev_server._get_services_for_test(
+            profile_data={
+                "services": [
+                    {"name": "a", "command": "x", "port": 3000},
+                    {"name": "b", "command": "y", "port": 3001, "depends_on": [42]},
+                ]
+            },
+            cwd=tmp_path,
+        )
+
+
+def test_get_services_ready_timeout_non_int_errors(tmp_path):
+    with pytest.raises(ValueError, match="ready_timeout_seconds"):
+        dev_server._get_services_for_test(
+            profile_data={
+                "services": [
+                    {"name": "a", "command": "x", "port": 3000,
+                     "ready_timeout_seconds": "thirty"}
+                ]
+            },
+            cwd=tmp_path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC3 — Topo ordering / parallel start
+# ---------------------------------------------------------------------------
+
+def test_topo_sort_independent_services_one_layer():
+    services = [
+        {"name": "a", "command": "x", "port": 3000},
+        {"name": "b", "command": "y", "port": 3001},
+        {"name": "c", "command": "z", "port": 3002},
+    ]
+    layers = dev_server._topo_sort(services)
+    assert len(layers) == 1
+    assert [s["name"] for s in layers[0]] == ["a", "b", "c"]
+
+
+def test_topo_sort_dependency_two_layers():
+    services = [
+        {"name": "a", "command": "x", "port": 3000},
+        {"name": "b", "command": "y", "port": 3001, "depends_on": ["a"]},
+    ]
+    layers = dev_server._topo_sort(services)
+    assert len(layers) == 2
+    assert [s["name"] for s in layers[0]] == ["a"]
+    assert [s["name"] for s in layers[1]] == ["b"]
+
+
+def test_topo_sort_mixed_dag_stable_declaration_order():
+    services = [
+        {"name": "a", "command": "x", "port": 3000},
+        {"name": "b", "command": "x", "port": 3001},
+        {"name": "c", "command": "x", "port": 3002, "depends_on": ["a"]},
+        {"name": "d", "command": "x", "port": 3003, "depends_on": ["a"]},
+        {"name": "e", "command": "x", "port": 3004, "depends_on": ["c", "d"]},
+    ]
+    layers = dev_server._topo_sort(services)
+    assert len(layers) == 3
+    assert [s["name"] for s in layers[0]] == ["a", "b"]
+    assert [s["name"] for s in layers[1]] == ["c", "d"]
+    assert [s["name"] for s in layers[2]] == ["e"]
+
+
+# ---------------------------------------------------------------------------
+# AC1 / AC3 — shlex command parsing
+# ---------------------------------------------------------------------------
+
+@patch("dev_server.subprocess.Popen")
+def test_start_command_with_quoted_args_via_shlex(mock_popen, tmp_path):
+    mock_proc = MagicMock()
+    mock_proc.pid = 42
+    mock_proc.poll.return_value = None
+    mock_popen.return_value = mock_proc
+
+    service = {
+        "name": "fe",
+        "command": 'npm run dev -- --port 5173 --host "0.0.0.0"',
+        "port": 5173,
+        "host": "localhost",
+        "scheme": "http",
+    }
+    proc, _record = dev_server._start_one(service, tmp_path)
+    args = mock_popen.call_args[0][0]
+    # Argv must include the literal '0.0.0.0' as a single token (quotes stripped)
+    assert "0.0.0.0" in args
+    # The double quotes themselves must NOT appear as part of any arg
+    assert all('"' not in a for a in args)
+
+
+# ---------------------------------------------------------------------------
+# AC3 — _wait_for_service health checks
+# ---------------------------------------------------------------------------
+
+class _FakeProc:
+    """Minimal Popen-like double for wait tests."""
+    def __init__(self, exit_after: float | None = None):
+        self.pid = 12345
+        self._dead_at = (time.time() + exit_after) if exit_after is not None else None
+
+    def poll(self):
+        if self._dead_at is None:
+            return None
+        return 1 if time.time() >= self._dead_at else None
+
+
+@patch("dev_server._http_probe", return_value=False)
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_wait_for_service_port_open_only(mock_port, mock_http, tmp_path):
+    svc = {"name": "a", "host": "localhost", "scheme": "http", "port": 3000}
+    proc = _FakeProc()
+    deadline = time.time() + 2
+    ok, reason = dev_server._wait_for_service(svc, proc, deadline)
+    assert ok is True
+    assert reason == ""
+
+
+def test_wait_for_service_child_died_fails_fast(tmp_path):
+    svc = {"name": "a", "host": "localhost", "scheme": "http", "port": 3000}
+    proc = _FakeProc(exit_after=0.0)  # dead immediately
+    deadline = time.time() + 30  # generous deadline
+    start = time.time()
+    ok, reason = dev_server._wait_for_service(svc, proc, deadline)
+    elapsed = time.time() - start
+    assert ok is False
+    assert reason == "process_exited"
+    assert elapsed < 5  # NOT the full 30s
+
+
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_wait_for_service_port_held_by_external_process_no_pid(mock_port, tmp_path):
+    """Port open BEFORE we Popened — but our PID never started.
+
+    `_already_running_owned` covers this at start-time. The lower-level
+    `_wait_for_service` doesn't get called in that path, so this case is
+    proven via cmd_start (see test_start_port_busy_no_state_errors_no_kill).
+    Marking as covered-elsewhere; nothing to assert at this level.
+    """
+    pass
+
+
+@patch("dev_server._http_probe")
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_wait_for_service_ready_path_2xx(mock_port, mock_http, tmp_path):
+    mock_http.return_value = True  # 200 OK
+    svc = {"name": "a", "host": "localhost", "scheme": "http", "port": 3000, "ready_path": "/health"}
+    proc = _FakeProc()
+    ok, _ = dev_server._wait_for_service(svc, proc, time.time() + 2)
+    assert ok is True
+
+
+@patch("dev_server._http_probe")
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_wait_for_service_ready_path_3xx(mock_port, mock_http, tmp_path):
+    # http_probe should accept 3xx; we model it returning True
+    mock_http.return_value = True
+    svc = {"name": "a", "host": "localhost", "scheme": "http", "port": 3000, "ready_path": "/"}
+    proc = _FakeProc()
+    ok, _ = dev_server._wait_for_service(svc, proc, time.time() + 2)
+    assert ok is True
+
+
+@patch("dev_server._http_probe")
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_wait_for_service_ready_path_5xx_retries_until_deadline(mock_port, mock_http, tmp_path):
+    # First two calls 5xx (False), then 200 (True)
+    mock_http.side_effect = [False, False, True]
+    svc = {"name": "a", "host": "localhost", "scheme": "http", "port": 3000, "ready_path": "/"}
+    proc = _FakeProc()
+    ok, _ = dev_server._wait_for_service(svc, proc, time.time() + 10)
+    assert ok is True
+    assert mock_http.call_count >= 3
+
+
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_wait_for_service_bounded_elapsed_time_under_short_deadline(mock_port, tmp_path):
+    """All HTTP probes fail; elapsed time MUST stay under the deadline."""
+    svc = {"name": "a", "host": "localhost", "scheme": "http", "port": 3000, "ready_path": "/"}
+    proc = _FakeProc()
+    deadline = time.time() + 3  # 3 seconds total
+    start = time.time()
+    with patch("dev_server._http_probe", return_value=False):
+        ok, reason = dev_server._wait_for_service(svc, proc, deadline)
+    elapsed = time.time() - start
+    assert ok is False
+    assert reason == "timeout"
+    # Hard upper bound: must respect deadline + a tiny tolerance for the final
+    # sleep iteration (1.0s between HTTP retries).
+    assert elapsed < 5, f"elapsed {elapsed}s overran deadline+tolerance"
+
+
+def test_wait_for_service_ipv6_only_bind(tmp_path):
+    """host=localhost: probe falls through IPv4 to IPv6 and succeeds on ::1."""
+    calls = []
+
+    def fake_port(host, port):
+        calls.append(host)
+        return host == "::1"
+
+    svc = {"name": "a", "host": "localhost", "scheme": "http", "port": 3000}
+    proc = _FakeProc()
+    with patch("dev_server._is_port_in_use_for_host", side_effect=fake_port), \
+         patch("dev_server._http_probe", return_value=False):
+        ok, _ = dev_server._wait_for_service(svc, proc, time.time() + 2)
+    assert ok is True
+    assert "::1" in calls
+
+
+def test_wait_for_service_explicit_ipv4_host_no_ipv6_probe(tmp_path):
+    calls = []
+
+    def fake_port(host, port):
+        calls.append(host)
+        return host == "127.0.0.1"
+
+    svc = {"name": "a", "host": "127.0.0.1", "scheme": "http", "port": 3000}
+    proc = _FakeProc()
+    with patch("dev_server._is_port_in_use_for_host", side_effect=fake_port), \
+         patch("dev_server._http_probe", return_value=False):
+        ok, _ = dev_server._wait_for_service(svc, proc, time.time() + 2)
+    assert ok is True
+    assert "::1" not in calls
+
+
+def test_wait_for_service_explicit_ipv6_host_no_ipv4_probe(tmp_path):
+    calls = []
+
+    def fake_port(host, port):
+        calls.append(host)
+        return host == "::1"
+
+    svc = {"name": "a", "host": "::1", "scheme": "http", "port": 3000}
+    proc = _FakeProc()
+    with patch("dev_server._is_port_in_use_for_host", side_effect=fake_port), \
+         patch("dev_server._http_probe", return_value=False):
+        ok, _ = dev_server._wait_for_service(svc, proc, time.time() + 2)
+    assert ok is True
+    assert "127.0.0.1" not in calls
+
+
+def test_wait_for_service_http_uses_declared_host(tmp_path):
+    """IPv6 host must produce bracketed URL: http://[::1]:3000/health"""
+    captured_urls = []
+
+    def fake_http(url, timeout):
+        captured_urls.append(url)
+        return True
+
+    svc = {"name": "a", "host": "::1", "scheme": "http", "port": 3000, "ready_path": "/health"}
+    proc = _FakeProc()
+    with patch("dev_server._is_port_in_use_for_host", return_value=True), \
+         patch("dev_server._http_probe", side_effect=fake_http):
+        ok, _ = dev_server._wait_for_service(svc, proc, time.time() + 2)
+    assert ok is True
+    assert any("[::1]" in u for u in captured_urls), captured_urls
+
+
+# ---------------------------------------------------------------------------
+# AC5 / AC4 — already-running detection (never kill foreign)
+# ---------------------------------------------------------------------------
+
+@patch("dev_server._is_pid_running", return_value=True)
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_start_already_running_only_when_pid_owned(mock_port, mock_pid, tmp_path):
+    services = [{"name": "primary", "command": "x", "port": 3000, "host": "localhost", "scheme": "http"}]
+    state = {
+        "version": 2,
+        "services": [{"name": "primary", "pid": 99, "port": 3000, "host": "localhost",
+                      "scheme": "http", "command": "x", "url": "http://localhost:3000",
+                      "ready_path": None, "ready_timeout_seconds": 60, "primary": True}],
+    }
+    dev_server._save_state(tmp_path, state)
+    result = dev_server.cmd_start(tmp_path, "supabase-nextjs")
+    assert result["running"] is True
+    assert result.get("started_by_us") is False
+
+
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_start_port_busy_no_state_errors_no_kill(mock_port, tmp_path):
+    """Port in use but no state file → error, do NOT kill anything."""
+    with patch("dev_server._kill_one") as kill_mock:
+        # Run cmd_start with default profile (matches existing single-service test)
+        result = dev_server.cmd_start(tmp_path, "supabase-nextjs")
+    assert result["running"] is False
+    assert "in use" in result.get("error", "").lower() or "occupied" in result.get("error", "").lower()
+    kill_mock.assert_not_called()
+
+
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_start_port_busy_state_file_mismatch_errors_no_kill(mock_port, tmp_path):
+    # State references a different service set
+    state = {
+        "version": 2,
+        "services": [{"name": "other", "pid": 99, "port": 3001, "host": "localhost",
+                      "scheme": "http", "command": "y", "url": "http://localhost:3001",
+                      "ready_path": None, "ready_timeout_seconds": 60, "primary": True}],
+    }
+    dev_server._save_state(tmp_path, state)
+    with patch("dev_server._kill_one") as kill_mock, \
+         patch("dev_server._is_pid_running", return_value=False):
+        result = dev_server.cmd_start(tmp_path, "supabase-nextjs")
+    assert result["running"] is False
+    kill_mock.assert_not_called()
+
+
+@patch("dev_server._is_port_in_use_for_host", return_value=False)
+@patch("dev_server._is_pid_running", return_value=True)
+def test_start_stale_state_different_service_set_with_live_pids_refuses(
+    mock_pid, mock_port, tmp_path
+):
+    """State references services {a, b} with live PIDs; new request targets
+    {primary} (different set) → refuse to act, no overwrite."""
+    state = {
+        "version": 2,
+        "services": [
+            {"name": "a", "pid": 100, "port": 4001, "host": "localhost",
+             "scheme": "http", "command": "x", "url": "http://localhost:4001",
+             "ready_path": None, "ready_timeout_seconds": 60, "primary": True},
+            {"name": "b", "pid": 101, "port": 4002, "host": "localhost",
+             "scheme": "http", "command": "y", "url": "http://localhost:4002",
+             "ready_path": None, "ready_timeout_seconds": 60, "primary": False},
+        ],
+    }
+    dev_server._save_state(tmp_path, state)
+    with patch("dev_server._kill_one") as kill_mock, \
+         patch("dev_server.subprocess.Popen") as popen_mock:
+        result = dev_server.cmd_start(tmp_path, "supabase-nextjs")
+    assert result["running"] is False
+    assert "stale" in result.get("error", "").lower()
+    kill_mock.assert_not_called()
+    popen_mock.assert_not_called()
+    # State file untouched
+    assert (tmp_path / dev_server.STATE_FILE).exists()
+
+
+# ---------------------------------------------------------------------------
+# AC5 — Atomic state writes / partial-failure rollback
+# ---------------------------------------------------------------------------
+
+@patch("dev_server._is_port_in_use_for_host", return_value=False)
+@patch("dev_server.subprocess.Popen")
+def test_start_state_file_only_after_all_healthy(mock_popen, mock_port, tmp_path):
+    # Two services. Service B fails health check.
+    procs = [MagicMock(pid=100), MagicMock(pid=101)]
+    for p in procs:
+        p.poll.return_value = None
+    mock_popen.side_effect = procs
+
+    services = [
+        {"name": "a", "command": "x", "port": 3000, "host": "localhost", "scheme": "http"},
+        {"name": "b", "command": "y", "port": 3001, "host": "localhost", "scheme": "http"},
+    ]
+
+    def fake_wait(svc, proc, deadline):
+        return (True, "") if svc["name"] == "a" else (False, "timeout")
+
+    with patch("dev_server._wait_for_service", side_effect=fake_wait), \
+         patch("dev_server._kill_one") as kill_mock:
+        result = dev_server.cmd_start_with_services(tmp_path, services, profile=None)
+    assert result["running"] is False
+    # State file should NOT exist
+    assert not (tmp_path / dev_server.STATE_FILE).exists()
+    # A's kill was attempted (rollback)
+    assert kill_mock.called
+
+
+@patch("dev_server._is_port_in_use_for_host", return_value=False)
+@patch("dev_server.subprocess.Popen")
+def test_start_partial_failure_kills_started_in_reverse_no_state(mock_popen, mock_port, tmp_path):
+    procs = [MagicMock(pid=100), MagicMock(pid=101), MagicMock(pid=102)]
+    for p in procs:
+        p.poll.return_value = None
+    mock_popen.side_effect = procs
+
+    # Three independent services start in one parallel layer. Popen runs for
+    # all three; then health checks run sequentially. c fails. Rollback kills
+    # all started procs in reverse (c, b, a) — Popen has already been called
+    # on c, so its process MUST be reaped.
+    services = [
+        {"name": "a", "command": "x", "port": 3000, "host": "localhost", "scheme": "http"},
+        {"name": "b", "command": "y", "port": 3001, "host": "localhost", "scheme": "http"},
+        {"name": "c", "command": "z", "port": 3002, "host": "localhost", "scheme": "http"},
+    ]
+
+    def fake_wait(svc, proc, deadline):
+        # a + b succeed; c fails.
+        return (True, "") if svc["name"] in {"a", "b"} else (False, "timeout")
+
+    kill_calls = []
+
+    def fake_kill(record):
+        kill_calls.append(record["name"])
+        return {"name": record["name"], "pid": record["pid"], "killed": True}
+
+    with patch("dev_server._wait_for_service", side_effect=fake_wait), \
+         patch("dev_server._kill_one", side_effect=fake_kill):
+        result = dev_server.cmd_start_with_services(tmp_path, services, profile=None)
+    assert result["running"] is False
+    # All Popened procs killed in reverse start order
+    assert kill_calls == ["c", "b", "a"]
+    assert not (tmp_path / dev_server.STATE_FILE).exists()
+
+
+@patch("dev_server._is_port_in_use_for_host", return_value=False)
+@patch("dev_server.subprocess.Popen")
+def test_start_partial_failure_kill_exception_still_clears_state(mock_popen, mock_port, tmp_path):
+    procs = [MagicMock(pid=100), MagicMock(pid=101)]
+    for p in procs:
+        p.poll.return_value = None
+    mock_popen.side_effect = procs
+
+    services = [
+        {"name": "a", "command": "x", "port": 3000, "host": "localhost", "scheme": "http"},
+        {"name": "b", "command": "y", "port": 3001, "host": "localhost", "scheme": "http"},
+    ]
+
+    def fake_wait(svc, proc, deadline):
+        return (True, "") if svc["name"] == "a" else (False, "timeout")
+
+    def boom(record):
+        raise OSError("kill exploded")
+
+    with patch("dev_server._wait_for_service", side_effect=fake_wait), \
+         patch("dev_server._kill_one", side_effect=boom):
+        result = dev_server.cmd_start_with_services(tmp_path, services, profile=None)
+    assert result["running"] is False
+    # No state file even though kill raised
+    assert not (tmp_path / dev_server.STATE_FILE).exists()
+
+
+@patch("dev_server._is_port_in_use_for_host", return_value=False)
+@patch("dev_server.subprocess.Popen")
+def test_save_state_atomic_replace_failure_no_orphan_tmp(mock_popen, mock_port, tmp_path, monkeypatch):
+    procs = [MagicMock(pid=100)]
+    for p in procs:
+        p.poll.return_value = None
+    mock_popen.side_effect = procs
+
+    services = [
+        {"name": "a", "command": "x", "port": 3000, "host": "localhost", "scheme": "http"},
+    ]
+
+    real_replace = dev_server.os.replace
+
+    def boom_replace(src, dst):
+        raise OSError("replace failed")
+
+    with patch("dev_server._wait_for_service", return_value=(True, "")), \
+         patch("dev_server._kill_one", return_value={"name": "a", "killed": True}), \
+         patch("dev_server.os.replace", side_effect=boom_replace):
+        result = dev_server.cmd_start_with_services(tmp_path, services, profile=None)
+    assert result["running"] is False
+    assert "error" in result
+    # No final state file
+    assert not (tmp_path / dev_server.STATE_FILE).exists()
+    # No orphan .tmp
+    tmps = list(tmp_path.glob(f"{dev_server.STATE_FILE}*"))
+    assert tmps == []
+
+
+# ---------------------------------------------------------------------------
+# AC4 — cmd_stop semantics
+# ---------------------------------------------------------------------------
+
+def test_stop_kills_all_pids_in_reverse_order(tmp_path):
+    state = {
+        "version": 2,
+        "profile": None,
+        "services": [
+            {"name": "a", "pid": 100, "port": 3000, "host": "localhost", "scheme": "http",
+             "command": "x", "url": "http://localhost:3000", "ready_path": None,
+             "ready_timeout_seconds": 60, "primary": True},
+            {"name": "b", "pid": 101, "port": 3001, "host": "localhost", "scheme": "http",
+             "command": "y", "url": "http://localhost:3001", "ready_path": None,
+             "ready_timeout_seconds": 60, "primary": False},
+        ],
+    }
+    dev_server._save_state(tmp_path, state)
+
+    kill_calls = []
+    def fake_kill(record):
+        kill_calls.append(record["name"])
+        return {"name": record["name"], "pid": record["pid"], "killed": True}
+
+    with patch("dev_server._kill_one", side_effect=fake_kill):
+        result = dev_server.cmd_stop(tmp_path)
+    assert kill_calls == ["b", "a"]
+    assert not (tmp_path / dev_server.STATE_FILE).exists()
+
+
+def test_stop_mixed_stale_and_live_pids(tmp_path):
+    state = {
+        "version": 2,
+        "services": [
+            {"name": "a", "pid": 100, "port": 3000, "host": "localhost", "scheme": "http",
+             "command": "x", "url": "http://localhost:3000", "ready_path": None,
+             "ready_timeout_seconds": 60, "primary": True},
+            {"name": "b", "pid": 101, "port": 3001, "host": "localhost", "scheme": "http",
+             "command": "y", "url": "http://localhost:3001", "ready_path": None,
+             "ready_timeout_seconds": 60, "primary": False},
+        ],
+    }
+    dev_server._save_state(tmp_path, state)
+
+    def fake_kill(record):
+        # 'a' is stale (already dead), 'b' is live
+        if record["name"] == "a":
+            return {"name": "a", "pid": 100, "killed": False, "reason": "not_running"}
+        return {"name": "b", "pid": 101, "killed": True}
+
+    with patch("dev_server._kill_one", side_effect=fake_kill):
+        result = dev_server.cmd_stop(tmp_path)
+    assert not (tmp_path / dev_server.STATE_FILE).exists()
+    # Both attempted
+    assert len(result.get("services", [])) == 2
+
+
+def test_stop_kill_raises_state_still_cleared(tmp_path):
+    state = {
+        "version": 2,
+        "services": [
+            {"name": "a", "pid": 100, "port": 3000, "host": "localhost", "scheme": "http",
+             "command": "x", "url": "http://localhost:3000", "ready_path": None,
+             "ready_timeout_seconds": 60, "primary": True},
+            {"name": "b", "pid": 101, "port": 3001, "host": "localhost", "scheme": "http",
+             "command": "y", "url": "http://localhost:3001", "ready_path": None,
+             "ready_timeout_seconds": 60, "primary": False},
+        ],
+    }
+    dev_server._save_state(tmp_path, state)
+
+    def boom(record):
+        if record["name"] == "b":
+            raise RuntimeError("kill bug")
+        return {"name": record["name"], "killed": True}
+
+    with patch("dev_server._kill_one", side_effect=boom):
+        # Must not raise out of cmd_stop; state must still be cleared.
+        dev_server.cmd_stop(tmp_path)
+    assert not (tmp_path / dev_server.STATE_FILE).exists()
+
+
+# Windows taskkill specifics
+
+def test_stop_windows_taskkill_not_found_treated_nonfatal(tmp_path, monkeypatch):
+    monkeypatch.setattr(dev_server.os, "name", "nt")
+    state = {
+        "version": 2,
+        "services": [
+            {"name": "a", "pid": 100, "port": 3000, "host": "localhost", "scheme": "http",
+             "command": "x", "url": "http://localhost:3000", "ready_path": None,
+             "ready_timeout_seconds": 60, "primary": True},
+        ],
+    }
+    dev_server._save_state(tmp_path, state)
+    # Mock subprocess.run for taskkill returning non-zero (not found)
+    completed = MagicMock(returncode=128, stdout="", stderr="not found")
+    with patch("dev_server.subprocess.run", return_value=completed):
+        # Should not raise
+        result = dev_server.cmd_stop(tmp_path)
+    assert not (tmp_path / dev_server.STATE_FILE).exists()
+
+
+def test_stop_windows_taskkill_timeout_treated_nonfatal(tmp_path, monkeypatch):
+    import subprocess
+    monkeypatch.setattr(dev_server.os, "name", "nt")
+    state = {
+        "version": 2,
+        "services": [
+            {"name": "a", "pid": 100, "port": 3000, "host": "localhost", "scheme": "http",
+             "command": "x", "url": "http://localhost:3000", "ready_path": None,
+             "ready_timeout_seconds": 60, "primary": True},
+        ],
+    }
+    dev_server._save_state(tmp_path, state)
+    with patch("dev_server.subprocess.run",
+               side_effect=subprocess.TimeoutExpired(cmd="taskkill", timeout=10)):
+        result = dev_server.cmd_stop(tmp_path)
+    assert not (tmp_path / dev_server.STATE_FILE).exists()
+
+
+# ---------------------------------------------------------------------------
+# AC6 — state-file v1 read compat
+# ---------------------------------------------------------------------------
+
+def test_state_v1_read_compat(tmp_path):
+    """Legacy v1 file (top-level pid/port, no version) → in-memory v2."""
+    legacy = {"pid": 12345, "port": 3000, "command": "npm run dev", "profile": "supabase-nextjs"}
+    (tmp_path / dev_server.STATE_FILE).write_text(json.dumps(legacy), encoding="utf-8")
+    state = dev_server._load_state(tmp_path)
+    assert state is not None
+    assert state.get("version") == 2 or "services" in state
+    services = state.get("services", [])
+    assert len(services) == 1
+    assert services[0]["pid"] == 12345
+    assert services[0]["port"] == 3000
+    assert services[0]["primary"] is True
+    assert services[0]["name"] == "primary"
+
+
+def test_state_v1_not_rewritten_on_read(tmp_path):
+    legacy = {"pid": 12345, "port": 3000, "command": "npm run dev"}
+    state_path = tmp_path / dev_server.STATE_FILE
+    state_path.write_text(json.dumps(legacy), encoding="utf-8")
+    dev_server._load_state(tmp_path)
+    # File on disk is unchanged
+    on_disk = json.loads(state_path.read_text(encoding="utf-8"))
+    assert "version" not in on_disk
+    assert on_disk.get("pid") == 12345
+
+
+def test_state_v2_round_trip(tmp_path):
+    state = {
+        "version": 2,
+        "profile": "vite-hono",
+        "services": [
+            {"name": "backend", "pid": 100, "port": 3847, "host": "localhost",
+             "scheme": "http", "command": "x", "url": "http://localhost:3847",
+             "ready_path": "/api/diagnostics", "ready_timeout_seconds": 60,
+             "primary": False},
+            {"name": "frontend", "pid": 101, "port": 5173, "host": "localhost",
+             "scheme": "http", "command": "y", "url": "http://localhost:5173",
+             "ready_path": "/", "ready_timeout_seconds": 60, "primary": True},
+        ],
+    }
+    dev_server._save_state(tmp_path, state)
+    loaded = dev_server._load_state(tmp_path)
+    assert loaded["version"] == 2
+    assert len(loaded["services"]) == 2
+    assert loaded["services"][1]["url"] == "http://localhost:5173"
+
+
+# ---------------------------------------------------------------------------
+# AC6 — Status output: top-level pid/url from primary
+# ---------------------------------------------------------------------------
+
+@patch("dev_server._is_pid_running", return_value=True)
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_status_v1_state_top_level_pid_url_populated(mock_port, mock_pid, tmp_path):
+    legacy = {"pid": 12345, "port": 3000, "command": "npm run dev"}
+    (tmp_path / dev_server.STATE_FILE).write_text(json.dumps(legacy), encoding="utf-8")
+    result = dev_server.cmd_status(tmp_path)
+    assert result["running"] is True
+    assert result["pid"] == 12345
+    assert "url" in result and "3000" in result["url"]
+
+
+def test_status_partial_alive_primary_dead_clears_top_level(tmp_path):
+    """Primary dead, secondary alive → running=False AND top-level pid/url=None."""
+    state = {
+        "version": 2,
+        "services": [
+            {"name": "backend", "pid": 100, "port": 3847, "host": "localhost",
+             "scheme": "http", "command": "x", "url": "http://localhost:3847",
+             "ready_path": None, "ready_timeout_seconds": 60, "primary": False},
+            {"name": "frontend", "pid": 101, "port": 5173, "host": "localhost",
+             "scheme": "http", "command": "y", "url": "http://localhost:5173",
+             "ready_path": None, "ready_timeout_seconds": 60, "primary": True},
+        ],
+    }
+    dev_server._save_state(tmp_path, state)
+
+    # backend alive; frontend (primary) dead
+    def fake_pid_alive(pid):
+        return pid == 100
+
+    def fake_port(host, port):
+        return port == 3847
+
+    with patch("dev_server._is_pid_running", side_effect=fake_pid_alive), \
+         patch("dev_server._is_port_in_use_for_host", side_effect=fake_port):
+        result = dev_server.cmd_status(tmp_path)
+    assert result["running"] is False
+    # Critical: top-level pid/url MUST be None when primary is dead, even if
+    # other services are alive (else callers see a usable URL that points to
+    # nothing).
+    assert result["pid"] is None
+    assert result["url"] is None
+
+
+@patch("dev_server._is_pid_running", return_value=True)
+@patch("dev_server._is_port_in_use_for_host", return_value=True)
+def test_status_v2_multi_service_top_level_from_primary(mock_port, mock_pid, tmp_path):
+    state = {
+        "version": 2,
+        "services": [
+            {"name": "backend", "pid": 100, "port": 3847, "host": "localhost",
+             "scheme": "http", "command": "x", "url": "http://localhost:3847",
+             "ready_path": "/api/diagnostics", "ready_timeout_seconds": 60,
+             "primary": False},
+            {"name": "frontend", "pid": 101, "port": 5173, "host": "localhost",
+             "scheme": "http", "command": "y", "url": "http://localhost:5173",
+             "ready_path": "/", "ready_timeout_seconds": 60, "primary": True},
+        ],
+    }
+    dev_server._save_state(tmp_path, state)
+    result = dev_server.cmd_status(tmp_path)
+    assert result["running"] is True
+    assert result["pid"] == 101  # primary's pid
+    assert result["url"] == "http://localhost:5173"
+    assert "services" in result
+    assert len(result["services"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI compat regression guard
+# ---------------------------------------------------------------------------
+
+@patch("dev_server._is_port_in_use_for_host", return_value=False)
+@patch("dev_server._wait_for_service", return_value=(True, ""))
+@patch("dev_server.subprocess.Popen")
+def test_cli_legacy_invocation_still_works(mock_popen, mock_wait, mock_port, tmp_path):
+    """Regression guard: existing callers using `start --profile X --cwd Y`
+    should produce a single-service start with legacy top-level keys."""
+    proc = MagicMock(pid=99999)
+    proc.poll.return_value = None
+    mock_popen.return_value = proc
+    result = dev_server.cmd_start(tmp_path, "supabase-nextjs")
+    assert result["running"] is True
+    assert "pid" in result
+    assert "url" in result
+    assert result.get("started_by_us") is True
+    assert "services" in result  # additive, present even for single-service
+
+
+# ---------------------------------------------------------------------------
+# AC13 — --services-json CLI fallback
+# ---------------------------------------------------------------------------
+
+def test_cli_services_json_starts_inline_services(tmp_path, capsys):
+    inline = json.dumps([
+        {"name": "a", "command": "x", "port": 3000, "host": "localhost", "scheme": "http"}
+    ])
+    proc = MagicMock(pid=42)
+    proc.poll.return_value = None
+    with patch("dev_server.subprocess.Popen", return_value=proc), \
+         patch("dev_server._is_port_in_use_for_host", return_value=False), \
+         patch("dev_server._wait_for_service", return_value=(True, "")):
+        # Drive via main()'s argv path
+        rc = dev_server.main_with_args([
+            "start", "--cwd", str(tmp_path), "--services-json", inline
+        ])
+    assert rc == 0
+
+
+def test_cli_services_json_overrides_profile_with_warning(tmp_path, capsys):
+    inline = json.dumps([
+        {"name": "a", "command": "x", "port": 3000, "host": "localhost", "scheme": "http"}
+    ])
+    proc = MagicMock(pid=42)
+    proc.poll.return_value = None
+    with patch("dev_server.subprocess.Popen", return_value=proc), \
+         patch("dev_server._is_port_in_use_for_host", return_value=False), \
+         patch("dev_server._wait_for_service", return_value=(True, "")):
+        rc = dev_server.main_with_args([
+            "start", "--cwd", str(tmp_path),
+            "--profile", "supabase-nextjs",
+            "--services-json", inline,
+        ])
+    captured = capsys.readouterr()
+    assert "overrides" in captured.err.lower() or "ignor" in captured.err.lower()
+
+
+def test_cli_services_json_invalid_json_errors_cleanly(tmp_path, capsys):
+    with patch("dev_server.subprocess.Popen") as mock_popen:
+        rc = dev_server.main_with_args([
+            "start", "--cwd", str(tmp_path),
+            "--services-json", "{not valid json",
+        ])
+    assert rc != 0
+    mock_popen.assert_not_called()
+
+
+def test_cli_services_json_size_one_works(tmp_path):
+    inline = json.dumps([
+        {"name": "api", "command": "node server.js", "port": 4000, "host": "localhost",
+         "scheme": "http"}
+    ])
+    proc = MagicMock(pid=42)
+    proc.poll.return_value = None
+    with patch("dev_server.subprocess.Popen", return_value=proc), \
+         patch("dev_server._is_port_in_use_for_host", return_value=False), \
+         patch("dev_server._wait_for_service", return_value=(True, "")):
+        rc = dev_server.main_with_args([
+            "start", "--cwd", str(tmp_path), "--services-json", inline
+        ])
+    assert rc == 0
+
+
+def test_warning_emitted_only_once_per_invocation(tmp_path, capsys):
+    """Both blocks in profile → exactly one stderr line, even if helpers re-enter."""
+    profiles_dir = tmp_path / "profiles"
+    profiles_dir.mkdir()
+    (profiles_dir / "test-profile.json").write_text(json.dumps({
+        "name": "test-profile",
+        "dev_server": {"command": "old-cmd", "port": 9999, "ready_path": "/"},
+        "services": [{"name": "a", "command": "x", "port": 3000, "host": "localhost", "scheme": "http"}],
+    }), encoding="utf-8")
+    proc = MagicMock(pid=42)
+    proc.poll.return_value = None
+    with patch("dev_server._profiles_dir", return_value=profiles_dir), \
+         patch("dev_server.subprocess.Popen", return_value=proc), \
+         patch("dev_server._is_port_in_use_for_host", return_value=False), \
+         patch("dev_server._wait_for_service", return_value=(True, "")):
+        dev_server.cmd_start(tmp_path, "test-profile")
+    captured = capsys.readouterr()
+    # Count occurrences of the warning text
+    lines = [l for l in captured.err.splitlines() if "dev_server" in l and "ignor" in l.lower()]
+    assert len(lines) == 1, captured.err
+
+
+# ---------------------------------------------------------------------------
+# AC11 — vite-hono profile loading
+# ---------------------------------------------------------------------------
+
+def test_profile_loader_reads_vite_hono_services_block():
+    """Confirm shipped vite-hono.json profile has 2 services with expected shape."""
+    repo = REPO  # shipwright repo root
+    profile_path = repo / "profiles" / "vite-hono.json"
+    if not profile_path.exists():
+        # Ship-side path
+        profile_path = repo.parent / "shared" / "profiles" / "vite-hono.json"
+    profile = json.loads(profile_path.read_text(encoding="utf-8"))
+    services = profile["services"]
+    assert len(services) == 2
+    names = {s["name"] for s in services}
+    assert names == {"backend", "frontend"}
+    backend = next(s for s in services if s["name"] == "backend")
+    frontend = next(s for s in services if s["name"] == "frontend")
+    assert backend["port"] == 3847
+    assert frontend["port"] == 5173
+    assert frontend.get("depends_on") == ["backend"]
+    assert frontend.get("primary") is True
+    assert backend["ready_path"] == "/api/diagnostics"
+    assert frontend["ready_path"] == "/"
+
+
+def test_vite_hono_topo_order_is_backend_then_frontend():
+    repo = REPO
+    profile_path = repo / "profiles" / "vite-hono.json"
+    if not profile_path.exists():
+        profile_path = repo.parent / "shared" / "profiles" / "vite-hono.json"
+    profile = json.loads(profile_path.read_text(encoding="utf-8"))
+    layers = dev_server._topo_sort(profile["services"])
+    assert len(layers) == 2
+    assert [s["name"] for s in layers[0]] == ["backend"]
+    assert [s["name"] for s in layers[1]] == ["frontend"]


### PR DESCRIPTION
## Summary

- New profile schema `services: [...]` for split frontend+backend repos. `shared/scripts/dev_server.py` manages multiple processes per project (parallel start with topo ordering, per-service health checks, atomic state writes, partial-failure rollback). Legacy `dev_server: {...}` profiles continue to work via internal normalization.
- New first-class profile `shared/profiles/vite-hono.json` derived from shipwright-webui's exact shape (Hono :3847 with `/api/diagnostics` health, Vite :5173 frontend `depends_on` backend, frontend primary).
- `shipwright-adopt` matcher: new `multi_service_detector` (split-pattern detection with framework signal + Vite-proxy confidence promotion); `stack_detector` merges sub-package.json deps into the matcher signature when the root has no real deps. Adopt `SKILL.md` Step B.5 documents a three-branch resolution hierarchy with explicit non-interactive safety.
- Closes the `--skip-crawl` workaround for split frontend+backend repos (memory `project_adopt_multiservice_gap.md`).

Run-ID: `iterate-20260425-multiservice-dev-server`

## Process

- 14 acceptance criteria, 101 new tests across 3 files. All pre-existing tests still green (888 shared + 30 adopt + 10 preview = 928 unaffected).
- 3 plan-review rounds (GPT-5.4 + Gemini 3.1 Pro via OpenRouter) before implementation; 2 code-review rounds after (internal `shipwright-build:code-reviewer` subagent + external LLM). 8 BLOCKERS + ~16 SHOULD-FIX addressed iteratively. Final verdicts: APPROVE-WITH-FIXES (GPT-5.4) + APPROVE-AS-IS (Gemini).
- Orientation-only mode: shipwright monorepo not yet adopted; no ADR file. Disposition is in the commit body.
- AC8 partial deviation: `shared/tests/test_dev_server.py` was modified to track refactored internal helper names (`_load_state` v1→v2 normalization; `_is_port_in_use` → `_is_port_in_use_for_host`). CLI surface preserved; legacy callers (build/test/preview/iterate) unaffected.

## Test plan

- [x] 71/71 dev_server tests green (legacy + new multi-service)
- [x] 30/30 adopt tests green (detector + stack_detector merge + matcher)
- [x] 888 pre-existing shared tests green; 10 preview tests green (caller compat)
- [ ] **Post-merge:** re-run `/shipwright-adopt` on `shipwright-webui` with full crawl. Expect matcher to pick `vite-hono` profile, both services to come up healthy, crawl to populate `e2e/flows/adopted-baseline.spec.ts` with route smoke tests for `/`, `/projects`, `/inbox`, `/diagnostics`, `/settings`, `/tasks/:uuid`.
- [ ] After merge: `bash scripts/update-marketplace.sh` to sync plugin cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)