### PR TITLE
feat(security,run): persist reports + iterate handoff + decouple orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ planning/
 .shipwright_toolcall_count
 compliance/
 
+# shipwright-security report artifacts (local + retention; never committed)
+/securityreports/
+
 # UV
 .uv/
 

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -33,10 +33,12 @@ if str(SHARED_SCRIPTS) not in sys.path:
 # our integration tests walk — making the assertion order phase-by-phase
 # non-deterministic per host.
 #
-# This autouse fixture mirrors the one in plugins/shipwright-run/tests/conftest.py:
-# clear all three signals at the start of every integration test so the
-# default state is "no security backend". Tests that need security to be
-# active opt in explicitly.
+# Iterate sec-report-and-orchestrator-decouple (2026): security is no longer
+# an orchestrator phase, so this fixture is a **no-op safety net** for the
+# orchestrator path. Kept in place because:
+#   1. AIKIDO_CLIENT_ID still informs `aikidoClientIdPresent` (diagnostic);
+#      clearing it prevents host env leaking into test assertions.
+#   2. Future scanner-related env vars benefit from the existing contract.
 
 _OSS_SCANNERS = ("semgrep", "trivy", "gitleaks")
 

--- a/plugins/shipwright-run/scripts/lib/orchestrator.py
+++ b/plugins/shipwright-run/scripts/lib/orchestrator.py
@@ -14,7 +14,6 @@ Output (JSON): config or next step info
 import argparse
 import json
 import os
-import shutil
 import subprocess
 import sys
 import uuid
@@ -48,63 +47,31 @@ _COMPLIANCE_SCRIPT = _THIS_PLUGIN.parent / "shipwright-compliance" / "scripts" /
 PIPELINE_STEPS = ["project", "design", "plan", "build", "test", "changelog", "deploy"]
 
 # Legacy pipeline entries removed by load_run_config migration. Kept for
-# documentation: projects migrated off a prior pipeline with "compliance" as
-# an explicit phase get that entry dropped from `pipeline` (not replayed) but
-# preserved in `completed_steps` as a historical marker.
-_LEGACY_PIPELINE_ENTRIES: frozenset[str] = frozenset({"compliance"})
+# documentation: projects migrated off a prior pipeline get those entries
+# dropped from `pipeline` (not replayed) but preserved in `completed_steps`
+# as a historical marker.
+#
+#   "compliance" — removed earlier (plan v7 Option Z); compliance is now an
+#       auto-background side-effect + on-demand /shipwright-compliance audit.
+#   "security" — removed in iterate sec-report-and-orchestrator-decouple
+#       (2026); security is now manual via /shipwright-security or scheduled
+#       via .github/workflows/security.yml.
+_LEGACY_PIPELINE_ENTRIES: frozenset[str] = frozenset({"compliance", "security"})
 
 # Plan § 4.4 / 9.2 — Orchestrator gate Critical-Check allowlist.
 # These FAILs block phase-transition only when
 # ``SHIPWRIGHT_ENFORCE_CRITICAL_GATES=1`` is set. Default OFF in code.
 _CRITICAL_GATE_CHECK_IDS: frozenset[str] = frozenset({"W5", "W6", "W7"})
 
-# Conditional steps: included only when their check function returns True
-CONDITIONAL_STEPS = {
-    "security": {
-        "check_fn": "_check_security_available",
-        "after": "test",  # inserted after this step
-    },
-}
-
-
-def _check_security_available() -> bool:
-    """Return True if any security scanner backend is configured.
-
-    Default: OSS tools (semgrep, trivy, gitleaks) are auto-detected on PATH.
-    AIKIDO_CLIENT_ID or explicit SHIPWRIGHT_SCANNER_BACKEND=<name> override
-    the OSS detection. SHIPWRIGHT_TEST_DISABLE_OSS_SCANNERS=1 is a test-only
-    kill-switch so subprocess-based integration tests can produce a
-    deterministic 7-phase pipeline regardless of what the dev/CI host has
-    installed.
-    """
-    # Explicit backend selection
-    if os.environ.get("SHIPWRIGHT_SCANNER_BACKEND"):
-        return True
-    # Aikido (cloud)
-    if os.environ.get("AIKIDO_CLIENT_ID"):
-        return True
-    # Test-only override
-    if os.environ.get("SHIPWRIGHT_TEST_DISABLE_OSS_SCANNERS"):
-        return False
-    # OSS tools (local)
-    return any(shutil.which(t) for t in ("semgrep", "trivy", "gitleaks"))
-
-
-_CHECK_FNS = {
-    "_check_security_available": _check_security_available,
-}
-
 
 def build_pipeline() -> list[str]:
-    """Build pipeline with conditional steps resolved."""
-    pipeline = PIPELINE_STEPS.copy()
-    for step, rule in CONDITIONAL_STEPS.items():
-        check_fn = _CHECK_FNS.get(rule["check_fn"], lambda: False)
-        if check_fn():
-            after = rule["after"]
-            idx = pipeline.index(after) + 1
-            pipeline.insert(idx, step)
-    return pipeline
+    """Return the static orchestrator phase list.
+
+    Iterate `sec-report-and-orchestrator-decouple` removed the conditional-
+    steps mechanism: security is no longer auto-inserted after test. Run
+    `/shipwright-security` manually or activate `.github/workflows/security.yml`.
+    """
+    return PIPELINE_STEPS.copy()
 
 
 def load_run_config(project_root: Path) -> dict[str, Any]:
@@ -129,36 +96,171 @@ def load_run_config(project_root: Path) -> dict[str, Any]:
 def _migrate_legacy_pipeline_if_needed(
     project_root: Path, config: dict[str, Any],
 ) -> dict[str, Any]:
-    """Drop legacy entries (e.g. ``compliance``) from ``config["pipeline"]``.
+    """Drop legacy entries from ``config["pipeline"]`` and migrate in-flight
+    security phase_tasks (when present).
 
-    Compliance is no longer a pipeline phase; it's an auto-background
-    side-effect + an on-demand detective audit via ``/shipwright-compliance``
-    (plan v7 Option Z). Legacy projects may have ``"compliance"`` in their
-    pipeline list — drop it. ``completed_steps`` is left untouched so the
-    historical record of completed compliance runs is preserved.
+    Legacy entries (see ``_LEGACY_PIPELINE_ENTRIES``):
+    - ``compliance`` — auto-background side-effect since plan v7 Option Z
+    - ``security`` — manual / CI since iterate sec-report-and-orchestrator-decouple
 
-    Idempotent: once filtered, subsequent loads short-circuit.
+    ``completed_steps`` is left untouched so the historical record of
+    completed runs is preserved.
+
+    For ``security`` specifically, also iterate ``phase_tasks[]`` and skip any
+    non-terminal entry (``backlog`` / ``awaiting_launch``) — they would
+    otherwise sit forever waiting for a phase that the orchestrator no longer
+    plans. ``in_progress`` security phase_tasks are LEFT ALONE (CAS-safe; the
+    user has an active session and must recover manually per the migration
+    notice).
+
+    Idempotent: once filtered, subsequent loads short-circuit. Mutates
+    ``config`` and persists via ``save_run_config`` only when changes occur.
     """
     pipeline = config.get("pipeline")
-    if not isinstance(pipeline, list):
-        return config
-    stale = [s for s in pipeline if s in _LEGACY_PIPELINE_ENTRIES]
-    if not stale:
+    pipeline_stale: list[str] = []
+    if isinstance(pipeline, list):
+        pipeline_stale = [s for s in pipeline if s in _LEGACY_PIPELINE_ENTRIES]
+
+    skipped_security_ids: list[str] = []
+    if any(s == "security" for s in pipeline_stale) or _has_non_terminal_security_phase_tasks(config):
+        now_iso = datetime.now(timezone.utc).isoformat()
+        skipped_security_ids = _migrate_in_flight_security_tasks(config, now_iso)
+
+    if not pipeline_stale and not skipped_security_ids:
         return config
 
     config = dict(config)
-    config["pipeline"] = [s for s in pipeline if s not in _LEGACY_PIPELINE_ENTRIES]
+    if pipeline_stale and isinstance(pipeline, list):
+        config["pipeline"] = [s for s in pipeline if s not in _LEGACY_PIPELINE_ENTRIES]
     save_run_config(project_root, config)
-    _record_pipeline_migration_event(project_root, removed=stale)
+    _record_pipeline_migration_event(
+        project_root,
+        removed=pipeline_stale,
+        skipped_security_phase_task_ids=skipped_security_ids,
+    )
+    _print_security_decouple_notice(
+        pipeline_stale=pipeline_stale,
+        skipped_security_ids=skipped_security_ids,
+        config=config,
+    )
     return config
 
 
-def _record_pipeline_migration_event(project_root: Path, *, removed: list[str]) -> None:
+def _has_non_terminal_security_phase_tasks(config: dict[str, Any]) -> bool:
+    """Return True if ``config["phase_tasks"]`` contains any security entry
+    in backlog / awaiting_launch / in_progress status."""
+    for task in config.get("phase_tasks", []) or []:
+        if not isinstance(task, dict):
+            continue
+        if task.get("phase") == "security" and task.get("status") in {
+            "backlog", "awaiting_launch", "in_progress",
+        }:
+            return True
+    return False
+
+
+def _migrate_in_flight_security_tasks(
+    config: dict[str, Any], now_iso: str,
+) -> list[str]:
+    """Skip non-terminal security phase_tasks (backlog / awaiting_launch).
+
+    Conservative: leaves ``in_progress`` tasks alone — the user has an active
+    session whose CAS-version we'd collide with. The migration notice
+    instructs the user to recover those manually.
+
+    Returns the list of phase_task IDs that were skipped.
+    """
+    skipped_ids: list[str] = []
+    for task in config.get("phase_tasks", []) or []:
+        if not isinstance(task, dict):
+            continue
+        if task.get("phase") != "security":
+            continue
+        if task.get("status") not in {"backlog", "awaiting_launch"}:
+            continue
+        task["status"] = "skipped"
+        task["completedAt"] = now_iso
+        task["result"] = {
+            "ok": False,
+            "skipped_by": "security-decouple-migration",
+        }
+        skipped_ids.append(task.get("phaseTaskId", ""))
+
+    if skipped_ids:
+        completed = config.setdefault("completed_phase_task_ids", [])
+        if isinstance(completed, list):
+            for tid in skipped_ids:
+                if tid and tid not in completed:
+                    completed.append(tid)
+    return skipped_ids
+
+
+def _print_security_decouple_notice(
+    *,
+    pipeline_stale: list[str],
+    skipped_security_ids: list[str],
+    config: dict[str, Any],
+) -> None:
+    """Print a user-facing notice when security is removed from the pipeline.
+
+    Surfaces both the legacy-pipeline-array migration AND the in-flight
+    phase_task migration, plus the manual-recover hint for any in_progress
+    security task that was left untouched.
+    """
+    if "security" not in pipeline_stale and not skipped_security_ids:
+        return
+
+    in_progress_ids = [
+        t.get("phaseTaskId")
+        for t in (config.get("phase_tasks") or [])
+        if isinstance(t, dict)
+        and t.get("phase") == "security"
+        and t.get("status") == "in_progress"
+    ]
+
+    lines = [
+        "[shipwright-run] Notice: 'security' is no longer a pipeline phase.",
+    ]
+    if "security" in pipeline_stale:
+        lines.append("  - 'security' removed from config.pipeline (legacy migration).")
+    if skipped_security_ids:
+        lines.append(
+            f"  - {len(skipped_security_ids)} non-terminal security phase_task(s) auto-skipped: "
+            + ", ".join(skipped_security_ids)
+        )
+    if in_progress_ids:
+        lines.append("  - Found in-progress security phase_task(s); not auto-migrated:")
+        for tid in in_progress_ids:
+            lines.append(
+                f"      uv run plugins/shipwright-run/scripts/lib/orchestrator.py "
+                f"recover-phase-task --phase-task-id {tid} --force-status skipped"
+            )
+    lines.append(
+        "  Run /shipwright-security manually for ad-hoc scans, or activate "
+        ".github/workflows/security.yml triggers for scheduled scans."
+    )
+    print("\n".join(lines), file=sys.stderr)
+
+
+def _record_pipeline_migration_event(
+    project_root: Path,
+    *,
+    removed: list[str],
+    skipped_security_phase_task_ids: list[str] | None = None,
+) -> None:
     """Record a ``pipeline_migration`` event. Non-blocking on failure."""
     record_script = _SHARED_SCRIPTS / "tools" / "record_event.py"
     if not record_script.exists():
         return
-    detail = f"removed from pipeline: {', '.join(removed)}"
+    parts: list[str] = []
+    if removed:
+        parts.append(f"removed from pipeline: {', '.join(removed)}")
+    if skipped_security_phase_task_ids:
+        parts.append(
+            "auto-skipped security phase_tasks: "
+            + ", ".join(skipped_security_phase_task_ids)
+        )
+    detail = "; ".join(parts) if parts else "no-op"
     try:
         subprocess.run(
             [sys.executable, str(record_script),
@@ -271,16 +373,13 @@ def create_config(
     if existing.get("standalone") and existing.get("completed_steps"):
         prior_completed = [s for s in existing["completed_steps"] if s in pipeline]
 
-    # Freeze runConditions at creation. `securityEnabled` reflects the actual
-    # scanner-availability decision (OSS by default — semgrep/trivy/gitleaks on
-    # PATH or AIKIDO_CLIENT_ID set). `aikidoClientIdPresent` is kept as a
-    # diagnostic flag separately so the WebUI/CLI can disambiguate "OSS
-    # fallback" from "AIKIDO cloud" without re-deriving.
+    # Freeze runConditions at creation. Iterate
+    # `sec-report-and-orchestrator-decouple` (2026): `securityEnabled` is
+    # always False because security is no longer an orchestrator phase. We
+    # still pass `aikido_client_id` so the diagnostic
+    # `aikidoClientIdPresent` flag stays accurate for WebUI / CLI display.
     aikido_id = os.environ.get("AIKIDO_CLIENT_ID")
-    run_conditions = freeze_run_conditions(
-        scanner_available=_check_security_available(),
-        aikido_client_id=aikido_id,
-    )
+    run_conditions = freeze_run_conditions(aikido_client_id=aikido_id)
 
     # Initial phase_tasks[] — only the project task is materialized at run start.
     # Subsequent tasks are appended by complete-phase-task → plan_next_phase
@@ -683,7 +782,10 @@ def main() -> int:
 
     p = subparsers.add_parser("update-step")
     p.add_argument("--project-root", default=".")
-    all_steps = PIPELINE_STEPS + list(CONDITIONAL_STEPS.keys())
+    # Iterate sec-report-and-orchestrator-decouple removed CONDITIONAL_STEPS
+    # ("security"). Legacy phase_tasks with phase=security are still accepted
+    # so users running update-step on an in-flight upgraded run aren't blocked.
+    all_steps = PIPELINE_STEPS + ["security"]
     p.add_argument("--step", required=True, choices=all_steps)
     p.add_argument("--status", required=True, choices=["in_progress", "complete", "failed"])
     p.add_argument("--force", action="store_true", help="Skip validation (user override)")

--- a/plugins/shipwright-run/scripts/lib/phase_state_machine.py
+++ b/plugins/shipwright-run/scripts/lib/phase_state_machine.py
@@ -127,11 +127,17 @@ def next_phase_task(
         return _spec("test", split_id=None, prereqs=prereq)
 
     if phase == "test":
-        if run_conditions["securityEnabled"]:
-            return _spec("security", split_id=None, prereqs=prereq)
+        # Iterate `sec-report-and-orchestrator-decouple` (2026): security is
+        # no longer an orchestrator phase. test → changelog unconditionally.
+        # The `securityEnabled` field stays in RunConditions for schema
+        # compatibility with shipwright-webui but does not gate routing.
         return _spec("changelog", split_id=None, prereqs=prereq)
 
     if phase == "security":
+        # Legacy-grace path: phase_tasks already serialized with
+        # ``phase: "security"`` (from runs that started before this iterate
+        # shipped) must still advance to changelog when terminal. New runs
+        # never produce a security phase_task.
         return _spec("changelog", split_id=None, prereqs=prereq)
 
     if phase == "changelog":
@@ -171,29 +177,29 @@ def _spec(phase: Phase, *, split_id: Optional[str], prereqs: list[str]) -> NextP
 
 def freeze_run_conditions(
     *,
-    scanner_available: bool,
     aikido_client_id: Optional[str] = None,
 ) -> RunConditions:
     """Compute the frozen run_conditions block from the current environment.
 
     Helper called at run creation by orchestrator.create_config. splitMode stays
