### PR TITLE
feat(security,ci): SARIF translator + dormant CI hardening (Iterate 2 of 2)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,11 @@
 name: Security Scan
 
 # DORMANT: Auto-triggers are disabled until Phase B (Go-Live).
+# When activated:
+#   - Uncomment pull_request and schedule below.
+#   - Fork PRs: SARIF upload + PR comment are skipped via repo-equality guard.
+#   - SARIF from all three OSS scanners uploads to GitHub Security tab
+#     (category: shipwright-security).
 # To activate: uncomment the pull_request and schedule triggers below.
 on:
   # pull_request:
@@ -11,7 +16,8 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write  # to post PR comments
+  pull-requests: write   # to post PR comments
+  security-events: write # required by github/codeql-action/upload-sarif@v3
 
 concurrency:
   group: security-${{ github.ref }}
@@ -69,6 +75,16 @@ jobs:
             --repo "${{ github.repository }}"
         continue-on-error: true  # don't fail the step; let the threshold check decide
 
+      - name: Generate SARIF outputs
+        working-directory: plugins/shipwright-security
+        run: |
+          uv run scripts/tools/scan.py \
+            --path ../.. \
+            --input-from-cache ${{ github.workspace }}/findings.json \
+            --sarif-dir ${{ github.workspace }}/sarif \
+            --repo "${{ github.repository }}"
+        continue-on-error: true
+
       - name: Run Prompt Injection scan
         working-directory: plugins/shipwright-security
         run: |
@@ -97,8 +113,23 @@ jobs:
             --repo "${{ github.repository }}" \
             --pr-mode
 
+      # --- Upload SARIF and post PR comment (with fork-PR guards) ---
+      #
+      # Fork-PR guard: PRs from forks run with a read-only GITHUB_TOKEN, so
+      # security-events:write and pull-requests:write are not granted. Both
+      # steps below are skipped on fork PRs (`head.repo.full_name` differs from
+      # the workflow's repository). Same-repo PRs, workflow_dispatch, and
+      # schedule events still upload SARIF and (for PR events) post comments.
+
+      - name: Upload SARIF to GitHub Security
+        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ github.workspace }}/sarif
+          category: shipwright-security
+
       - name: Post PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -127,4 +158,5 @@ jobs:
             findings.json
             prompt_risks.json
             report.md
