### PR TITLE
chore(security): bump codeql-action to v4 + continue-on-error on private repos

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -124,7 +124,14 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: github/codeql-action/upload-sarif@v3
+        # `continue-on-error: true` so this step never gates the workflow on
+        # private repos without GitHub Advanced Security (the API returns
+        # "Advanced Security must be enabled" and would otherwise fail-close
+        # the run). Findings still land in findings.json + the SARIF
+        # artifact + the critical-gate. v4 of the action (v3 deprecation
+        # lands 2026-12). Mirrors shared/templates/github-actions/security.yml.template.
+        uses: github/codeql-action/upload-sarif@v4
+        continue-on-error: true
         with:
           sarif_file: ${{ github.workspace }}/sarif
           category: shipwright-security

--- a/shared/templates/github-actions/security.yml.template
+++ b/shared/templates/github-actions/security.yml.template
@@ -89,7 +89,20 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: github/codeql-action/upload-sarif@v3
+        # `continue-on-error: true` so this step never gates the workflow:
+        # - Public repos: Code Scanning is free and on by default → uploads
+        #   land in the Security tab as expected.
+        # - Private repos without GitHub Advanced Security: the API returns
+        #   "Advanced Security must be enabled for this repository to use
+        #   code scanning" and the step fails. The findings still live in
+        #   `findings.json` + `prompt_risks.json` + the SARIF artifact
+        #   (uploaded below via actions/upload-artifact) + the critical-
+        #   gate downstream — none of which require GHAS. So a Private-
+        #   no-GHAS repo still gets the value of the scan; only the
+        #   Security-tab integration is missing.
+        # - v4 of the action (v3 deprecation lands 2026-12).
+        uses: github/codeql-action/upload-sarif@v4
+        continue-on-error: true
         with:
           sarif_file: sarif
           category: shipwright-security


### PR DESCRIPTION
## Summary

Two small chore fixes to the GitHub Actions security workflow, applied identically to the monorepo's own deployed `.github/workflows/security.yml` and the canonical `shared/templates/github-actions/security.yml.template`:

1. **`github/codeql-action/upload-sarif@v3` → `@v4`** — v3 deprecation lands December 2026 ([changelog](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/)). Surfaced as a non-blocking warning in webui's smoke run today.

2. **`continue-on-error: true` on the SARIF upload step** — on private repos without GitHub Advanced Security, this step fails with `Advanced Security must be enabled for this repository to use code scanning` and previously gated the entire workflow. Now it gracefully degrades: findings still live in `findings.json` + the SARIF artifact + the critical-gate downstream (none of those require GHAS). Only the Security-tab integration is missing on private-no-GHAS repos.

## Why this matters

Webui (private repo) was the trigger: smoke run today failed at SARIF upload, blocking the value of the rest of the workflow. After this lands + propagates to webui, the workflow completes green and findings are accessible via:
- Run logs (per-scanner output)
- Scan artifacts download (`security-scan-results` artifact)
- The critical-findings gate (still gates merge if there are real critical findings)

Public repos and private-with-GHAS repos are completely unaffected.

## Test plan

- [x] Drift tests stay green (42 passed) — `SARIF_UPLOAD_USES_PREFIX` matches by prefix, v3→v4 doesn't touch any constants
- [ ] Follow-up: webui PR will sync these changes byte-equal from the updated template
- [ ] After webui sync: `gh workflow run security.yml --ref main` on webui should complete green

## Files changed

- `shared/templates/github-actions/security.yml.template` (canonical)
- `.github/workflows/security.yml` (monorepo's own deployed copy — kept in lockstep with the template, currently dormant via `workflow_dispatch:` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)