-    None until design completes — the design-stop hook calls freeze-splits which
-    sets it.
+    None until design completes — the design-stop hook calls freeze-splits
+    which sets it.
 
-    `scanner_available` is the authoritative input — orchestrator's
-    `_check_security_available()` evaluates it across all backends (explicit
-    SHIPWRIGHT_SCANNER_BACKEND, AIKIDO cloud, OSS tools on PATH:
-    semgrep/trivy/gitleaks). Default is OSS — the security phase is planned
-    whenever any of those tools is reachable.
+    Iterate `sec-report-and-orchestrator-decouple` (2026): security is no
+    longer an orchestrator phase. ``securityEnabled`` is therefore hardcoded
+    to ``False``. The field is preserved (rather than removed) because the
+    v2 schema (``shared/schemas/run_config.v2.schema.json``) marks it as
+    required with ``additionalProperties: false`` — shipwright-webui consumes
+    that contract.
 
-    `aikido_client_id` is kept as a separate input purely for the diagnostic
-    `aikidoClientIdPresent` flag (helpful when a user wonders whether AIKIDO
-    or an OSS fallback is driving their pipeline). It does NOT gate
-    `securityEnabled` on its own anymore.
+    ``aikido_client_id`` is kept as a diagnostic input. It populates
+    ``aikidoClientIdPresent`` so WebUI / CLI surfaces can disambiguate "user
+    has Aikido configured" from "no scanner backend at all", but it does NOT
+    gate any pipeline phase.
     """
     has_aikido = bool((aikido_client_id or "").strip())
     return {
-        "securityEnabled": bool(scanner_available),
+        "securityEnabled": False,
         "splitMode": None,
         "aikidoClientIdPresent": has_aikido,
     }

--- a/plugins/shipwright-run/skills/run/SKILL.md
+++ b/plugins/shipwright-run/skills/run/SKILL.md
@@ -33,9 +33,11 @@ Usage:
   /shipwright-run                        (interactive)
   /shipwright-run @requirements.md
 
-Pipeline: Project → Design → Plan → Build → Test → Security → Changelog → Deploy
-          Security runs by default when an OSS scanner (semgrep, trivy, gitleaks)
-          is on PATH or AIKIDO_CLIENT_ID is set; skipped when no backend exists.
+Pipeline: Project → Design → Plan → Build → Test → Changelog → Deploy
+
+Security scanning is no longer part of the orchestrator pipeline.
+Run /shipwright-security manually after build/test, or activate the
+.github/workflows/security.yml triggers when ready (see CI integration docs).
 
 Each phase runs in its own external Claude CLI session.
 This master session writes the pipeline spec, prints the first
@@ -142,7 +144,7 @@ uv run {plugin_root}/scripts/lib/orchestrator.py write-config \
 
 This writes `shipwright_run_config.json` at `schemaVersion: 2`. The orchestrator:
 
-- Generates `runId` and freezes `runConditions` (e.g. `securityEnabled` from `AIKIDO_CLIENT_ID`).
+- Generates `runId` and freezes `runConditions`. Post-decouple, `securityEnabled` is always `false` (security is no longer an orchestrator phase). `aikidoClientIdPresent` is set from `AIKIDO_CLIENT_ID` for diagnostic purposes only — it does not gate any phase.
 - Initializes `phase_tasks[]` with the first task: `{phase: "project", status: "awaiting_launch", sessionUuid: <pre-bound uuid4>, prerequisites: []}`.
 - Subsequent phase tasks are appended by phase Stop hooks via `complete-phase-task` → `plan-next-phase`. **The master never plans phases directly.**
 
@@ -198,7 +200,7 @@ render the launch card for the user to paste into a fresh terminal.
 - `sessionUuid` → `phase_tasks[0].sessionUuid` (pre-bound uuid4).
 - `slashCommand` → `phase_tasks[0].slashCommand` (`/shipwright-project` for run init).
 - `projectRoot` → `$(pwd)` (the cwd you passed to `write-config`).
-- `pipelineLength` → `len(config.pipeline)` (7 baseline, 8 with security).
+- `pipelineLength` → `len(config.pipeline)` (always 7 post-decouple — security is no longer an orchestrator phase).
 - `nameSuffix` → `splitId ? f"{phase} / {splitId}" : phase` (here just `"project"`).
 
 **Render the banner:**

--- a/plugins/shipwright-run/tests/conftest.py
+++ b/plugins/shipwright-run/tests/conftest.py
@@ -16,18 +16,20 @@ _OSS_SCANNERS = ("semgrep", "trivy", "gitleaks")
 def _isolate_scanner_environment(monkeypatch):
     """Make scanner availability deterministic for the test suite.
 
-    Production behaviour: orchestrator._check_security_available() returns
-    True if SHIPWRIGHT_SCANNER_BACKEND is set, OR AIKIDO_CLIENT_ID is set, OR
-    any of (semgrep, trivy, gitleaks) is on PATH. The dev/CI host can have
-    any of those installed (semgrep is common), which makes the security
-    phase appear or disappear from `pipeline` non-deterministically across
-    workstations.
+    Iterate sec-report-and-orchestrator-decouple (2026): security is no
+    longer an orchestrator phase, so `_check_security_available()` no longer
+    exists and `freeze_run_conditions()` always returns
+    `securityEnabled: False`. This fixture is therefore a **no-op safety
+    net** for the orchestrator path — kept in place because:
 