+            sarif/
           retention-days: 30

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  actions: read          # required by github/codeql-action/upload-sarif@v3 to attach SARIF to the run
   pull-requests: write   # to post PR comments
   security-events: write # required by github/codeql-action/upload-sarif@v3
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -757,6 +757,10 @@ Every layer must report an explicit result (`pass`, `fail`, or `skipped: {reason
 
 **Standalone usage:** Yes -- the phase runs when any scanner backend is available. With OSS tools installed, it works without any cloud account. With Aikido, the standalone commands (`issues`, `summary`, `report`, `repos`) work against any connected repository.
 
+> **Aikido backend -- not re-verified in v0.3:** The v0.3 restructuring (report persistence, iterate handoff, orchestrator decouple) was built and verified against the OSS backend only. The Aikido path in SKILL.md Step 6 is preserved and should continue to function via `aikido_client.py report`, but has not been re-run end-to-end against the new flow. If you use Aikido, please report any regressions in GitHub issues.
+
+**CI integration:** `.github/workflows/security.yml` is shipped DORMANT -- only `workflow_dispatch` is active out of the box. The workflow is fully wired (SARIF upload to GitHub Security tab, PR-comment, fork-PR guards, weekly cron) but the auto-triggers are commented out so consumers activate them deliberately at Phase B / Go-Live. See `plugins/shipwright-security/skills/security/references/ci-integration.md` for activation steps and behavior details.
+
 ---
 
 ### 4.8 Release Management -- /shipwright-changelog

--- a/plugins/shipwright-security/scripts/lib/sarif_writer.py
+++ b/plugins/shipwright-security/scripts/lib/sarif_writer.py
@@ -1,0 +1,177 @@
+"""SARIF 2.1.0 writer for normalized shipwright-security findings.
+
+Pure transform: takes a list of normalized findings (the output of
+ScannerBackend.scan() — see scanner_backend.py) and returns a SARIF 2.1.0
+document. Designed to be called once per scanner source (semgrep, trivy,
+gitleaks, ...) so each tool gets its own SARIF file.
+
+Why a translator instead of native scanner SARIF flags:
+- Single-pass: scanners run once, SARIF is a pure transform of the same
+  normalized data already in memory.
+- Consistent: same severity / rule-id semantics across tools, no
+  per-tool SARIF dialect quirks.
+- Empty-aware: caller can request a valid empty SARIF document by passing
+  an empty findings list plus an explicit ``source`` — required because
+  ``upload-sarif`` fails on an empty directory.
+
+GitHub Security tab consumes SARIF strictly:
+- ``level`` enum is ``error | warning | note | none`` only.
+- ``security-severity`` (CVSS 0-10, as a string) drives the severity badge.
+- ``partialFingerprints`` lets GitHub dedup the same finding across scans.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Iterable
+
+SARIF_SCHEMA_URI = (
+    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/"
+    "sarif-schema-2.1.0.json"
+)
+SARIF_VERSION = "2.1.0"
+
+# severity (normalized) → SARIF level enum (strict GitHub validation)
+_SEVERITY_TO_LEVEL = {
+    "critical": "error",
+    "high": "error",
+    "medium": "warning",
+    "low": "note",
+    "info": "note",
+}
+
+_DRIVER_INFO_URI = {
+    "semgrep": "https://semgrep.dev",
+    "trivy": "https://github.com/aquasecurity/trivy",
+    "gitleaks": "https://github.com/gitleaks/gitleaks",
+    "aikido": "https://www.aikido.dev",
+}
+
+
+def _level_for(severity: Any) -> str:
+    if not isinstance(severity, str):
+        return "none"
+    return _SEVERITY_TO_LEVEL.get(severity.lower(), "none")
+
+
+def _fingerprint(finding: dict, source: str) -> str:
+    """Stable per-finding fingerprint used for cross-scan dedup in GitHub UI."""
+    parts = [
+        str(finding.get("source") or source or ""),
+        str(finding.get("rule") or ""),
+        str(finding.get("affected_file") or ""),
+        str(finding.get("affected_line") if finding.get("affected_line") is not None else ""),
+        str(finding.get("cve_id") or ""),
+    ]
+    raw = "|".join(parts).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _build_rule(finding: dict, source: str, rule_id: str) -> dict:
+    description = finding.get("description") or rule_id
+    short = _truncate(description, 120) if description else rule_id
+    cwe = finding.get("cwe_classes") or []
+    rule = {
+        "id": rule_id,
+        "name": finding.get("rule") or rule_id,
+        "shortDescription": {"text": short},
+        "fullDescription": {"text": description},
+        "defaultConfiguration": {"level": _level_for(finding.get("severity"))},
+        "properties": {
+            "tags": [t for t in cwe if isinstance(t, str)],
+        },
+    }
+    score = finding.get("severity_score")
+    if isinstance(score, (int, float)):
+        rule["properties"]["security-severity"] = f"{float(score):.1f}"
+    help_uri = finding.get("help_uri")
+    if isinstance(help_uri, str) and help_uri:
+        rule["helpUri"] = help_uri
+    return rule
+
+
+def _build_result(finding: dict, source: str, rule_id: str) -> dict:
+    description = finding.get("description") or rule_id
+    result: dict[str, Any] = {
+        "ruleId": rule_id,
+        "level": _level_for(finding.get("severity")),
+        "message": {"text": description},
+        "partialFingerprints": {
+            "shipwright/v1": _fingerprint(finding, source),
+        },
+    }
+    affected_file = finding.get("affected_file")
+    if isinstance(affected_file, str) and affected_file:
+        physical: dict[str, Any] = {
+            "artifactLocation": {"uri": affected_file},
+        }
+        line = finding.get("affected_line")
+        if isinstance(line, int) and line > 0:
+            physical["region"] = {"startLine": line}
+        result["locations"] = [{"physicalLocation": physical}]
+    score = finding.get("severity_score")
+    if isinstance(score, (int, float)):
+        result.setdefault("properties", {})["security-severity"] = f"{float(score):.1f}"
+    return result
+
+
+def to_sarif(findings: Iterable[dict], source: str) -> dict:
+    """Translate a list of normalized findings (single source) to SARIF 2.1.0.
+
+    Args:
+        findings: Iterable of normalized finding dicts (see scanner_backend.py).
+                  All findings should share the same ``source``; if not, the
+                  function still groups them under the supplied ``source`` driver
+                  but uses each finding's own source for its rule prefix.
+        source: Required scanner name (``"semgrep"``, ``"trivy"``, ...). Used as
+                the SARIF tool driver name AND as the rule-id prefix for every
+                rule. Required even when ``findings`` is empty so the caller can
+                emit a valid placeholder SARIF document.
+
+    Returns:
+        SARIF 2.1.0 root object (a single ``run``). Empty findings produce a
+        valid document with ``runs[0].results = []`` and ``rules = []``.
+    """
+    if not isinstance(source, str) or not source.strip():
+        raise ValueError("sarif_writer.to_sarif requires a non-empty 'source'")
+    source = source.strip().lower()
+
+    rules_by_id: dict[str, dict] = {}
+    results: list[dict] = []
+
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        finding_source = (finding.get("source") or source).strip().lower() or source
+        rule_name = finding.get("rule") or "unknown"
+        rule_id = f"{finding_source}/{rule_name}"
+
+        if rule_id not in rules_by_id:
+            rules_by_id[rule_id] = _build_rule(finding, source, rule_id)
+
+        results.append(_build_result(finding, source, rule_id))
+
+    return {
+        "$schema": SARIF_SCHEMA_URI,
+        "version": SARIF_VERSION,
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": source,
+                        "informationUri": _DRIVER_INFO_URI.get(
+                            source, "https://github.com/svenroth-ai/shipwright"
+                        ),
+                        "rules": list(rules_by_id.values()),
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }

--- a/plugins/shipwright-security/scripts/tools/scan.py
+++ b/plugins/shipwright-security/scripts/tools/scan.py
@@ -87,6 +87,21 @@ except ImportError as _e:
         raise RuntimeError(f"scanner_backend unavailable: {_BACKEND_IMPORT_ERROR}")
 
 
+try:
+    from sarif_writer import to_sarif  # type: ignore
+    _SARIF_IMPORT_ERROR: str | None = None
+except ImportError as _e:
+    _SARIF_IMPORT_ERROR = str(_e)
+
+    def to_sarif(findings, source):  # type: ignore[misc]
+        raise RuntimeError(f"sarif_writer unavailable: {_SARIF_IMPORT_ERROR}")
+
+
+# Scanners with a known SARIF capability — emit one .sarif file per source
+# even on clean scans so `upload-sarif` doesn't fail on an empty directory.
+_SARIF_DEFAULT_SOURCES = ("semgrep", "trivy", "gitleaks")
+
+
 SCAN_TYPE_ALIASES = {
     "secret-detection": "secrets",
     "secret_detection": "secrets",
@@ -153,6 +168,32 @@ def count_above_threshold(findings: list[dict[str, Any]], fail_on: set[str]) -> 
     return sum(1 for f in findings if f.get("severity", "").lower() in fail_on)
 
 
+def _write_sarif_outputs(findings: list[dict[str, Any]], sarif_dir: Path) -> None:
+    """Write one SARIF 2.1.0 file per scanner source.
+
+    Always writes a placeholder for every source in `_SARIF_DEFAULT_SOURCES`
+    (semgrep, trivy, gitleaks) — even on clean scans — so that
+    `github/codeql-action/upload-sarif@v3` doesn't fail on an empty directory.
+    Additional sources discovered in `findings` get their own file too.
+    """
+    sarif_dir.mkdir(parents=True, exist_ok=True)
+
+    by_source: dict[str, list[dict[str, Any]]] = {s: [] for s in _SARIF_DEFAULT_SOURCES}
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        src = (f.get("source") or "unknown").strip().lower() or "unknown"
+        by_source.setdefault(src, []).append(f)
+
+    for source, group in by_source.items():
+        doc = to_sarif(group, source=source)
+        out_path = sarif_dir / f"{source}.sarif"
+        out_path.write_text(
+            json.dumps(doc, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Run the OSS security scanner (Semgrep / Trivy / Gitleaks)",
@@ -186,6 +227,18 @@ def main() -> int:
         default="oss",
         choices=["oss", "aikido"],
         help="Scanner backend to use (default: oss)",
+    )
+    parser.add_argument(
+        "--sarif-dir",
+        help="Directory to write per-source SARIF 2.1.0 files (one .sarif per scanner). "
+             "Always emits a placeholder file for known scanners on clean scans so "
+             "GitHub Actions upload-sarif doesn't fail on an empty directory.",
+    )
+    parser.add_argument(
+        "--input-from-cache",
+        help="Path to a previously-written findings.json. When provided AND the "
+             "file exists, skip scanning entirely and reuse those findings. "
+             "Used by CI to avoid double-scanning between report and SARIF steps.",
     )
     args = parser.parse_args()
 
@@ -221,44 +274,88 @@ def main() -> int:
         )
         return 2
 
-    try:
-        backend = get_backend(args.backend)
-    except RuntimeError as e:
-        print(
-            json.dumps(
-                structured_error(
-                    what_failed=str(e),
-                    what_was_attempted=f"initialize '{args.backend}' scanner backend",
-                    error_category="business",
-                    is_retryable=False,
-                    alternatives=[
-                        "Install Semgrep: pip install semgrep",
-                        "Install Trivy: https://github.com/aquasecurity/trivy/releases",
-                        "Install Gitleaks: https://github.com/gitleaks/gitleaks/releases",
-                    ],
-                )
-            ),
-            file=sys.stderr,
-        )
-        return 2
+    cache_path: Path | None = None
+    if args.input_from_cache:
+        cache_path = Path(args.input_from_cache).resolve()
 
-    try:
-        findings = backend.scan(str(target), scan_types=scan_types)
-    except Exception as e:  # noqa: BLE001 — scanner errors are varied
-        print(
-            json.dumps(
-                structured_error(
-                    what_failed=f"Scanner raised an exception: {e}",
-                    what_was_attempted=f"run {args.backend} backend scan",
-                    error_category="transient",
-                    is_retryable=True,
-                )
-            ),
-            file=sys.stderr,
-        )
-        return 2
+    backend_name = args.backend
+    backend_capabilities: set[str] | None = None
 
-    config = build_config(findings, repo=args.repo, scanner=args.backend)
+    if cache_path and cache_path.exists():
+        try:
+            cached = json.loads(cache_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            print(
+                json.dumps(
+                    structured_error(
+                        what_failed=f"Failed to load --input-from-cache: {e}",
+                        what_was_attempted=f"read findings cache at {cache_path}",
+                        error_category="validation",
+                        is_retryable=False,
+                    )
+                ),
+                file=sys.stderr,
+            )
+            return 2
+        findings = cached.get("findings", []) if isinstance(cached, dict) else []
+        backend_name = (cached.get("scanner") if isinstance(cached, dict) else None) or backend_name
+    else:
+        try:
+            backend = get_backend(args.backend)
+        except RuntimeError as e:
+            print(
+                json.dumps(
+                    structured_error(
+                        what_failed=str(e),
+                        what_was_attempted=f"initialize '{args.backend}' scanner backend",
+                        error_category="business",
+                        is_retryable=False,
+                        alternatives=[
+                            "Install Semgrep: pip install semgrep",
+                            "Install Trivy: https://github.com/aquasecurity/trivy/releases",
+                            "Install Gitleaks: https://github.com/gitleaks/gitleaks/releases",
+                        ],
+                    )
+                ),
+                file=sys.stderr,
+            )
+            return 2
+
+        try:
+            findings = backend.scan(str(target), scan_types=scan_types)
+        except Exception as e:  # noqa: BLE001 — scanner errors are varied
+            print(
+                json.dumps(
+                    structured_error(
+                        what_failed=f"Scanner raised an exception: {e}",
+                        what_was_attempted=f"run {args.backend} backend scan",
+                        error_category="transient",
+                        is_retryable=True,
+                    )
+                ),
+                file=sys.stderr,
+            )
+            return 2
+
+        backend_capabilities = getattr(backend, "capabilities", None)
+
+    config = build_config(findings, repo=args.repo, scanner=backend_name)
+
+    if args.sarif_dir:
+        try:
+            _write_sarif_outputs(findings, Path(args.sarif_dir).resolve())
+        except Exception as e:  # noqa: BLE001 — best-effort, never abort scan
+            print(
+                json.dumps(
+                    structured_error(
+                        what_failed=f"SARIF write failed: {e}",
+                        what_was_attempted=f"write SARIF files to {args.sarif_dir}",
+                        error_category="transient",
+                        is_retryable=True,
+                    )
+                ),
+                file=sys.stderr,
+            )
 
     if args.output:
         output_path = Path(args.output).resolve()
@@ -273,8 +370,10 @@ def main() -> int:
                 "output_path": str(output_path),
                 "findings_count": len(findings),
                 "by_severity": config["by_severity"],
-                "backend": args.backend,
-                "scan_types": scan_types or sorted(backend.capabilities),
+                "backend": backend_name,
+                "scan_types": scan_types or (
+                    sorted(backend_capabilities) if backend_capabilities else None
+                ),
             }
         )
     else:
@@ -283,7 +382,7 @@ def main() -> int:
                 "command": "scan",
                 "findings_count": len(findings),
                 "by_severity": config["by_severity"],
-                "backend": args.backend,
+                "backend": backend_name,
                 "config": config,
             }
         )

--- a/plugins/shipwright-security/skills/security/references/ci-integration.md
+++ b/plugins/shipwright-security/skills/security/references/ci-integration.md
@@ -75,6 +75,26 @@ SARIF specifics:
 - **Severity score** — `severity_score` (0.0-10.0) is exposed as
   `properties.security-severity`, driving the GitHub badge.
 
+## Permissions footgun — `actions: read`
+
+The workflow declares an explicit `permissions:` block. Once you do that,
+GitHub silently sets every *unlisted* permission to **none** for the run.
+`upload-sarif@v3` needs `actions: read` to attach the SARIF to the workflow
+run; without it the SARIF validates and parses fine but the final API push
+fails with `Resource not accessible by integration`. The current block
+includes:
+
+```yaml
+permissions:
+  contents: read
+  actions: read           # required by upload-sarif@v3
+  pull-requests: write    # PR comment
+  security-events: write  # SARIF upload
+```
+
+If you ever extend the workflow with another action that hits a new GitHub
+API surface, double-check whether it needs an additional permission slot.
+
 ## Fork-PR degradation
 
 PRs from forks run with a read-only `GITHUB_TOKEN`: neither

--- a/plugins/shipwright-security/skills/security/references/ci-integration.md
+++ b/plugins/shipwright-security/skills/security/references/ci-integration.md
@@ -1,0 +1,124 @@
+# CI Integration — `.github/workflows/security.yml`
+
+The shipwright-security workflow runs the OSS scanner chain (Semgrep + Trivy +
+Gitleaks) on GitHub Actions, posts a PR comment summarising findings, and
+uploads SARIF to the GitHub Security tab. It ships **DORMANT**: only
+`workflow_dispatch` (manual trigger) is active by default. You activate the
+auto-triggers explicitly when you're ready.
+
+## Current state — DORMANT
+
+The `on:` block in `security.yml` looks like this:
+
+```yaml
+on:
+  # pull_request:
+  #   branches: [main]
+  # schedule:
+  #   - cron: '0 6 * * 1'  # Monday 06:00 UTC — weekly full scan
+  workflow_dispatch:
+```
+
+You can manually fire the scan today via:
+
+```bash
+gh workflow run security.yml
+```
+
+The full pipeline (scan → SARIF translate → PR comment skip → critical gate →
+artifact upload) runs on every dispatch. The PR-comment step is no-op outside
+PR events; SARIF still uploads on `workflow_dispatch` and `schedule` events.
+
+## Activation (Phase B / Go-Live)
+
+When ready to go live, edit `security.yml` and uncomment the two auto-trigger
+blocks:
+
+```yaml
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+```
+
+No other code changes are needed. After the merge:
+- Every PR against `main` triggers a scan with a comment summary.
+- Every Monday 06:00 UTC, a full scan runs and uploads fresh SARIF.
+- The GitHub Security tab shows findings under **category: shipwright-security**
+  (separate from CodeQL's own category).
+
+## Trigger semantics (once activated)
+
+| Trigger | What runs | Where results land |
+|---------|-----------|--------------------|
+| `pull_request` against main | Full scan + SARIF translate + PR comment + critical gate | PR comment (replace), GitHub Security tab, `security-scan-results` artifact |
+| `schedule` (weekly) | Full scan + SARIF translate + critical gate | GitHub Security tab, artifact |
+| `workflow_dispatch` | Same as schedule (manual) | GitHub Security tab, artifact |
+
+## SARIF upload — single-pass translator
+
+Scanners run **once** and emit a normalised `findings.json`. A second `scan.py`
+invocation reads that cache (`--input-from-cache`) and translates the in-memory
+findings into per-source SARIF files (`--sarif-dir`). One `.sarif` per scanner
+with a known capability is **always** written, even on clean scans, so
+`upload-sarif` doesn't fail on an empty directory.
+
+SARIF specifics:
+- **`level` mapping** — `critical|high → error`, `medium → warning`,
+  `low|info → note`, anything else → `none`.
+- **Stable rule IDs** — `{source}/{rule}` (e.g. `semgrep/spawn-shell-true`).
+- **Stable fingerprints** — `partialFingerprints["shipwright/v1"]` is a
+  sha256 of `source|rule|file|line|cve_id`, so GitHub dedups the same finding
+  across scans.
+- **Severity score** — `severity_score` (0.0-10.0) is exposed as
+  `properties.security-severity`, driving the GitHub badge.
+
+## Fork-PR degradation
+
+PRs from forks run with a read-only `GITHUB_TOKEN`: neither
+`security-events: write` nor `pull-requests: write` is granted by GitHub. The
+workflow handles this transparently:
+
+- The scan still runs against the PR branch (artifacts are uploaded).
+- The SARIF upload step **is skipped** (`if:` guard checks
+  `github.event.pull_request.head.repo.full_name == github.repository`).
+- The PR comment step **is skipped** for the same reason.
+- The critical-finding gate still fires — fork PRs introducing critical
+  findings still fail the workflow.
+
+If you need full SARIF/PR-comment coverage on fork PRs, the canonical
+GitHub-recommended pattern is the `pull_request_target` event with manual
+checkout of the PR head — explicitly out of scope for v0.3 because it
+introduces a token-scope footgun for the maintainer.
+
+## Critical-finding gate
+
+A `jq`-based step counts findings with `severity == "critical"` across both
+`findings.json` and `prompt_risks.json`. If the total is non-zero, the workflow
+fails with `::error::` annotation, blocking merge. This behaviour is preserved
+across iterates — it is the only hard gate the workflow enforces.
+
+## Local parity
+
+`run_scan_and_report.py` (the local interactive flow) produces the same
+normalised findings with the same redaction rules. The differences are purely
+in destination:
+
+| Local | CI |
+|-------|----|
+| `securityreports/latest.{md,json}` (gitignored, 20 retained) | `findings.json` + `report.md` artifact (30-day retention) |
+| Iterate-handoff dialog | PR comment |
+| n/a | SARIF to GitHub Security tab |
+
+A finding fingerprint is identical between the two paths, so once SARIF is
+live, GitHub will dedup local-then-CI duplicate sightings of the same issue.
+
+## Snapshot test
+
+`tests/test_workflow_shape.py` asserts the dormant invariants on every
+test run: triggers stay commented, `security-events: write` is set, fork
+guards are present, SARIF category is `shipwright-security`. Any future edit
+that accidentally activates triggers will break those tests until either the
+trigger blocks are re-commented or the snapshot is intentionally updated.

--- a/plugins/shipwright-security/tests/test_sarif_writer.py
+++ b/plugins/shipwright-security/tests/test_sarif_writer.py
@@ -1,0 +1,254 @@
+"""Tests for plugins/shipwright-security/scripts/lib/sarif_writer.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT / "scripts" / "lib"))
+
+import sarif_writer  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _semgrep_finding(**overrides):
+    base = {
+        "id": "semgrep-0001",
+        "severity": "high",
+        "severity_score": 7.5,
+        "type": "sast",
+        "rule": "python.lang.security.hardcoded-credentials",
+        "cve_id": None,
+        "affected_package": None,
+        "affected_file": "scripts/api.py",
+        "affected_line": 42,
+        "description": "Hardcoded credentials detected",
+        "remediation_hint": "Move to env var",
+        "cwe_classes": ["CWE-798"],
+        "source": "semgrep",
+    }
+    base.update(overrides)
+    return base
+
+
+def _trivy_finding(**overrides):
+    base = {
+        "id": "trivy-0001",
+        "severity": "critical",
+        "severity_score": 9.8,
+        "type": "sca",
+        "rule": "CVE-2024-12345",
+        "cve_id": "CVE-2024-12345",
+        "affected_package": "django",
+        "affected_file": "requirements.txt",
+        "affected_line": None,
+        "description": "Critical vulnerability in django",
+        "remediation_hint": "Upgrade to django>=4.2.10",
+        "cwe_classes": [],
+        "source": "trivy",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Schema-level checks
+# ---------------------------------------------------------------------------
+
+class TestSarifShape:
+
+    def test_empty_findings_produces_valid_sarif(self):
+        doc = sarif_writer.to_sarif([], source="semgrep")
+        assert doc["version"] == "2.1.0"
+        assert doc["$schema"].endswith("sarif-schema-2.1.0.json")
+        assert isinstance(doc["runs"], list) and len(doc["runs"]) == 1
+        run = doc["runs"][0]
+        assert run["tool"]["driver"]["name"] == "semgrep"
+        assert run["tool"]["driver"]["rules"] == []
+        assert run["results"] == []
+
+    def test_runs_grouped_under_supplied_driver(self):
+        doc = sarif_writer.to_sarif([_semgrep_finding()], source="semgrep")
+        assert doc["runs"][0]["tool"]["driver"]["name"] == "semgrep"
+        assert doc["runs"][0]["tool"]["driver"]["informationUri"] == "https://semgrep.dev"
+
+    def test_blank_source_raises(self):
+        with pytest.raises(ValueError):
+            sarif_writer.to_sarif([], source="")
+        with pytest.raises(ValueError):
+            sarif_writer.to_sarif([], source="   ")
+
+    def test_unknown_source_still_valid(self):
+        doc = sarif_writer.to_sarif([], source="custom-tool")
+        # informationUri falls back to a project pointer
+        assert doc["runs"][0]["tool"]["driver"]["informationUri"].startswith("https://")
+
+
+# ---------------------------------------------------------------------------
+# Severity → level mapping (Gemini #2)
+# ---------------------------------------------------------------------------
+
+class TestSeverityMapping:
+
+    @pytest.mark.parametrize(
+        "severity,expected_level",
+        [
+            ("critical", "error"),
+            ("high", "error"),
+            ("medium", "warning"),
+            ("low", "note"),
+            ("info", "note"),
+            ("unknown", "none"),
+            ("", "none"),
+            (None, "none"),
+        ],
+    )
+    def test_level_mapping(self, severity, expected_level):
+        finding = _semgrep_finding(severity=severity)
+        doc = sarif_writer.to_sarif([finding], source="semgrep")
+        result = doc["runs"][0]["results"][0]
+        assert result["level"] == expected_level
+        rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+        assert rule["defaultConfiguration"]["level"] == expected_level
+
+    def test_uppercase_severity_normalized(self):
+        finding = _semgrep_finding(severity="HIGH")
+        doc = sarif_writer.to_sarif([finding], source="semgrep")
+        assert doc["runs"][0]["results"][0]["level"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Rule construction
+# ---------------------------------------------------------------------------
+
+class TestRules:
+
+    def test_rule_id_is_source_prefixed(self):
+        finding = _semgrep_finding(rule="spawn-shell-true")
+        doc = sarif_writer.to_sarif([finding], source="semgrep")
+        rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+        assert rule["id"] == "semgrep/spawn-shell-true"
+        assert doc["runs"][0]["results"][0]["ruleId"] == "semgrep/spawn-shell-true"
+
+    def test_rules_deduplicated(self):
+        a = _semgrep_finding(rule="r1", affected_line=10)
+        b = _semgrep_finding(rule="r1", affected_line=20)
+        c = _semgrep_finding(rule="r2", affected_line=30)
+        doc = sarif_writer.to_sarif([a, b, c], source="semgrep")
+        rules = doc["runs"][0]["tool"]["driver"]["rules"]
+        rule_ids = sorted(r["id"] for r in rules)
+        assert rule_ids == ["semgrep/r1", "semgrep/r2"]
+        assert len(doc["runs"][0]["results"]) == 3  # results NOT deduplicated
+
+    def test_security_severity_carried_as_string(self):
+        finding = _semgrep_finding(severity_score=7.5)
+        doc = sarif_writer.to_sarif([finding], source="semgrep")
+        rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+        assert rule["properties"]["security-severity"] == "7.5"
+
+    def test_severity_score_missing_skipped(self):
+        finding = _semgrep_finding()
+        finding.pop("severity_score", None)
+        doc = sarif_writer.to_sarif([finding], source="semgrep")
+        rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+        assert "security-severity" not in rule["properties"]
+
+    def test_cwe_tags_propagate(self):
+        finding = _semgrep_finding(cwe_classes=["CWE-798", "CWE-259"])
+        doc = sarif_writer.to_sarif([finding], source="semgrep")
+        rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+        assert "CWE-798" in rule["properties"]["tags"]
+        assert "CWE-259" in rule["properties"]["tags"]
+
+
+# ---------------------------------------------------------------------------
+# Result construction
+# ---------------------------------------------------------------------------
+
+class TestResults:
+
+    def test_location_for_file_with_line(self):
+        finding = _semgrep_finding(affected_file="scripts/api.py", affected_line=42)
+        doc = sarif_writer.to_sarif([finding], source="semgrep")
+        result = doc["runs"][0]["results"][0]
+        loc = result["locations"][0]["physicalLocation"]
+        assert loc["artifactLocation"]["uri"] == "scripts/api.py"
+        assert loc["region"]["startLine"] == 42
+
+    def test_location_for_file_without_line(self):
+        finding = _trivy_finding(affected_file="requirements.txt", affected_line=None)
+        doc = sarif_writer.to_sarif([finding], source="trivy")
+        result = doc["runs"][0]["results"][0]
+        loc = result["locations"][0]["physicalLocation"]
+        assert loc["artifactLocation"]["uri"] == "requirements.txt"
+        assert "region" not in loc
+
+    def test_no_location_when_file_missing(self):
+        finding = _semgrep_finding(affected_file=None, affected_line=None)
+        doc = sarif_writer.to_sarif([finding], source="semgrep")
+        result = doc["runs"][0]["results"][0]
+        assert "locations" not in result
+
+    def test_partial_fingerprint_present(self):
+        finding = _semgrep_finding()
+        doc = sarif_writer.to_sarif([finding], source="semgrep")
+        fp = doc["runs"][0]["results"][0]["partialFingerprints"]
+        assert "shipwright/v1" in fp
+        assert len(fp["shipwright/v1"]) == 64  # sha256 hex
+
+    def test_fingerprint_stable_across_calls(self):
+        finding = _semgrep_finding()
+        a = sarif_writer.to_sarif([finding], source="semgrep")
+        b = sarif_writer.to_sarif([finding], source="semgrep")
+        assert (
+            a["runs"][0]["results"][0]["partialFingerprints"]["shipwright/v1"]
+            == b["runs"][0]["results"][0]["partialFingerprints"]["shipwright/v1"]
+        )
+
+    def test_fingerprint_changes_with_file(self):
+        a = _semgrep_finding(affected_file="a.py")
+        b = _semgrep_finding(affected_file="b.py")
+        doc_a = sarif_writer.to_sarif([a], source="semgrep")
+        doc_b = sarif_writer.to_sarif([b], source="semgrep")
+        assert (
+            doc_a["runs"][0]["results"][0]["partialFingerprints"]["shipwright/v1"]
+            != doc_b["runs"][0]["results"][0]["partialFingerprints"]["shipwright/v1"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Robustness — non-dict items, missing fields
+# ---------------------------------------------------------------------------
+
+class TestRobustness:
+
+    def test_non_dict_findings_skipped(self):
+        doc = sarif_writer.to_sarif(
+            [_semgrep_finding(), "junk", None, 42, _semgrep_finding(rule="r2")],
+            source="semgrep",
+        )
+        assert len(doc["runs"][0]["results"]) == 2
+
+    def test_missing_rule_uses_unknown(self):
+        finding = _semgrep_finding()
+        finding.pop("rule")
+        doc = sarif_writer.to_sarif([finding], source="semgrep")
+        rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+        assert rule["id"] == "semgrep/unknown"
+
+    def test_finding_source_overrides_per_finding(self):
+        # A finding with source=trivy fed into a semgrep group should use
+        # its own source for the rule prefix (defensive — caller is expected
+        # to pre-group, but mis-grouping shouldn't crash).
+        a = _semgrep_finding(source="trivy", rule="CVE-1")
+        doc = sarif_writer.to_sarif([a], source="semgrep")
+        # Driver name remains the supplied one (semgrep), but the rule id
+        # honours the finding's own source.
+        assert doc["runs"][0]["tool"]["driver"]["name"] == "semgrep"
+        assert doc["runs"][0]["results"][0]["ruleId"] == "trivy/CVE-1"

--- a/plugins/shipwright-security/tests/test_scan_cli.py
+++ b/plugins/shipwright-security/tests/test_scan_cli.py
@@ -218,3 +218,163 @@ class TestMainE2E:
              patch("scan.get_backend", side_effect=raise_rt, create=True):
             rc = scan.main()
         assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# --sarif-dir + --input-from-cache (Iterate 2: sec-ci-activation)
+# ---------------------------------------------------------------------------
+
+class TestSarifDir:
+
+    def test_writes_default_sarif_files_on_clean_scan(self, tmp_path):
+        class FakeBackend:
+            capabilities = {"sast", "sca", "secrets"}
+
+            def scan(self, target, scan_types=None):
+                return []
+
+        sarif_dir = tmp_path / "sarif"
+        argv = [
+            "scan.py",
+            "--path", str(tmp_path),
+            "--sarif-dir", str(sarif_dir),
+        ]
+
+        with patch.object(sys, "argv", argv), \
+             patch("scan.get_backend", return_value=FakeBackend(), create=True):
+            rc = scan.main()
+
+        assert rc == 0
+        # All three default scanner sources must have a SARIF file even on empty scans
+        for source in ("semgrep", "trivy", "gitleaks"):
+            sarif_file = sarif_dir / f"{source}.sarif"
+            assert sarif_file.exists(), f"missing SARIF file for {source}"
+            doc = json.loads(sarif_file.read_text(encoding="utf-8"))
+            assert doc["version"] == "2.1.0"
+            assert doc["runs"][0]["tool"]["driver"]["name"] == source
+            assert doc["runs"][0]["results"] == []
+
+    def test_groups_findings_by_source(self, tmp_path):
+        findings = [
+            {"id": "s1", "severity": "high", "type": "sast", "rule": "r1", "source": "semgrep",
+             "affected_file": "a.py", "affected_line": 1, "description": "d"},
+            {"id": "t1", "severity": "critical", "type": "sca", "rule": "CVE-1", "source": "trivy",
+             "affected_file": "req.txt", "description": "d"},
+            {"id": "s2", "severity": "medium", "type": "sast", "rule": "r2", "source": "semgrep",
+             "affected_file": "b.py", "affected_line": 2, "description": "d"},
+        ]
+
+        class FakeBackend:
+            capabilities = {"sast", "sca"}
+
+            def scan(self, target, scan_types=None):
+                return findings
+
+        sarif_dir = tmp_path / "sarif"
+        argv = [
+            "scan.py",
+            "--path", str(tmp_path),
+            "--sarif-dir", str(sarif_dir),
+        ]
+        with patch.object(sys, "argv", argv), \
+             patch("scan.get_backend", return_value=FakeBackend(), create=True):
+            rc = scan.main()
+
+        assert rc == 0
+        semgrep_doc = json.loads((sarif_dir / "semgrep.sarif").read_text(encoding="utf-8"))
+        trivy_doc = json.loads((sarif_dir / "trivy.sarif").read_text(encoding="utf-8"))
+        gitleaks_doc = json.loads((sarif_dir / "gitleaks.sarif").read_text(encoding="utf-8"))
+        assert len(semgrep_doc["runs"][0]["results"]) == 2
+        assert len(trivy_doc["runs"][0]["results"]) == 1
+        assert gitleaks_doc["runs"][0]["results"] == []  # placeholder still emitted
+
+
+class TestInputFromCache:
+
+    def test_skips_scanner_when_cache_exists(self, tmp_path):
+        cache = tmp_path / "findings.json"
+        cache.write_text(
+            json.dumps({
+                "scanner": "oss",
+                "findings": [
+                    {"id": "f1", "severity": "high", "type": "sast", "rule": "r1",
+                     "source": "semgrep", "affected_file": "a.py", "affected_line": 1,
+                     "description": "d"},
+                ],
+            }),
+            encoding="utf-8",
+        )
+
+        argv = [
+            "scan.py",
+            "--path", str(tmp_path),
+            "--input-from-cache", str(cache),
+            "--output", str(tmp_path / "out.json"),
+        ]
+
+        # If get_backend is invoked at all the test fails — cache must short-circuit
+        with patch.object(sys, "argv", argv), \
+             patch("scan.get_backend", side_effect=AssertionError("must not invoke backend"),
+                   create=True):
+            rc = scan.main()
+
+        assert rc == 0
+        out = json.loads((tmp_path / "out.json").read_text(encoding="utf-8"))
+        assert out["total_findings"] == 1
+        assert out["findings"][0]["id"] == "f1"
+
+    def test_falls_back_to_scan_when_cache_missing(self, tmp_path):
+        # cache path provided but file does NOT exist → scanner runs normally
+        class FakeBackend:
+            capabilities = {"sast"}
+
+            def scan(self, target, scan_types=None):
+                return [{"id": "live", "severity": "low", "type": "sast", "rule": "r",
+                         "source": "semgrep", "affected_file": "x.py", "affected_line": 1,
+                         "description": "d"}]
+
+        argv = [
+            "scan.py",
+            "--path", str(tmp_path),
+            "--input-from-cache", str(tmp_path / "missing.json"),
+            "--output", str(tmp_path / "out.json"),
+        ]
+        with patch.object(sys, "argv", argv), \
+             patch("scan.get_backend", return_value=FakeBackend(), create=True):
+            rc = scan.main()
+        assert rc == 0
+        out = json.loads((tmp_path / "out.json").read_text(encoding="utf-8"))
+        assert out["findings"][0]["id"] == "live"
+
+    def test_combined_cache_plus_sarif(self, tmp_path):
+        # CI's expected pattern: read findings.json from disk, write SARIF, no scan.
+        cache = tmp_path / "findings.json"
+        cache.write_text(
+            json.dumps({
+                "scanner": "oss",
+                "findings": [
+                    {"id": "f1", "severity": "critical", "type": "sca", "rule": "CVE-1",
+                     "source": "trivy", "affected_file": "r.txt", "description": "d"},
+                ],
+            }),
+            encoding="utf-8",
+        )
+
+        sarif_dir = tmp_path / "sarif"
+        argv = [
+            "scan.py",
+            "--path", str(tmp_path),
+            "--input-from-cache", str(cache),
+            "--sarif-dir", str(sarif_dir),
+        ]
+        with patch.object(sys, "argv", argv), \
+             patch("scan.get_backend", side_effect=AssertionError("must not scan"),
+                   create=True):
+            rc = scan.main()
+
+        assert rc == 0
+        trivy_doc = json.loads((sarif_dir / "trivy.sarif").read_text(encoding="utf-8"))
+        assert len(trivy_doc["runs"][0]["results"]) == 1
+        # placeholders still emitted for the other scanners
+        assert (sarif_dir / "semgrep.sarif").exists()
+        assert (sarif_dir / "gitleaks.sarif").exists()

--- a/plugins/shipwright-security/tests/test_workflow_shape.py
+++ b/plugins/shipwright-security/tests/test_workflow_shape.py
@@ -1,0 +1,162 @@
+"""Snapshot test for .github/workflows/security.yml invariants.
+
+Iterate 2 (`sec-ci-activation`) deliberately leaves auto-triggers DORMANT —
+only `workflow_dispatch` is active. This test guards against accidental
+uncommenting in future edits, and verifies the SARIF + fork-guard +
+permission contract baked into the workflow.
+
+Text-regex based (no PyYAML dep) — the goal is to catch drift on a small
+set of invariants, not to validate the full YAML structure.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "security.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    assert WORKFLOW_PATH.exists(), f"missing workflow: {WORKFLOW_PATH}"
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Triggers — must remain DORMANT until Phase B (Go-Live)
+# ---------------------------------------------------------------------------
+
+class TestDormantTriggers:
+
+    def test_pull_request_trigger_is_commented(self, workflow_text):
+        # Match an UNCOMMENTED `pull_request:` at the top of the `on:` block.
+        # Allowed: `# pull_request:` lines (commented).
+        # Forbidden: a bare `pull_request:` line at indent level 2 (inside `on:`).
+        for line in workflow_text.splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            if stripped.startswith("pull_request:"):
+                pytest.fail(
+                    "pull_request trigger appears UNCOMMENTED in security.yml. "
+                    "Iterate 2 (`sec-ci-activation`) keeps triggers dormant — "
+                    "user activates them manually at Phase B / Go-Live."
+                )
+
+    def test_schedule_trigger_is_commented(self, workflow_text):
+        for line in workflow_text.splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            if stripped.startswith("schedule:"):
+                pytest.fail(
+                    "schedule trigger appears UNCOMMENTED in security.yml. "
+                    "Iterate 2 (`sec-ci-activation`) keeps triggers dormant."
+                )
+
+    def test_workflow_dispatch_is_active(self, workflow_text):
+        # workflow_dispatch must remain active so the user can trigger manually.
+        active_dispatch = any(
+            line.strip() == "workflow_dispatch:"
+            and not line.lstrip().startswith("#")
+            for line in workflow_text.splitlines()
+        )
+        assert active_dispatch, "workflow_dispatch trigger missing from security.yml"
+
+    def test_dormant_banner_present(self, workflow_text):
+        # The banner is what tells humans (and future-Claude) why triggers
+        # look weird — keep it intact.
+        assert "DORMANT" in workflow_text
+
+
+# ---------------------------------------------------------------------------
+# Permissions
+# ---------------------------------------------------------------------------
+
+class TestPermissions:
+
+    def test_security_events_write_present(self, workflow_text):
+        # Required by github/codeql-action/upload-sarif@v3
+        assert re.search(
+            r"^\s*security-events:\s*write\b",
+            workflow_text,
+            re.MULTILINE,
+        ), "security-events: write permission missing"
+
+    def test_contents_read_present(self, workflow_text):
+        assert re.search(
+            r"^\s*contents:\s*read\b",
+            workflow_text,
+            re.MULTILINE,
+        ), "contents: read permission missing"
+
+    def test_pull_requests_write_present(self, workflow_text):
+        assert re.search(
+            r"^\s*pull-requests:\s*write\b",
+            workflow_text,
+            re.MULTILINE,
+        ), "pull-requests: write permission missing (needed for PR comments)"
+
+
+# ---------------------------------------------------------------------------
+# SARIF upload + fork-PR guards
+# ---------------------------------------------------------------------------
+
+class TestSarifAndGuards:
+
+    def test_sarif_generation_step_present(self, workflow_text):
+        assert "--sarif-dir" in workflow_text, \
+            "SARIF generation step missing (--sarif-dir flag not used)"
+        assert "--input-from-cache" in workflow_text, \
+            "SARIF generation must use --input-from-cache to avoid double-scan"
+
+    def test_upload_sarif_action_used(self, workflow_text):
+        assert "github/codeql-action/upload-sarif@v3" in workflow_text, \
+            "upload-sarif action not invoked"
+
+    def test_upload_sarif_fork_guard(self, workflow_text):
+        # The upload step must guard against fork PRs (read-only GITHUB_TOKEN).
+        # We require the head-repo equality clause to appear near the upload
+        # step. The exact `if:` shape:
+        #   if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        assert (
+            "github.event.pull_request.head.repo.full_name == github.repository"
+            in workflow_text
+        ), "fork-PR guard (head.repo.full_name == github.repository) missing"
+
+    def test_pr_comment_fork_guard(self, workflow_text):
+        # The PR comment step must also be guarded — fork PR can't grant
+        # pull-requests: write.
+        # Look for the PR-comment step's `if:` containing both event check and head-repo check.
+        pr_comment_block = re.search(
+            r"-\s+name:\s*Post PR comment\s*\n\s*if:\s*([^\n]+)",
+            workflow_text,
+        )
+        assert pr_comment_block, "Post PR comment step missing"
+        cond = pr_comment_block.group(1)
+        assert "pull_request" in cond, "PR-comment if: must check event_name"
+        assert "head.repo.full_name == github.repository" in cond, \
+            "PR-comment step missing fork-PR guard"
+
+    def test_sarif_category_set(self, workflow_text):
+        # SARIF results land under "shipwright-security" category in the
+        # GitHub Security tab — separate from CodeQL's own category.
+        assert re.search(
+            r"category:\s*shipwright-security\b",
+            workflow_text,
+        ), "SARIF category 'shipwright-security' missing on upload-sarif step"
+
+
+# ---------------------------------------------------------------------------
+# Critical-finding gate (regression — existing behavior preserved)
+# ---------------------------------------------------------------------------
+
+class TestCriticalGate:
+
+    def test_critical_check_present(self, workflow_text):
+        assert "critical security findings" in workflow_text, \
+            "critical-findings gate missing — workflow no longer blocks on critical"

--- a/plugins/shipwright-security/tests/test_workflow_shape.py
+++ b/plugins/shipwright-security/tests/test_workflow_shape.py
@@ -101,6 +101,19 @@ class TestPermissions:
             re.MULTILINE,
         ), "pull-requests: write permission missing (needed for PR comments)"
 
+    def test_actions_read_present(self, workflow_text):
+        # Once an explicit `permissions:` block is set, GitHub defaults all
+        # unlisted permissions to NONE. upload-sarif@v3 needs actions:read
+        # to attach the SARIF to the workflow run; without it the SARIF
+        # validates and parses but the final API push fails with
+        # "Resource not accessible by integration". Verified empirically on
+        # run https://github.com/svenroth-ai/shipwright/actions/runs/24942627768
+        assert re.search(
+            r"^\s*actions:\s*read\b",
+            workflow_text,
+            re.MULTILINE,
+        ), "actions: read permission missing (required by upload-sarif@v3 with explicit permissions block)"
+
 
 # ---------------------------------------------------------------------------
 # SARIF upload + fork-PR guards


### PR DESCRIPTION
## Summary

Iterate 2 of shipwright-security v0.3 (`sec-ci-activation`). Pairs with #17 (Iterate 1 — report persistence + iterate handoff + orchestrator decouple, already merged).