-    This autouse fixture clears all three signals at the start of every test
-    so the default state is "no security backend". Tests that need security
-    to be active opt in explicitly via monkeypatch.setenv("AIKIDO_CLIENT_ID",
-    ...) or by patching shutil.which to return a path for one of the OSS
-    tools.
+    1. The fixture also clears AIKIDO_CLIENT_ID, which is still referenced
+       (as a diagnostic in `aikidoClientIdPresent`) — without clearing,
+       host env can leak into test assertions.
+    2. Future scanner-related env vars added by other plugins benefit from
+       the existing isolation contract.
+
+    Tests that need to assert AIKIDO_CLIENT_ID-dependent behaviour opt in
+    explicitly via `monkeypatch.setenv("AIKIDO_CLIENT_ID", ...)`.
     """
     monkeypatch.delenv("AIKIDO_CLIENT_ID", raising=False)
     monkeypatch.delenv("SHIPWRIGHT_SCANNER_BACKEND", raising=False)

--- a/plugins/shipwright-run/tests/test_orchestrator.py
+++ b/plugins/shipwright-run/tests/test_orchestrator.py
@@ -85,21 +85,29 @@ def test_update_step_failed(tmp_project):
     assert config["current_step"] == "build"
 
 
-def test_build_pipeline_without_aikido(monkeypatch):
+def test_build_pipeline_never_includes_security_post_decouple(monkeypatch):
+    """Iterate sec-report-and-orchestrator-decouple removed security from
+    the orchestrator phase list. build_pipeline() returns PIPELINE_STEPS
+    verbatim regardless of scanner-env state.
+    """
     monkeypatch.delenv("AIKIDO_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SHIPWRIGHT_SCANNER_BACKEND", raising=False)
     pipeline = build_pipeline()
     assert "security" not in pipeline
     assert pipeline == PIPELINE_STEPS
 
 
-def test_build_pipeline_with_aikido(monkeypatch):
+def test_build_pipeline_aikido_env_does_not_inject_security(monkeypatch):
+    """AIKIDO_CLIENT_ID set must NOT cause security to be planned —
+    the orchestrator no longer auto-runs security."""
     monkeypatch.setenv("AIKIDO_CLIENT_ID", "test-id")
     pipeline = build_pipeline()
-    assert "security" in pipeline
-    assert pipeline.index("security") == pipeline.index("test") + 1
+    assert "security" not in pipeline
+    assert pipeline == PIPELINE_STEPS
 
 
-def test_create_config_with_security(tmp_project, monkeypatch):
+def test_create_config_pipeline_omits_security(tmp_project, monkeypatch):
+    """Fresh runs produce a config whose pipeline never includes security."""
     monkeypatch.setenv("AIKIDO_CLIENT_ID", "test-id")
     config = create_config(
         scope="full_app",
@@ -108,8 +116,134 @@ def test_create_config_with_security(tmp_project, monkeypatch):
         deploy_target="jelastic-dev",
         project_root=tmp_project,
     )
-    assert "security" in config["pipeline"]
-    assert config["pipeline"].index("security") == config["pipeline"].index("test") + 1
+    assert "security" not in config["pipeline"]
+
+
+def test_create_config_run_conditions_securityenabled_always_false(tmp_project, monkeypatch):
+    """Schema requires the field; post-decouple value is always False."""
+    monkeypatch.setenv("AIKIDO_CLIENT_ID", "ak_live_xxx")
+    config = create_config(
+        scope="full_app",
+        profile="supabase-nextjs",
+        autonomy="guided",
+        deploy_target="jelastic-dev",
+        project_root=tmp_project,
+    )
+    rc = config["runConditions"]
+    assert rc["securityEnabled"] is False
+    # aikidoClientIdPresent stays as a diagnostic
+    assert rc["aikidoClientIdPresent"] is True
+
+
+def test_legacy_pipeline_with_security_is_migrated_out(tmp_project):
+    """Running load_run_config on a config that has 'security' in pipeline
+    drops it (same _LEGACY_PIPELINE_ENTRIES pattern as compliance removal).
+    """
+    import json
+    from orchestrator import load_run_config, CONFIG_NAME
+
+    legacy = {
+        "schemaVersion": 2,
+        "scope": "full_app",
+        "pipeline": ["project", "design", "plan", "build", "test", "security", "changelog", "deploy"],
+        "phase_tasks": [],
+        "completed_phase_task_ids": [],
+        "splits_frozen": [],
+        "runConditions": {
+            "securityEnabled": True,
+            "splitMode": None,
+            "aikidoClientIdPresent": False,
+        },
+        "status": "in_progress",
+        "completed_steps": [],
+        "current_step": "project",
+        "created_at": "2026-04-01T00:00:00+00:00",
+    }
+    (tmp_project / CONFIG_NAME).write_text(json.dumps(legacy), encoding="utf-8")
+
+    loaded = load_run_config(tmp_project)
+    assert "security" not in loaded["pipeline"]
+    # All other phases preserved
+    assert loaded["pipeline"] == ["project", "design", "plan", "build", "test", "changelog", "deploy"]
+
+
+def test_migrate_in_flight_security_phase_tasks_skips_backlog_and_awaiting_launch(tmp_project):
+    """Active migration: non-terminal security phase_tasks (backlog /
+    awaiting_launch) are auto-skipped with a structured reason."""
+    import json
+    from orchestrator import load_run_config, CONFIG_NAME
+
+    legacy = {
+        "schemaVersion": 2,
+        "scope": "full_app",
+        "pipeline": ["project", "test", "security", "changelog"],  # legacy: includes security
+        "phase_tasks": [
+            {"phaseTaskId": "ptk-aaa", "phase": "test", "status": "done"},
+            {"phaseTaskId": "ptk-sec1", "phase": "security", "status": "backlog"},
+            {"phaseTaskId": "ptk-sec2", "phase": "security", "status": "awaiting_launch"},
+        ],
+        "completed_phase_task_ids": ["ptk-aaa"],
+        "splits_frozen": [],
+        "runConditions": {
+            "securityEnabled": True,
+            "splitMode": None,
+            "aikidoClientIdPresent": False,
+        },
+        "status": "in_progress",
+        "completed_steps": [],
+        "current_step": "security",
+        "created_at": "2026-04-01T00:00:00+00:00",
+    }
+    (tmp_project / CONFIG_NAME).write_text(json.dumps(legacy), encoding="utf-8")
+
+    loaded = load_run_config(tmp_project)
+
+    # Both non-terminal security phase_tasks become skipped
+    sec_tasks = [t for t in loaded["phase_tasks"] if t["phase"] == "security"]
+    assert len(sec_tasks) == 2
+    assert all(t["status"] == "skipped" for t in sec_tasks)
+    assert all(t.get("result", {}).get("skipped_by") == "security-decouple-migration" for t in sec_tasks)
+
+    # Skipped phase_tasks join completed_phase_task_ids
+    completed_ids = set(loaded["completed_phase_task_ids"])
+    assert "ptk-sec1" in completed_ids
+    assert "ptk-sec2" in completed_ids
+
+
+def test_migrate_in_flight_security_leaves_in_progress_alone(tmp_project):
+    """Active migration is conservative: in_progress security phase_task is
+    left untouched (CAS-safe — user has an active session). The user must
+    manually recover via recover-phase-task per the migration notice.
+    """
+    import json
+    from orchestrator import load_run_config, CONFIG_NAME
+
+    legacy = {
+        "schemaVersion": 2,
+        "scope": "full_app",
+        "pipeline": ["project", "test", "security", "changelog"],
+        "phase_tasks": [
+            {"phaseTaskId": "ptk-sec1", "phase": "security", "status": "in_progress",
+             "claimedBySessionUuid": "active-uuid", "version": 1},
+        ],
+        "completed_phase_task_ids": [],
+        "splits_frozen": [],
+        "runConditions": {
+            "securityEnabled": True,
+            "splitMode": None,
+            "aikidoClientIdPresent": False,
+        },
+        "status": "in_progress",
+        "completed_steps": [],
+        "current_step": "security",
+        "created_at": "2026-04-01T00:00:00+00:00",
+    }
+    (tmp_project / CONFIG_NAME).write_text(json.dumps(legacy), encoding="utf-8")
+
+    loaded = load_run_config(tmp_project)
+    sec_task = loaded["phase_tasks"][0]
+    assert sec_task["status"] == "in_progress"  # NOT skipped
+    assert sec_task.get("claimedBySessionUuid") == "active-uuid"
 
 
 def test_compliance_runs_on_step_complete(tmp_project, mocker):

--- a/plugins/shipwright-run/tests/test_phase_state_machine.py
+++ b/plugins/shipwright-run/tests/test_phase_state_machine.py
@@ -159,17 +159,11 @@ def test_build_split_less_done_to_test():
     assert spec["splitId"] is None
 
 
-def test_test_done_security_enabled_to_security():
-    spec = next_phase_task(
-        run_conditions=_rc(security=True),
-        splits_frozen=[],
-        completed=_completed("test"),
-    )
-    assert spec is not None
-    assert spec["phase"] == "security"
-
-
-def test_test_done_security_disabled_to_changelog():
+def test_test_done_always_to_changelog():
+    """Post-decouple (sec-report-and-orchestrator-decouple): test → changelog
+    unconditionally. The securityEnabled field stays in RunConditions for
+    schema compatibility with shipwright-webui but no longer gates routing.
+    """
     spec = next_phase_task(
         run_conditions=_rc(security=False),
         splits_frozen=[],
@@ -179,7 +173,26 @@ def test_test_done_security_disabled_to_changelog():
     assert spec["phase"] == "changelog"
 
 
-def test_security_done_to_changelog():
+def test_test_done_to_changelog_even_when_securityenabled_true_legacy_value():
+    """Legacy run-configs may have ``securityEnabled: true`` baked in. Post-
+    decouple the state machine must NOT route to security based on that flag —
+    test always advances to changelog.
+    """
+    spec = next_phase_task(
+        run_conditions=_rc(security=True),  # legacy field value, ignored now
+        splits_frozen=[],
+        completed=_completed("test"),
+    )
+    assert spec is not None
+    assert spec["phase"] == "changelog"
+
+
+def test_security_done_to_changelog_legacy_grace_path():
+    """Legacy phase_tasks already serialized with ``phase: "security"`` (e.g.
+    from runs that started before this iterate shipped) must still advance
+    to changelog when their status becomes terminal. The branch is dead for
+    new runs but kept as legacy-grace.
+    """
     spec = next_phase_task(
         run_conditions=_rc(security=True),
         splits_frozen=[],
@@ -257,51 +270,52 @@ def test_skipped_status_returns_structural_successor():
     assert spec["phase"] == "changelog"
 
 
-# ---- runConditions freeze helper ----
+# ---- runConditions freeze helper (post-decouple signature) ----
+#
+# Iterate `sec-report-and-orchestrator-decouple` removed `scanner_available`
+# from the parameter list. `securityEnabled` is hardcoded to False because
+# security is no longer a pipeline phase. `aikidoClientIdPresent` is kept as
+# a diagnostic so WebUI consumers can tell whether the user has Aikido
+# configured (informational only — does not gate anything).
 
 
-def test_freeze_run_conditions_security_off_when_no_scanner_no_aikido():
-    rc = freeze_run_conditions(scanner_available=False, aikido_client_id=None)
+def test_freeze_run_conditions_default_returns_security_off():
+    rc = freeze_run_conditions()
     assert rc["securityEnabled"] is False
     assert rc["aikidoClientIdPresent"] is False
     assert rc["splitMode"] is None
 
 
-def test_freeze_run_conditions_security_off_when_empty_aikido_no_oss():
-    rc = freeze_run_conditions(scanner_available=False, aikido_client_id="   ")
-    assert rc["securityEnabled"] is False
-    assert rc["aikidoClientIdPresent"] is False
-
-
-def test_freeze_run_conditions_security_on_via_oss_default():
-    """Default path: OSS scanner on PATH, no AIKIDO. securityEnabled=True,
-    aikidoClientIdPresent=False (so the WebUI/CLI can disambiguate)."""
-    rc = freeze_run_conditions(scanner_available=True, aikido_client_id=None)
-    assert rc["securityEnabled"] is True
-    assert rc["aikidoClientIdPresent"] is False
-
-
-def test_freeze_run_conditions_security_on_via_aikido():
-    """AIKIDO cloud backend. securityEnabled=True AND aikidoClientIdPresent=True."""
-    rc = freeze_run_conditions(scanner_available=True, aikido_client_id="ak_live_xxxx")
-    assert rc["securityEnabled"] is True
+def test_freeze_run_conditions_aikido_id_sets_diagnostic_flag():
+    rc = freeze_run_conditions(aikido_client_id="ak_live_xxxx")
+    # Diagnostic: user has Aikido configured. Does NOT enable any pipeline phase.
     assert rc["aikidoClientIdPresent"] is True
-    assert rc["splitMode"] is None  # set later by freeze-splits at design-stop
-
-
-def test_freeze_run_conditions_aikido_present_but_scanner_unavailable_is_off():
-    """Defensive: aikido id is set but caller decided no scanner — security off.
-    Authority is `scanner_available`, not the AIKIDO id."""
-    rc = freeze_run_conditions(scanner_available=False, aikido_client_id="ak_live_xxxx")
+    # Security still off — the orchestrator no longer auto-runs security.
     assert rc["securityEnabled"] is False
-    assert rc["aikidoClientIdPresent"] is True
+
+
+def test_freeze_run_conditions_whitespace_aikido_id_treated_as_absent():
+    rc = freeze_run_conditions(aikido_client_id="   ")
+    assert rc["aikidoClientIdPresent"] is False
+    assert rc["securityEnabled"] is False
+
+
+def test_freeze_run_conditions_empty_aikido_id_treated_as_absent():
+    rc = freeze_run_conditions(aikido_client_id="")
+    assert rc["aikidoClientIdPresent"] is False
 
 
 # ---- Title and slash command sanity ----
 
 
 def test_slash_commands_match_plugin_names():
-    """All eight phases have a /shipwright-<phase> slash command."""
+    """Each phase planned by the orchestrator has a /shipwright-<phase> slash command.
+
+    Post-decouple (sec-report-and-orchestrator-decouple), security is no longer
+    on the planned-successor chain. The test→changelog transition is exercised
+    here; the legacy-grace security→changelog path is covered by
+    `test_security_done_to_changelog_legacy_grace_path` separately.
+    """
     # 'project' is the initial state, no predecessor
     assert initial_phase_spec()["slashCommand"] == "/shipwright-project"
 
@@ -310,13 +324,12 @@ def test_slash_commands_match_plugin_names():
         "plan": ("design", None, []),  # split_mode=none branch
         "build": ("plan", None, []),
         "test": ("build", None, []),
-        "security": ("test", None, []),
-        "changelog": ("security", None, []),
+        "changelog": ("test", None, []),  # was ("security", ...) pre-decouple
         "deploy": ("changelog", None, []),
     }
     for phase, (pred_phase, pred_split, splits) in successors.items():
         spec = next_phase_task(
-            run_conditions=_rc(security=(phase == "security")),
+            run_conditions=_rc(),
             splits_frozen=splits,
             completed=_completed(pred_phase, split_id=pred_split),
         )

--- a/plugins/shipwright-run/tests/test_run_config_v2.py
+++ b/plugins/shipwright-run/tests/test_run_config_v2.py
@@ -76,10 +76,14 @@ def test_create_config_freezes_run_conditions(tmp_project):
     assert rc["splitMode"] is None  # set later by freeze-splits
 
 
-def test_create_config_freezes_security_when_aikido_set(tmp_project):
+def test_create_config_aikido_id_sets_diagnostic_flag(tmp_project):
+    """Iterate sec-report-and-orchestrator-decouple: securityEnabled is
+    hardcoded False post-decouple. The aikidoClientIdPresent diagnostic
+    still tracks AIKIDO_CLIENT_ID for WebUI display purposes.
+    """
     with mock.patch.dict("os.environ", {"AIKIDO_CLIENT_ID": "ak_test_xxx"}, clear=False):
         cfg = create_config("full_app", "supabase-nextjs", "guided", "jelastic-dev", tmp_project)
-    assert cfg["runConditions"]["securityEnabled"] is True
+    assert cfg["runConditions"]["securityEnabled"] is False
     assert cfg["runConditions"]["aikidoClientIdPresent"] is True
 
 

--- a/plugins/shipwright-security/scripts/lib/oss_backend.py
+++ b/plugins/shipwright-security/scripts/lib/oss_backend.py
@@ -127,6 +127,7 @@ _DEFAULT_EXCLUDES: tuple[str, ...] = (
     ".next",
     "__pycache__",
     ".cache",
+    "securityreports",
 )
 
 # Env-var additions must be simple folder names: letters, digits, underscore,

--- a/plugins/shipwright-security/scripts/lib/redact.py
+++ b/plugins/shipwright-security/scripts/lib/redact.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Redaction helpers for secret evidence in scanner findings.
+
+Two layers (default-on; opt-out via ``full_evidence=True``):
+
+  1. Allowlist-based structural redaction
+     Any field NOT in ``SAFE_FIELD_ALLOWLIST`` is dropped (by deletion, not
+     by string substitution — types are preserved). Covers raw-secret fields
+     emitted by Gitleaks (``match`` / ``secret`` / ``commit`` / ``author`` /
+     ``email`` / ``fingerprint``) plus any future tool-added field.
+
+  2. Free-text content masking on ``description`` / ``remediation_hint``
+     Scanner-authored prose may quote the matched secret value verbatim. A
+     small set of regex patterns scrubs known-shape and high-entropy strings,
+     replacing them with ``REDACTED_TOKEN``.
+
+The two layers are independent — allowlist removes whole-field secrets; the
+masker scrubs in-prose secrets in fields that pass the allowlist.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+REDACTED_TOKEN = "<redacted-secret>"
+
+# Fields preserved by the allowlist filter. Add a new field here ONLY after
+# confirming it cannot carry raw secret evidence — doing so consciously is
+# safer than blocklisting every new tool-added field reactively.
+SAFE_FIELD_ALLOWLIST: frozenset[str] = frozenset({
+    "id",
+    "severity",
+    "severity_score",
+    "type",
+    "rule",
+    "cve_id",
+    "affected_file",
+    "affected_line",
+    "affected_package",
+    "installed_version",
+    "fixed_version",
+    "cwe_classes",
+    "source",
+    "_remediation_class",
+    "_remediation_status",
+    "description",
+    "remediation_hint",
+})
+
+# Fields where free-text masking is applied. Both are scanner-authored prose
+# that may incidentally embed the matched secret value.
+_FREE_TEXT_FIELDS: frozenset[str] = frozenset({"description", "remediation_hint"})
+
+
+# Known-shape patterns first (anchored by recognisable prefix), then a generic
+# high-entropy fallback. Ordering matters — specific patterns mask before the
+# entropy fallback can over-match.
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Stripe-style live secret keys
+    re.compile(r"sk-live-[A-Za-z0-9]{8,}"),
+    re.compile(r"sk_live_[A-Za-z0-9]{8,}"),
+    re.compile(r"sk_test_[A-Za-z0-9]{8,}"),
+    # GitHub PATs / app installation tokens
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),
+    # AWS access key IDs
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"ASIA[0-9A-Z]{16}"),
+    # Slack tokens
+    re.compile(r"xox[abprs]-[A-Za-z0-9-]{10,}"),
+    # Bearer-prefixed tokens (JWT or opaque)
+    re.compile(r"Bearer\s+[A-Za-z0-9._\-+/=]{16,}"),
+    # JWT-shaped triplet (header.payload.signature) — base64url segments
+    re.compile(r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
+    # Generic high-entropy fallback: continuous run of 32+ base64-ish chars.
+    # Letters AND digits required to avoid masking long English words.
+    re.compile(r"(?=\w*[A-Za-z])(?=\w*\d)[A-Za-z0-9+/]{32,}={0,2}"),
+)
+
+
+def mask_secrets_in_text(text: str) -> str:
+    """Replace known-shape and high-entropy secret values with REDACTED_TOKEN.
+
+    Idempotent: re-masking already-masked text is a no-op (the placeholder
+    token doesn't match any pattern).
+    """
+    if not isinstance(text, str) or not text:
+        return text
+    masked = text
+    for pat in _SECRET_PATTERNS:
+        masked = pat.sub(REDACTED_TOKEN, masked)
+    return masked
+
+
+def redact_finding(
+    finding: dict[str, Any], *, full_evidence: bool = False,
+) -> dict[str, Any]:
+    """Return a redacted copy of ``finding``.
+
+    Args:
+        finding: a normalized finding dict (typically from backend.scan()).
+        full_evidence: if True, return the finding unchanged. Reserved for
+            opt-in local-debug contexts; production / CI / shared-disk paths
+            should leave this False.
+
+    Returns:
+        A new dict; the input is not mutated.
+    """
+    if full_evidence:
+        return dict(finding)
+
+    # Layer 1 — allowlist filter (structural)
+    out: dict[str, Any] = {
+        k: v for k, v in finding.items() if k in SAFE_FIELD_ALLOWLIST
+    }
+
+    # Layer 2 — free-text content masking on whitelisted prose fields
+    for field in _FREE_TEXT_FIELDS:
+        if field in out and isinstance(out[field], str):
+            out[field] = mask_secrets_in_text(out[field])
+
+    return out
+
+
+def redact_findings(
+    findings: Iterable[dict[str, Any]], *, full_evidence: bool = False,
+) -> list[dict[str, Any]]:
+    """Apply ``redact_finding`` to a list of findings."""
+    return [redact_finding(f, full_evidence=full_evidence) for f in findings]

--- a/plugins/shipwright-security/scripts/tools/generate_security_report.py
+++ b/plugins/shipwright-security/scripts/tools/generate_security_report.py
@@ -323,12 +323,46 @@ def generate_pr_report(findings: list[dict[str, Any]], repo_name: str = "unknown
 # CLI
 # ---------------------------------------------------------------------------
 
+# Schema version for the machine-readable JSON sidecar emitted via
+# --json-output. Bump if you change top-level fields. Existing top-level
+# fields stay stable; new fields may be added.
+JSON_SIDECAR_SCHEMA_VERSION = 1
+
+
+def build_json_sidecar(
+    findings: list[dict[str, Any]], repo_name: str = "unknown",
+) -> dict[str, Any]:
+    """Compose the machine-readable sidecar payload.
+
+    Mirrors the data presented in generate_standard_report so an
+    automated consumer (CI, /shipwright-iterate handoff) can read this
+    file instead of parsing the markdown.
+    """
+    by_severity = Counter(f.get("severity", "unknown") for f in findings)
+    breakdown = scanner_breakdown(findings)
+    by_source = {src: int(cnt.get("total", 0)) for src, cnt in breakdown.items()}
+    return {
+        "schema_version": JSON_SIDECAR_SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "repo": repo_name,
+        "risk_level": calculate_risk_level(findings),
+        "total_findings": len(findings),
+        "by_severity": dict(by_severity),
+        "by_source": by_source,
+        "findings": list(findings),
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Generate security report")
     parser.add_argument("--project-root", default=".", help="Project root directory")
     parser.add_argument("--input", help="Input JSON file (e.g. findings.json from scan.py)")
     parser.add_argument("--prompt-risks", help="Additional JSON file with prompt-injection findings")
     parser.add_argument("--output", help="Output file path")
+    parser.add_argument(
+        "--json-output",
+        help="Optional machine-readable sidecar path (e.g. securityreports/latest.json)",
+    )
     parser.add_argument("--repo", default="unknown", help="Repository name for report title")
     parser.add_argument(
         "--pr-mode",
@@ -372,12 +406,23 @@ def main() -> int:
 
     risk_level = calculate_risk_level(findings)
 
+    # Optional machine-readable sidecar (independent of --output / --format).
+    if args.json_output:
+        sidecar = build_json_sidecar(findings, args.repo)
+        sidecar_path = Path(args.json_output)
+        sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+        sidecar_path.write_text(
+            json.dumps(sidecar, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
     if args.format == "json":
         result = structured_success(data={
             "command": "generate_report",
             "findings_count": len(findings),
             "risk_level": risk_level,
             "report_markdown": report,
+            "json_sidecar_path": args.json_output,
         })
         print(json.dumps(result, ensure_ascii=False))
         return 0
@@ -388,6 +433,7 @@ def main() -> int:
         result = structured_success(data={
             "command": "generate_report",
             "output_path": args.output,
+            "json_sidecar_path": args.json_output,
             "findings_count": len(findings),
             "risk_level": risk_level,
         })
@@ -395,6 +441,7 @@ def main() -> int:
         result = structured_success(data={
             "command": "generate_report",
             "report_markdown": report,
+            "json_sidecar_path": args.json_output,
             "findings_count": len(findings),
             "risk_level": risk_level,
         })

--- a/plugins/shipwright-security/scripts/tools/run_scan_and_report.py
+++ b/plugins/shipwright-security/scripts/tools/run_scan_and_report.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Local-interactive OSS scanner wrapper.
+
+Runs the OSS backend, redacts findings, persists a human Markdown report
+plus a machine-readable JSON sidecar to ``securityreports/`` (with second-
+granularity history retention), and best-effort updates ``.gitignore``.
+
+For Aikido backend, this wrapper short-circuits with a pointer to
+``aikido_client.py report`` — Aikido has its own report path, untouched
+by this iterate.
+
+Usage:
+    uv run scripts/tools/run_scan_and_report.py \
+        --project-root . \
+        [--repo owner/name] \
+        [--full-evidence]
+
+Exit codes:
+    0  scan completed (or non-OSS backend short-circuit)
+    1  scan failed or full-evidence refused in CI
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Path setup — make sibling scripts/lib + scripts/tools importable
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PLUGIN_ROOT = SCRIPT_DIR.parent.parent
+SHARED_ROOT = PLUGIN_ROOT.parent.parent / "shared"
+
+sys.path.insert(0, str(PLUGIN_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(PLUGIN_ROOT / "scripts" / "tools"))
+sys.path.insert(0, str(SHARED_ROOT / "scripts"))
+
+try:
+    from scanner_backend import get_backend  # type: ignore
+    import oss_backend  # noqa: F401
+    try:
+        import aikido_client  # noqa: F401
+    except ImportError:
+        pass
+except ImportError as exc:  # pragma: no cover - import safety
+    print(f"Failed to import scanner backend: {exc}", file=sys.stderr)
+    raise
+
+from redact import redact_findings  # noqa: E402
+
+import generate_security_report as gsr  # noqa: E402
+
+try:
+    from lib.errors import structured_success  # type: ignore
+except (ImportError, ModuleNotFoundError):
+    def structured_success(data=None):
+        result = {"success": True}
+        if data:
+            result.update(data)
+        return result
+
+
+def _fix_windows_encoding() -> None:
+    if sys.platform == "win32":
+        try:
+            sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+            sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPORTS_DIRNAME = "securityreports"
+HISTORY_DIRNAME = "history"
+LATEST_MD = "latest.md"
+LATEST_JSON = "latest.json"
+GITIGNORE_ENTRY = "/securityreports/"
+RETAIN_PAIRS = 20
+
+# Strict filename pattern for archived scans. User-added or malformed files
+# in history/ that don't match are NEVER pruned — they stay where the user
+# put them.
+SCAN_FILENAME_RE = re.compile(r"^scan-(\d{8}-\d{6}-[0-9a-f]{6})\.(md|json)$")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _new_scan_id(now: datetime) -> str:
+    """``scan-YYYYMMDD-HHMMSS-{6 hex}`` — second-grain + uuid for collision-safety."""
+    ts = now.strftime("%Y%m%d-%H%M%S")
+    return f"scan-{ts}-{uuid.uuid4().hex[:6]}"
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write text to ``path`` atomically: tmp file in same dir + os.replace.
+
+    Same-directory tmp avoids cross-drive rename failures on Windows. The
+    tmp file is opened with delete=False so the os.replace can succeed.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        suffix=".tmp", prefix=path.name + ".", dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(text)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _ensure_gitignore_entry(project_root: Path) -> str:
+    """Best-effort gitignore append.
+
+    - If .gitignore is missing → skip silently (don't materialize one).
+    - If .gitignore exists and contains the entry → no-op (idempotent).
+    - Else → append, ensuring the existing file ends with a newline first.
+
+    Returns: 'added' | 'present' | 'skipped'
+    """
+    gi = project_root / ".gitignore"
+    if not gi.exists():
+        return "skipped"
+
+    existing = gi.read_text(encoding="utf-8")
+    # Match exact entry (with or without leading slash) on its own line
+    lines = existing.splitlines()
+    for line in lines:
+        stripped = line.strip()
+        if stripped in {"/securityreports/", "securityreports/"}:
+            return "present"
+
+    # Need to append. Ensure file ends with a newline before adding our entry,
+    # otherwise we'd merge with the last existing line.
+    suffix = "" if existing.endswith("\n") else "\n"
+    addition = f"{suffix}{GITIGNORE_ENTRY}\n"
+    gi.write_text(existing + addition, encoding="utf-8")
+    return "added"
+
+
+def _list_archived_scans(history_dir: Path) -> list[tuple[str, list[Path]]]:
+    """Return list of (scan_id_stem, [files]) ordered newest-first.
+
+    Only files matching SCAN_FILENAME_RE are considered — manual / malformed
+    files in the directory are ignored.
+    """
+    if not history_dir.exists():
+        return []
+
+    by_stem: dict[str, list[Path]] = {}
+    for child in history_dir.iterdir():
+        if not child.is_file():
+            continue
+        m = SCAN_FILENAME_RE.match(child.name)
+        if not m:
+            continue
+        stem = f"scan-{m.group(1)}"
+        by_stem.setdefault(stem, []).append(child)
+
+    # Newest stem first (lexicographic sort works because YYYYMMDD-HHMMSS stems
+    # are monotonic).
+    return sorted(by_stem.items(), key=lambda kv: kv[0], reverse=True)
+
+
+def _prune_history(history_dir: Path, retain: int = RETAIN_PAIRS) -> int:
+    """Delete archived scans beyond the retain limit; return count removed."""
+    grouped = _list_archived_scans(history_dir)
+    to_delete = grouped[retain:]
+    removed = 0
+    for _stem, files in to_delete:
+        for f in files:
+            try:
+                f.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# Main flow
+# ---------------------------------------------------------------------------
+
+
+def _build_md_with_scan_id(findings: list[dict[str, Any]], repo: str, scan_id: str) -> str:
+    """Build the human-readable Markdown report with an HTML-comment scan_id header."""
+    body = gsr.generate_standard_report(findings, repo)
+    # Embed scan_id as the first line so latest.md ↔ latest.json correlate
+    return f"<!-- scan_id: {scan_id} -->\n{body}"
+
+
+def _build_json_with_scan_id(findings: list[dict[str, Any]], repo: str, scan_id: str) -> dict[str, Any]:
+    payload = gsr.build_json_sidecar(findings, repo)
+    payload["scan_id"] = scan_id
+    return payload
+
+
+def run(*, project_root: Path, repo: str = "unknown", full_evidence: bool = False) -> int:
+    """Programmatic entry point — return exit code (0 success, 1 failure)."""
+    # Refuse --full-evidence in CI to avoid persisting raw secrets in shared
+    # disk artifacts. Tests document this contract.
+    if full_evidence and os.environ.get("CI"):
+        print(
+            "[shipwright-security] refusing --full-evidence in CI environment. "
+            "Re-run locally or unset CI=.",
+            file=sys.stderr,
+        )
+        return 1
+
+    backend = get_backend()
+    if getattr(backend, "name", None) != "oss":
+        print(
+            "[shipwright-security] non-OSS backend detected — this wrapper is "
+            "OSS-only. For Aikido, run: "
+            "uv run plugins/shipwright-security/scripts/lib/aikido_client.py report",
+            file=sys.stderr,
+        )
+        return 0
+
+    target = str(project_root)
+    raw_findings = backend.scan(target)
+
+    # Default-on redaction unless explicitly opted out
+    findings = redact_findings(raw_findings, full_evidence=full_evidence)
+
+    now = datetime.now(timezone.utc)
+    scan_id = _new_scan_id(now)
+
+    md_text = _build_md_with_scan_id(findings, repo, scan_id)
+    json_payload = _build_json_with_scan_id(findings, repo, scan_id)
+    json_text = json.dumps(json_payload, ensure_ascii=False, indent=2) + "\n"
+
+    reports_dir = project_root / REPORTS_DIRNAME
+    history_dir = reports_dir / HISTORY_DIRNAME
+    history_dir.mkdir(parents=True, exist_ok=True)
+
+    # Atomic write of the latest.* pair
+    _atomic_write(reports_dir / LATEST_MD, md_text)
+    _atomic_write(reports_dir / LATEST_JSON, json_text)
+
+    # Archive (separate atomic writes — by design they share the same scan_id
+    # so a partial-write crash is detectable from latest.md ↔ latest.json mismatch).
+    _atomic_write(history_dir / f"{scan_id}.md", md_text)
+    _atomic_write(history_dir / f"{scan_id}.json", json_text)
+
+    removed = _prune_history(history_dir)
+
+    gitignore_status = _ensure_gitignore_entry(project_root)
+
+    summary = structured_success(data={
+        "command": "run_scan_and_report",
+        "scan_id": scan_id,
+        "findings_count": len(findings),
+        "report_md": str(reports_dir / LATEST_MD),
+        "report_json": str(reports_dir / LATEST_JSON),
+        "history_pruned": removed,
+        "gitignore": gitignore_status,
+        "redaction": "off" if full_evidence else "on",
+    })
+    print(json.dumps(summary, ensure_ascii=False))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-root", default=".", help="Project root (default: cwd)")
+    parser.add_argument("--repo", default="unknown", help="Repository name for the report header")
+    parser.add_argument(
+        "--full-evidence",
+        action="store_true",
+        help="Retain raw secret evidence in findings. Refused when CI env is set. "
+             "Use only for explicit local debugging.",
+    )
+    args = parser.parse_args()
+    project_root = Path(args.project_root).resolve()
+    return run(project_root=project_root, repo=args.repo, full_evidence=args.full_evidence)
+
+
+if __name__ == "__main__":
+    _fix_windows_encoding()
+    sys.exit(main())

--- a/plugins/shipwright-security/skills/security/SKILL.md
+++ b/plugins/shipwright-security/skills/security/SKILL.md
@@ -228,21 +228,28 @@ For accepted findings → run security-fixer subagent → re-run tests.
 
 ## Step 6: Generate Report
 
-**For Aikido backend:**
+**For OSS backend (standalone or pipeline):**
+
+Run the wrapper. It handles scan + redaction + report + history archiving + best-effort `.gitignore`:
+
+```bash
+uv run {plugin_root}/scripts/tools/run_scan_and_report.py --project-root {project_root} --repo {repo}
+```
+
+Output:
+- `{project_root}/securityreports/latest.md` — human-readable Markdown report
+- `{project_root}/securityreports/latest.json` — machine-readable sidecar (`schema_version: 1`, `scan_id`, full normalized findings)
+- `{project_root}/securityreports/history/scan-YYYYMMDD-HHMMSS-{6hex}.{md,json}` — archived (last 20 pairs retained)
+- `{project_root}/.gitignore` — `/securityreports/` appended if file exists and entry missing
+
+The wrapper redacts secret evidence by default (Gitleaks `match`/`secret`/`commit`/`author`/`email` fields; high-entropy strings in `description` / `remediation_hint`). Use `--full-evidence` to retain raw values for explicit local debugging — refused when `CI` env is set.
+
+After the wrapper exits, read `{project_root}/securityreports/latest.json` for the structured scan summary (total_findings, by_severity, by_source, risk_level).
+
+**For Aikido backend (path preserved, untouched by v0.3 restructuring):**
 ```bash
 uv run --project {plugin_root} {plugin_root}/scripts/lib/aikido_client.py report --repo {repo}
 ```
-
-**For OSS backend:**
-Generate the report from the normalized findings returned by `backend.scan()`.
-
-Write a Markdown report to the project root.
-
-**Report contents:**
-- Summary: total findings, severity breakdown
-- Remediation status: fixed / declined / deferred / open
-- Detailed findings table
-- Timestamp
 
 ---
 
@@ -269,6 +276,39 @@ Write results to `shipwright_security_config.json` in the project root:
 ```
 
 This config is consumed by `/shipwright-compliance` for traceability.
+
+---
+
+## Step 8: Iterate Handoff (OSS standalone mode only)
+
+After Step 6 completes for the OSS backend in standalone mode, offer the user a one-question handoff into `/shipwright-iterate` so they can work through fixes.
+
+**Skip Step 8 entirely if any of:**
+- `total_findings == 0` in `securityreports/latest.json`
+- `os.environ.get("CI")` is set (any truthy value)
+- `os.environ.get("SHIPWRIGHT_NON_INTERACTIVE")` is set
+- `sys.stdin.isatty()` returns False
+- Pipeline mode is active (`shipwright_project_config.json` exists in project root) — the remediation loop in Steps 2-5 already handled it
+
+**Pre-flight check:** verify `shipwright_run_config.json` exists in `project_root`.
+- If missing → print: `"To fix these findings, open /shipwright-iterate in a Shipwright-managed project and point it at securityreports/latest.md"`, then exit 0.
+- If present → proceed.
+
+**Ask the user via AskUserQuestion:**
+
+> Scan complete: {total_findings} findings ({by_severity summary}).
+> Start an iterate to work through fixes?
+>
+> - **YES** — start `/shipwright-iterate` (the report path is passed as context)
+> - **NO** — done, just the report
+
+**On YES:** invoke the `/shipwright-iterate` skill with this generic brief (no scanner prose interpolated, no prompt-injection surface):
+
+> Review and fix security findings from the most recent scan.
+> Report: `securityreports/latest.md` (machine-readable sidecar: `securityreports/latest.json`).
+> Work through findings with the user — pick what to fix, what to suppress, what to defer. Favor small iterate scopes (one rule-family or one fix category per iterate) to keep review tight.
+
+**Failure handling:** if the `/shipwright-iterate` invocation raises or exits non-zero, print the same brief verbatim to the terminal, log the error to stderr, and exit 0. The report (`securityreports/latest.*`) remains written regardless of handoff success.
 
 ---
 

--- a/plugins/shipwright-security/tests/test_generate_security_report.py
+++ b/plugins/shipwright-security/tests/test_generate_security_report.py
@@ -1,0 +1,249 @@
+"""Tests for generate_security_report.py — extensions added in iterate
+sec-report-and-orchestrator-decouple.
+
+Covers:
+- ``--json-output PATH`` writes a machine-readable sidecar
+- JSON payload carries ``schema_version: 1`` and the same findings as MD
+- Existing ``--input`` / ``stdin`` / ``--pr-mode`` flows are unchanged
+- Risk level + severity + scanner breakdown match between MD and JSON
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+TOOL = PLUGIN_ROOT / "scripts" / "tools" / "generate_security_report.py"
+
+
+def _findings_fixture(tmp_path: Path) -> Path:
+    """Write a small findings.json with one finding of each source."""
+    findings = {
+        "findings": [
+            {
+                "id": "f-01",
+                "source": "semgrep",
+                "type": "sast",
+                "rule": "subprocess-shell-true",
+                "severity": "high",
+                "severity_score": 7.5,
+                "affected_file": "scripts/run.py",
+                "affected_line": 42,
+                "cwe_classes": ["CWE-78"],
+                "description": "Found subprocess.run with shell=True.",
+                "_remediation_class": "agent-fixable",
+            },
+            {
+                "id": "f-02",
+                "source": "trivy",
+                "type": "sca",
+                "rule": "CVE-2025-71176",
+                "cve_id": "CVE-2025-71176",
+                "severity": "medium",
+                "severity_score": 5.0,
+                "affected_package": "requests",
+                "installed_version": "2.31.0",
+                "fixed_version": "2.32.0",
+                "affected_file": "uv.lock",
+                "_remediation_class": "auto-fixable",
+            },
+            {
+                "id": "f-03",
+                "source": "gitleaks",
+                "type": "secret_detection",
+                "rule": "generic-api-key",
+                "severity": "high",
+                "affected_file": "tests/fixtures/sample.json",
+                "affected_line": 8,
+                "cwe_classes": ["CWE-798"],
+                "description": "Generic API key.",
+                "_remediation_class": "agent-fixable",
+            },
+        ],
+    }
+    p = tmp_path / "findings.json"
+    p.write_text(json.dumps(findings), encoding="utf-8")
+    return p
+
+
+def _run_tool(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    """Invoke the tool via uv run from the plugin root."""
+    cmd = [sys.executable, str(TOOL), *args]
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=str(cwd),
+    )
+
+
+# ---------------------------------------------------------------------------
+# --json-output sidecar
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutputSidecar:
+
+    def test_json_output_writes_sidecar_file(self, tmp_path: Path):
+        findings_path = _findings_fixture(tmp_path)
+        md_out = tmp_path / "out.md"
+        json_out = tmp_path / "out.json"
+
+        result = _run_tool(
+            "--input", str(findings_path),
+            "--output", str(md_out),
+            "--json-output", str(json_out),
+            "--repo", "test/repo",
+            cwd=tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        assert md_out.exists()
+        assert json_out.exists()
+
+    def test_json_payload_has_schema_version_1(self, tmp_path: Path):
+        findings_path = _findings_fixture(tmp_path)
+        md_out = tmp_path / "out.md"
+        json_out = tmp_path / "out.json"
+
+        _run_tool(
+            "--input", str(findings_path),
+            "--output", str(md_out),
+            "--json-output", str(json_out),
+            cwd=tmp_path,
+        )
+        payload = json.loads(json_out.read_text(encoding="utf-8"))
+        assert payload["schema_version"] == 1
+
+    def test_json_payload_carries_findings_unchanged(self, tmp_path: Path):
+        findings_path = _findings_fixture(tmp_path)
+        md_out = tmp_path / "out.md"
+        json_out = tmp_path / "out.json"
+
+        _run_tool(
+            "--input", str(findings_path),
+            "--output", str(md_out),
+            "--json-output", str(json_out),
+            cwd=tmp_path,
+        )
+        payload = json.loads(json_out.read_text(encoding="utf-8"))
+        assert isinstance(payload["findings"], list)
+        assert len(payload["findings"]) == 3
+        sources = {f["source"] for f in payload["findings"]}
+        assert sources == {"semgrep", "trivy", "gitleaks"}
+
+    def test_json_payload_has_risk_level_and_breakdown(self, tmp_path: Path):
+        findings_path = _findings_fixture(tmp_path)
+        md_out = tmp_path / "out.md"
+        json_out = tmp_path / "out.json"
+
+        _run_tool(
+            "--input", str(findings_path),
+            "--output", str(md_out),
+            "--json-output", str(json_out),
+            cwd=tmp_path,
+        )
+        payload = json.loads(json_out.read_text(encoding="utf-8"))
+        # 2 highs + 1 medium → HIGH per generate_security_report.calculate_risk_level
+        assert payload["risk_level"] == "HIGH"
+        assert payload["total_findings"] == 3
+        assert payload["by_severity"]["high"] == 2
+        assert payload["by_severity"]["medium"] == 1
+        assert payload["by_source"]["semgrep"] == 1
+        assert payload["by_source"]["trivy"] == 1
+        assert payload["by_source"]["gitleaks"] == 1
+
+    def test_json_payload_includes_repo_name(self, tmp_path: Path):
+        findings_path = _findings_fixture(tmp_path)
+        md_out = tmp_path / "out.md"
+        json_out = tmp_path / "out.json"
+
+        _run_tool(
+            "--input", str(findings_path),
+            "--output", str(md_out),
+            "--json-output", str(json_out),
+            "--repo", "svenroth-ai/shipwright",
+            cwd=tmp_path,
+        )
+        payload = json.loads(json_out.read_text(encoding="utf-8"))
+        assert payload["repo"] == "svenroth-ai/shipwright"
+
+
+# ---------------------------------------------------------------------------
+# Markdown output unchanged when --json-output is given alongside
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownStillProduced:
+
+    def test_markdown_output_includes_findings_section(self, tmp_path: Path):
+        findings_path = _findings_fixture(tmp_path)
+        md_out = tmp_path / "out.md"
+        json_out = tmp_path / "out.json"
+
+        _run_tool(
+            "--input", str(findings_path),
+            "--output", str(md_out),
+            "--json-output", str(json_out),
+            cwd=tmp_path,
+        )
+        md_content = md_out.read_text(encoding="utf-8")
+        # existing structure preserved
+        assert "## Summary" in md_content
+        assert "subprocess-shell-true" in md_content
+        assert "CVE-2025-71176" in md_content
+
+
+# ---------------------------------------------------------------------------
+# --json-output without --output (json-only mode)
+# ---------------------------------------------------------------------------
+
+
+class TestJsonOutputAlone:
+
+    def test_json_output_without_md_output_is_supported(self, tmp_path: Path):
+        """User may want only the machine-readable sidecar, no markdown."""
+        findings_path = _findings_fixture(tmp_path)
+        json_out = tmp_path / "out.json"
+
+        result = _run_tool(
+            "--input", str(findings_path),
+            "--json-output", str(json_out),
+            cwd=tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        assert json_out.exists()
+        payload = json.loads(json_out.read_text(encoding="utf-8"))
+        assert payload["schema_version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Empty findings — schema_version still emitted
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyFindings:
+
+    def test_zero_findings_still_emits_valid_schema(self, tmp_path: Path):
+        empty = tmp_path / "empty.json"
+        empty.write_text(json.dumps({"findings": []}), encoding="utf-8")
+        md_out = tmp_path / "out.md"
+        json_out = tmp_path / "out.json"
+
+        result = _run_tool(
+            "--input", str(empty),
+            "--output", str(md_out),
+            "--json-output", str(json_out),
+            cwd=tmp_path,
+        )
+        assert result.returncode == 0
+        payload = json.loads(json_out.read_text(encoding="utf-8"))
+        assert payload["schema_version"] == 1
+        assert payload["total_findings"] == 0
+        assert payload["risk_level"] == "NONE"
+        assert payload["findings"] == []

--- a/plugins/shipwright-security/tests/test_oss_backend.py
+++ b/plugins/shipwright-security/tests/test_oss_backend.py
@@ -217,6 +217,9 @@ class TestScannerExclusions:
             ".next",
             "__pycache__",
             ".cache",
+            # securityreports added in iterate sec-report-and-orchestrator-decouple
+            # so successive scans don't recurse into their own output.
+            "securityreports",
         ):
             assert name in _DEFAULT_EXCLUDES
 

--- a/plugins/shipwright-security/tests/test_redact.py
+++ b/plugins/shipwright-security/tests/test_redact.py
@@ -1,0 +1,237 @@
+"""Tests for the redact module — secret-evidence sanitisation.
+
+Two layers:
+  1. Allowlist-based structural redaction (drop unknown fields by deletion;
+     types preserved; never replace ints/bools with strings).
+  2. Free-text content masking on description / remediation_hint to scrub
+     high-entropy or known-shape secret payloads that a scanner pasted into
+     prose (Gitleaks 'description' often quotes the matched secret).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT / "scripts" / "lib"))
+
+from redact import (  # noqa: E402
+    REDACTED_TOKEN,
+    SAFE_FIELD_ALLOWLIST,
+    mask_secrets_in_text,
+    redact_finding,
+    redact_findings,
+)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist-based redaction
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistRedaction:
+
+    def test_drops_unknown_fields(self):
+        finding = {
+            "id": "f-01",
+            "severity": "high",
+            "rule": "generic-api-key",
+            "affected_file": "tests/fixtures/sample.json",
+            "affected_line": 8,
+            "match": "sk-live-abcd1234",          # raw secret — must drop
+            "secret": "sk-live-abcd1234",         # raw secret — must drop
+            "fingerprint": "abc:123:line:8",      # tool fingerprint — must drop
+            "commit": "deadbeef",                  # git metadata — must drop
+            "author": "alice",                     # git metadata — must drop
+            "email": "alice@example.com",          # git metadata — must drop
+        }
+        out = redact_finding(finding)
+        assert "match" not in out
+        assert "secret" not in out
+        assert "fingerprint" not in out
+        assert "commit" not in out
+        assert "author" not in out
+        assert "email" not in out
+
+    def test_keeps_safe_fields_unchanged(self):
+        finding = {
+            "id": "f-01",
+            "severity": "high",
+            "rule": "generic-api-key",
+            "affected_file": "tests/fixtures/sample.json",
+            "affected_line": 8,
+        }
+        out = redact_finding(finding)
+        assert out["id"] == "f-01"
+        assert out["severity"] == "high"
+        assert out["rule"] == "generic-api-key"
+        assert out["affected_file"] == "tests/fixtures/sample.json"
+        assert out["affected_line"] == 8
+
+    def test_preserves_types_for_safe_fields(self):
+        """Type-safety: ints stay ints, bools stay bools.
+
+        We MUST NOT replace an int with the string '<redacted>' — that breaks
+        downstream JSON / SARIF / UI consumers expecting integer line numbers.
+        """
+        finding = {
+            "id": "f-01",
+            "severity": "high",
+            "rule": "x",
+            "affected_file": "a.py",
+            "affected_line": 42,
+            "severity_score": 7.5,
+        }
+        out = redact_finding(finding)
+        assert isinstance(out["affected_line"], int)
+        assert isinstance(out["severity_score"], float)
+
+    def test_redact_findings_handles_list(self):
+        findings = [
+            {"id": "f-1", "severity": "high", "rule": "x", "match": "secret-a"},
+            {"id": "f-2", "severity": "low", "rule": "y", "secret": "secret-b"},
+        ]
+        out = redact_findings(findings)
+        assert len(out) == 2
+        assert all("match" not in f for f in out)
+        assert all("secret" not in f for f in out)
+
+    def test_full_evidence_disables_allowlist(self):
+        finding = {
+            "id": "f-01",
+            "severity": "high",
+            "rule": "x",
+            "match": "sk-live-abcd1234",
+            "secret": "sk-live-abcd1234",
+        }
+        out = redact_finding(finding, full_evidence=True)
+        assert out["match"] == "sk-live-abcd1234"
+        assert out["secret"] == "sk-live-abcd1234"
+
+    def test_safe_field_allowlist_includes_expected(self):
+        """Spot-check the contract — adding fields requires conscious update."""
+        for name in (
+            "id", "severity", "severity_score", "type", "rule", "cve_id",
+            "affected_file", "affected_line", "affected_package",
+            "installed_version", "fixed_version", "cwe_classes",
+            "source", "_remediation_class", "_remediation_status",
+            "description", "remediation_hint",
+        ):
+            assert name in SAFE_FIELD_ALLOWLIST, f"missing safe field: {name}"
+
+
+# ---------------------------------------------------------------------------
+# Free-text masking
+# ---------------------------------------------------------------------------
+
+
+class TestFreeTextMasking:
+
+    def test_masks_sk_live_prefix(self):
+        text = "Found credential sk-live-1234567890abcdef in config"
+        masked = mask_secrets_in_text(text)
+        assert "sk-live-1234567890abcdef" not in masked
+        assert REDACTED_TOKEN in masked
+
+    def test_masks_aws_access_key(self):
+        text = "AWS key AKIAIOSFODNN7EXAMPLE detected"
+        masked = mask_secrets_in_text(text)
+        assert "AKIAIOSFODNN7EXAMPLE" not in masked
+        assert REDACTED_TOKEN in masked
+
+    def test_masks_github_token(self):
+        text = "Use token ghp_abc123def456ghi789jkl012mno345pqr678stuv01 to authenticate"
+        masked = mask_secrets_in_text(text)
+        assert "ghp_abc123def456ghi789jkl012mno345pqr678stuv01" not in masked
+        assert REDACTED_TOKEN in masked
+
+    def test_masks_slack_bot_token(self):
+        text = "Use xoxb-1234567890-1234567890-AbCdEfGhIjKlMnOpQrStUvWx for slack"
+        masked = mask_secrets_in_text(text)
+        assert "xoxb-1234567890-1234567890-AbCdEfGhIjKlMnOpQrStUvWx" not in masked
+        assert REDACTED_TOKEN in masked
+
+    def test_masks_bearer_header(self):
+        text = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MX0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        masked = mask_secrets_in_text(text)
+        assert "eyJhbGciOiJIUzI1NiJ9" not in masked
+        assert REDACTED_TOKEN in masked
+
+    def test_masks_high_entropy_string(self):
+        # 40-char alphanumeric — looks entropy-y enough to mask
+        text = "Found credential abcdefghij0123456789ABCDEFGHIJ0123456789xx in file"
+        masked = mask_secrets_in_text(text)
+        assert "abcdefghij0123456789ABCDEFGHIJ0123456789xx" not in masked
+        assert REDACTED_TOKEN in masked
+
+    def test_does_not_mask_normal_prose(self):
+        text = "Use parameterized queries instead of string concatenation."
+        masked = mask_secrets_in_text(text)
+        assert masked == text
+
+    def test_does_not_mask_short_words(self):
+        text = "Hardcoded password 'admin' detected"
+        masked = mask_secrets_in_text(text)
+        # 'admin' is too short to look like an entropy secret
+        assert "admin" in masked
+
+    def test_does_not_mask_normal_uuid_in_prose(self):
+        text = "See run-12345678 for details"
+        masked = mask_secrets_in_text(text)
+        # 16-char hyphen segment doesn't trip entropy patterns
+        assert masked == text
+
+    def test_redact_finding_masks_description_field(self):
+        finding = {
+            "id": "f-01",
+            "severity": "high",
+            "rule": "generic-api-key",
+            "description": "Detected key sk-live-1234567890abcdef in source",
+            "affected_file": "a.py",
+        }
+        out = redact_finding(finding)
+        assert "sk-live-1234567890abcdef" not in out["description"]
+        assert REDACTED_TOKEN in out["description"]
+
+    def test_redact_finding_masks_remediation_hint_field(self):
+        finding = {
+            "id": "f-01",
+            "severity": "high",
+            "rule": "x",
+            "remediation_hint": "Replace ghp_abc123def456ghi789jkl012mno345pqr678stuv01 with env var",
+            "affected_file": "a.py",
+        }
+        out = redact_finding(finding)
+        assert "ghp_abc123def456ghi789jkl012mno345pqr678stuv01" not in out["remediation_hint"]
+        assert REDACTED_TOKEN in out["remediation_hint"]
+
+    def test_full_evidence_disables_masking(self):
+        finding = {
+            "id": "f-01",
+            "severity": "high",
+            "rule": "x",
+            "description": "Detected key sk-live-1234567890abcdef in source",
+            "affected_file": "a.py",
+        }
+        out = redact_finding(finding, full_evidence=True)
+        assert "sk-live-1234567890abcdef" in out["description"]
+
+
+# ---------------------------------------------------------------------------
+# Idempotence
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotence:
+
+    def test_redacting_a_redacted_finding_is_a_noop(self):
+        finding = {
+            "id": "f-01",
+            "severity": "high",
+            "rule": "x",
+            "affected_file": "a.py",
+            "affected_line": 1,
+        }
+        once = redact_finding(finding)
+        twice = redact_finding(once)
+        assert once == twice

--- a/plugins/shipwright-security/tests/test_run_scan_and_report.py
+++ b/plugins/shipwright-security/tests/test_run_scan_and_report.py
@@ -1,0 +1,285 @@
+"""Tests for run_scan_and_report.py — local-interactive OSS wrapper.
+
+Covers the unit-level contract:
+  - Aikido backend short-circuits cleanly
+  - Reports land at securityreports/latest.{md,json}
+  - History gets archived as scan-{ts}-{uuid}.{md,json}
+  - Pairs (md+json) are pruned together; strict filename pattern; manual
+    files in history/ are left alone
+  - .gitignore best-effort: appended only when missing; never overwritten
+  - scan_id is consistent between md (HTML comment) and json (field)
+  - --full-evidence retains raw secret values; default-on redaction strips them
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(PLUGIN_ROOT / "scripts" / "tools"))
+
+import run_scan_and_report  # noqa: E402
+
+SCAN_FILENAME_RE = re.compile(r"^scan-\d{8}-\d{6}-[0-9a-f]{6}\.(md|json)$")
+
+
+def _stub_findings() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "f-01",
+            "source": "semgrep",
+            "type": "sast",
+            "rule": "subprocess-shell-true",
+            "severity": "high",
+            "affected_file": "scripts/run.py",
+            "affected_line": 42,
+            "description": "Found shell=True.",
+            "_remediation_class": "agent-fixable",
+        },
+        {
+            "id": "f-02",
+            "source": "gitleaks",
+            "type": "secret_detection",
+            "rule": "generic-api-key",
+            "severity": "high",
+            "affected_file": "tests/fixtures/sample.json",
+            "affected_line": 8,
+            "description": "Detected sk-live-1234567890abcdef in source.",
+            # Raw secret evidence the redactor must strip:
+            "match": "sk-live-1234567890abcdef",
+            "secret": "sk-live-1234567890abcdef",
+            "_remediation_class": "agent-fixable",
+        },
+    ]
+
+
+@pytest.fixture
+def stub_oss_backend(monkeypatch):
+    """Patch get_backend to return an OSS-named mock that returns _stub_findings."""
+    backend = MagicMock()
+    backend.name = "oss"
+    backend.scan.return_value = _stub_findings()
+    monkeypatch.setattr(run_scan_and_report, "get_backend", lambda: backend)
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# Backend short-circuit
+# ---------------------------------------------------------------------------
+
+
+class TestBackendShortCircuit:
+
+    def test_aikido_backend_short_circuits_with_message(self, monkeypatch, tmp_path: Path, capsys):
+        backend = MagicMock()
+        backend.name = "aikido"
+        monkeypatch.setattr(run_scan_and_report, "get_backend", lambda: backend)
+
+        rc = run_scan_and_report.run(project_root=tmp_path, repo="x/y", full_evidence=False)
+        assert rc == 0
+        backend.scan.assert_not_called()
+        # No reports written
+        assert not (tmp_path / "securityreports").exists()
+
+
+# ---------------------------------------------------------------------------
+# Happy path — outputs land in the right places
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+
+    def test_writes_latest_md_and_latest_json(self, stub_oss_backend, tmp_path: Path):
+        rc = run_scan_and_report.run(project_root=tmp_path, repo="test/repo", full_evidence=False)
+        assert rc == 0
+
+        latest_md = tmp_path / "securityreports" / "latest.md"
+        latest_json = tmp_path / "securityreports" / "latest.json"
+        assert latest_md.exists()
+        assert latest_json.exists()
+
+    def test_archives_to_history_with_strict_pattern(self, stub_oss_backend, tmp_path: Path):
+        rc = run_scan_and_report.run(project_root=tmp_path, repo="test/repo", full_evidence=False)
+        assert rc == 0
+
+        history = tmp_path / "securityreports" / "history"
+        archived = sorted(p.name for p in history.iterdir())
+        assert len(archived) == 2  # one md + one json
+
+        for name in archived:
+            assert SCAN_FILENAME_RE.match(name), f"unexpected archived file: {name}"
+
+    def test_scan_id_matches_between_md_and_json(self, stub_oss_backend, tmp_path: Path):
+        run_scan_and_report.run(project_root=tmp_path, repo="test/repo", full_evidence=False)
+
+        latest_json_text = (tmp_path / "securityreports" / "latest.json").read_text(encoding="utf-8")
+        latest_md_text = (tmp_path / "securityreports" / "latest.md").read_text(encoding="utf-8")
+
+        json_payload = json.loads(latest_json_text)
+        scan_id = json_payload["scan_id"]
+        assert scan_id, "json must include scan_id"
+
+        # MD carries the same scan_id in an HTML comment so readers can correlate
+        # files after a partial-write crash (different scan_ids → mismatch detected).
+        assert f"scan_id: {scan_id}" in latest_md_text
+
+    def test_redaction_default_strips_raw_secret_fields(self, stub_oss_backend, tmp_path: Path):
+        run_scan_and_report.run(project_root=tmp_path, repo="test/repo", full_evidence=False)
+
+        payload = json.loads((tmp_path / "securityreports" / "latest.json").read_text(encoding="utf-8"))
+        for finding in payload["findings"]:
+            assert "match" not in finding
+            assert "secret" not in finding
+            # description prose stripped of the secret value
+            if finding.get("description"):
+                assert "sk-live-1234567890abcdef" not in finding["description"]
+
+    def test_full_evidence_retains_raw_secret_fields(self, stub_oss_backend, tmp_path: Path):
+        run_scan_and_report.run(project_root=tmp_path, repo="test/repo", full_evidence=True)
+
+        payload = json.loads((tmp_path / "securityreports" / "latest.json").read_text(encoding="utf-8"))
+        gitleaks_finding = next(f for f in payload["findings"] if f["source"] == "gitleaks")
+        assert gitleaks_finding["match"] == "sk-live-1234567890abcdef"
+
+    def test_full_evidence_refused_in_ci(self, stub_oss_backend, tmp_path: Path, monkeypatch, capsys):
+        monkeypatch.setenv("CI", "true")
+        rc = run_scan_and_report.run(project_root=tmp_path, repo="test/repo", full_evidence=True)
+        # Refuses with non-zero exit OR forces redaction; either way the
+        # raw secret must NOT appear in the output.
+        assert rc != 0 or not (tmp_path / "securityreports" / "latest.json").exists() or (
+            "sk-live-1234567890abcdef"
+            not in (tmp_path / "securityreports" / "latest.json").read_text(encoding="utf-8")
+        )
+
+    def test_atomic_write_no_tmp_files_left_behind(self, stub_oss_backend, tmp_path: Path):
+        run_scan_and_report.run(project_root=tmp_path, repo="test/repo", full_evidence=False)
+        # tmp/staging files must be cleaned up
+        leftovers = list((tmp_path / "securityreports").glob("*.tmp"))
+        leftovers += list((tmp_path / "securityreports").glob("*.partial"))
+        assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# History retention + paired prune
+# ---------------------------------------------------------------------------
+
+
+class TestRetention:
+
+    def test_keeps_at_most_20_pairs_after_many_runs(self, stub_oss_backend, tmp_path: Path):
+        # Pre-populate 25 pairs in history/
+        history = tmp_path / "securityreports" / "history"
+        history.mkdir(parents=True)
+        from datetime import datetime, timedelta
+        base = datetime(2026, 1, 1, 12, 0, 0)
+        for i in range(25):
+            ts = (base + timedelta(seconds=i)).strftime("%Y%m%d-%H%M%S")
+            stem = f"scan-{ts}-{i:06x}"
+            (history / f"{stem}.md").write_text("md", encoding="utf-8")
+            (history / f"{stem}.json").write_text("{}", encoding="utf-8")
+
+        # Run once more; retention should prune to 20 pairs
+        run_scan_and_report.run(project_root=tmp_path, repo="x", full_evidence=False)
+
+        archived = list(history.iterdir())
+        # 20 newest pairs = 40 files (plus the new run we just added)
+        # The new run ADDS one pair, prune is to 20 most recent total.
+        # So expected: exactly 40 files (20 pairs).
+        assert len(archived) == 40
+
+    def test_prune_deletes_pairs_atomically_md_and_json_together(
+        self, stub_oss_backend, tmp_path: Path,
+    ):
+        history = tmp_path / "securityreports" / "history"
+        history.mkdir(parents=True)
+        # Populate 22 pairs, prune to 20 → 2 pairs deleted
+        from datetime import datetime, timedelta
+        base = datetime(2026, 1, 1, 12, 0, 0)
+        for i in range(22):
+            ts = (base + timedelta(seconds=i)).strftime("%Y%m%d-%H%M%S")
+            stem = f"scan-{ts}-{i:06x}"
+            (history / f"{stem}.md").write_text("md", encoding="utf-8")
+            (history / f"{stem}.json").write_text("{}", encoding="utf-8")
+
+        run_scan_and_report.run(project_root=tmp_path, repo="x", full_evidence=False)
+
+        # Every remaining stem must have BOTH .md and .json (no orphaned siblings)
+        stems_md = {p.stem for p in history.glob("*.md")}
+        stems_json = {p.stem for p in history.glob("*.json")}
+        assert stems_md == stems_json
+
+    def test_prune_ignores_files_that_dont_match_strict_pattern(
+        self, stub_oss_backend, tmp_path: Path,
+    ):
+        history = tmp_path / "securityreports" / "history"
+        history.mkdir(parents=True)
+        # User-added or out-of-pattern files: must not be deleted
+        (history / "user-notes.md").write_text("notes", encoding="utf-8")
+        (history / "manual-export.json").write_text("{}", encoding="utf-8")
+        (history / "scan-2026-04-23.md").write_text("legacy without seconds", encoding="utf-8")
+
+        run_scan_and_report.run(project_root=tmp_path, repo="x", full_evidence=False)
+
+        assert (history / "user-notes.md").exists()
+        assert (history / "manual-export.json").exists()
+        assert (history / "scan-2026-04-23.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# .gitignore best-effort
+# ---------------------------------------------------------------------------
+
+
+class TestGitignoreBestEffort:
+
+    def test_appends_entry_when_gitignore_exists_without_it(
+        self, stub_oss_backend, tmp_path: Path,
+    ):
+        gi = tmp_path / ".gitignore"
+        gi.write_text("node_modules/\n.venv/\n", encoding="utf-8")
+
+        run_scan_and_report.run(project_root=tmp_path, repo="x", full_evidence=False)
+        content = gi.read_text(encoding="utf-8")
+        assert "/securityreports/" in content
+        # Existing entries preserved
+        assert "node_modules/" in content
+        assert ".venv/" in content
+
+    def test_does_not_duplicate_when_entry_already_present(
+        self, stub_oss_backend, tmp_path: Path,
+    ):
+        gi = tmp_path / ".gitignore"
+        gi.write_text("node_modules/\n/securityreports/\n", encoding="utf-8")
+
+        run_scan_and_report.run(project_root=tmp_path, repo="x", full_evidence=False)
+        content = gi.read_text(encoding="utf-8")
+        assert content.count("/securityreports/") == 1
+
+    def test_does_not_create_gitignore_when_absent(
+        self, stub_oss_backend, tmp_path: Path,
+    ):
+        # No .gitignore exists in tmp_path
+        assert not (tmp_path / ".gitignore").exists()
+
+        run_scan_and_report.run(project_root=tmp_path, repo="x", full_evidence=False)
+        # We don't materialize a .gitignore in projects that didn't have one
+        assert not (tmp_path / ".gitignore").exists()
+
+    def test_handles_gitignore_without_trailing_newline(
+        self, stub_oss_backend, tmp_path: Path,
+    ):
+        gi = tmp_path / ".gitignore"
+        gi.write_text("node_modules/", encoding="utf-8")  # no trailing \n
+
+        run_scan_and_report.run(project_root=tmp_path, repo="x", full_evidence=False)
+        content = gi.read_text(encoding="utf-8")
+        # Entry on its own line — no merge with the previous line
+        assert "node_modules//securityreports/" not in content
+        assert "/securityreports/" in content

--- a/shared/tests/conftest.py
+++ b/shared/tests/conftest.py
@@ -16,12 +16,13 @@ _OSS_SCANNERS = ("semgrep", "trivy", "gitleaks")
 
 @pytest.fixture(autouse=True)
 def _isolate_scanner_environment(monkeypatch):
-    """Make orchestrator._check_security_available() deterministic per host.
+    """No-op safety net for the orchestrator path.
 
-    Mirrors the autouse fixture in plugins/shipwright-run/tests/conftest.py
-    and integration-tests/conftest.py — clears AIKIDO/SHIPWRIGHT_SCANNER_BACKEND,
-    sets SHIPWRIGHT_TEST_DISABLE_OSS_SCANNERS=1 (covers subprocess invocations),
-    and patches shutil.which to hide the OSS scanners from in-process callers.
+    Iterate sec-report-and-orchestrator-decouple (2026) removed
+    `_check_security_available()`. The env-clearing here is now defensive:
+    ensures AIKIDO_CLIENT_ID and any future scanner-related env vars don't
+    leak from the host into shared-test assertions. Mirror of fixtures in
+    plugins/shipwright-run/tests/conftest.py + integration-tests/conftest.py.
     """
     monkeypatch.delenv("AIKIDO_CLIENT_ID", raising=False)
     monkeypatch.delenv("SHIPWRIGHT_SCANNER_BACKEND", raising=False)


### PR DESCRIPTION
## Summary

Iterate 1 of `sec-report-and-orchestrator-decouple` (Plan: `~/.claude/plans/1-plan-mode-active-composed-starlight.md`).

- **Security plugin:** reports persist in `securityreports/` (gitignored, 20-pair retention, atomic writes, second-grain timestamps). New `redact_findings` (allowlist + free-text masker, type-safe). New `run_scan_and_report.py` wrapper. `generate_security_report.py` gains `--json-output` (`schema_version: 1` + `scan_id`). SKILL.md Step 6 routes through wrapper; new Step 8 offers a single Y/N handoff into `/shipwright-iterate` (gated on TTY + CI + non-interactive + pipeline-mode + iterate prerequisites).
- **Run plugin:** orchestrator decoupled from security. `build_pipeline()` is static (no more `CONDITIONAL_STEPS`). `freeze_run_conditions()` drops `scanner_available` parameter; `securityEnabled` hardcoded false (schema-required field preserved). Legacy v2 configs migrate (`_LEGACY_PIPELINE_ENTRIES` += `"security"`). New `_migrate_in_flight_security_tasks()` skips non-terminal security phase_tasks (backlog/awaiting_launch); in_progress left untouched with manual recover instruction.
- **Schema impact: ZERO.** `shared/schemas/run_config.v2.schema.json` unchanged (shipwright-webui contract preserved).
- All 6 currently-failing tests flagged in `project_run_orchestrator_iterate.md` go green naturally.

## Test plan

- [x] `plugins/shipwright-security`: 237 passed (1 pre-existing flake unchanged)
- [x] `plugins/shipwright-run`: 144 passed
- [x] `integration-tests`: 64 passed (1 pre-existing `override_logger` ModuleNotFoundError unchanged)
- [x] Lint: 24 errors all pre-existing on main, 0 introduced by this iterate
- [x] End-to-end: `run_scan_and_report.py` produces `securityreports/latest.{md,json}` + history archive on the shipwright monorepo (26 findings: 10 semgrep + 13 trivy + 3 gitleaks; `scan_id` correlates across files; redaction on)

## Out of scope (Iterate 2 follows)

- `.github/workflows/security.yml` activation + SARIF upload
- `docs/guide.md` Aikido-not-re-verified note
- new `references/ci-integration.md` docs
- `sarif_writer.py` translator + `scan.py --sarif-dir` / `--input-from-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)