The `.github/workflows/security.yml` workflow stays **DORMANT** by design — only `workflow_dispatch` is active. Auto-triggers (`pull_request`, `schedule`) are kept commented so the user activates them deliberately at Phase B / Go-Live. Iterate 2 makes the workflow *ready to go live* without flipping the switch.

### What's new

- **SARIF 2.1.0 translator** (`scripts/lib/sarif_writer.py`): pure function `to_sarif(findings, source)`. No double-scan — translates the already-normalized scanner output in memory. Severity → SARIF level mapping (`critical|high → error`, `medium → warning`, `low|info → note`, else `none`), stable `ruleId={source}/{rule}`, sha256 `partialFingerprints["shipwright/v1"]` for cross-scan dedup in the GitHub Security tab, and `severity_score` carried as `properties.security-severity`.
- **`scan.py --sarif-dir PATH`** — writes one `.sarif` per scanner with a known capability (semgrep / trivy / gitleaks), always, even on clean scans, so `upload-sarif` doesn't fail on an empty directory.
- **`scan.py --input-from-cache PATH`** — CI runs scanners once and a follow-up step translates SARIF from the cached `findings.json`, no re-scan.
- **Workflow hardening** — `security-events: write` permission added (required by `upload-sarif@v3`); fork-PR guards (`head.repo.full_name == github.repository`) on both upload-sarif and PR-comment steps; SARIF uploads under `category: shipwright-security`.
- **`tests/test_workflow_shape.py`** — regex snapshot test: triggers stay commented, permissions present, fork guards present, SARIF category set, dormant banner intact. Catches accidental uncommenting in future edits.
- **`skills/security/references/ci-integration.md`** — activation steps, trigger semantics, fork-PR degradation, local-vs-CI parity.
- **`docs/guide.md` §4.7** — Aikido-not-re-verified honesty note + CI integration pointer.

### Tests

| Suite | Before (Iterate 1 baseline) | After |
|---|---|---|
| shipwright-security | 237 passed | 282 passed (+27 sarif_writer / +13 workflow-shape / +5 scan_cli) |
| shipwright-run | 144 passed | 144 passed |
| integration-tests | 64 passed | 64 passed |

Two pre-existing failures unchanged from main: `test_explicit_name_not_in_registry` test pollution (only fires when run after `TestMainE2E::test_writes_output_file`) and `integration-tests/test_compliance_enforcement.py::test_override_logging_integration` (`override_logger ModuleNotFoundError`). Both called out in the Iterate-1 handoff.

## Test plan

- [ ] Pull and run `cd plugins/shipwright-security && uv run pytest tests/ -v` — 282 passed + 1 pre-existing pollution flake
- [ ] Run `cd plugins/shipwright-run && uv run pytest tests/ -v` — 144 passed
- [ ] Run `uv run pytest integration-tests/ -v` — 64 passed (1 pre-existing failure)
- [ ] `gh workflow run security.yml --ref iterate/sec-ci-activation` — manual dispatch on the branch should produce `sarif/{semgrep,trivy,gitleaks}.sarif` in the artifact bundle and surface findings in the Security tab under category `shipwright-security`
- [ ] Verify `.github/workflows/security.yml` `on:` block keeps `pull_request` and `schedule` commented out

🤖 Generated with [Claude Code](https://claude.com/claude-code)