### PR TITLE
fix(adopt): seed External Review on; drop dead plan-config key

### DIFF
--- a/.shipwright/agent_docs/build_dashboard.md
+++ b/.shipwright/agent_docs/build_dashboard.md
@@ -1,10 +1,11 @@
 # Project Activity Dashboard
-> Updated: 2026-05-16 10:46 UTC | Session: 386ec9ab-a0c6-4796-a4e8-206d042a644e | Run: iterate-2026-05-16-fix-events-worktree-aware
+> Updated: 2026-05-16 12:53 UTC | Session: fb04bce5-41b0-4629-baf5-bf3854659e19 | Run: iterate-2026-05-16-fix-adopt-review-config
 
-## Recent Changes (28 iterations)
+## Recent Changes (29 iterations)
 
 | Type | Description | Tests | Commit | FRs | Date |
 |------|-------------|-------|--------|-----|------|
+| bug | events.jsonl worktree-awareness: F7/verifier/dashboard resolve the log via git-common-dir; leak-guard exempts it; dashboard embeds run_id | 2519/2526 | 34a7987 | FR-01.11 | 2026-05-16 |
 | bug | RTM data collection: parse 6-column adopt FR tables + resolve shipwright_events.jsonl via git-common-dir for worktree finalization; fixes false 'Traceability coverage 0%' on adopted projects | 312/312 | ea24bf4 | FR-01.10 | 2026-05-15 |
 | feature | Triage Inbox Iterate 2: 4 additional producers (security + performance + F0.5 + drift) wired into append_triage_item_idempotent. CI producer DEFERRED. ADR-047. | 40/40 | aab9bd7 |  | 2026-05-14 |
 | feature | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI (rebased onto post-test-hygiene main; ADR renumbered 045→046) | 1642/1649 | f638908 |  | 2026-05-11 |
@@ -35,7 +36,7 @@
 | change | post-adoption framework cleanup (Sub-1A through 1D) | 225/225 | 3db485b | FR-01.01, FR-01.02, FR-01.03 | 2026-05-02 |
 
 ## Test Status
-Last run: 2026-05-16 | Unit: 2519/2526 | Integration: 110/110 | E2E: 81/81 | Smoke: not_run | (iterate)
+Last run: 2026-05-16 | Unit: 304/304 | E2E: 8/8 | Smoke: not_run | (iterate)
 
 ## Pipeline
 

--- a/.shipwright/agent_docs/conventions.md
+++ b/.shipwright/agent_docs/conventions.md
@@ -69,6 +69,8 @@ Python 3.11+ with uv as package manager. All scripts are invoked via uv run. Hoo
 
 - **Cross-session dedup needs an explicit "no window" mode.** A default time-based window (e.g. 24h) silently mis-fires for producers whose findings persist across sessions for weeks/months. Compliance audit findings stay valid until resolved — re-emitting on day 2 would create N copies of the same finding. Support `window_seconds=None` for indefinite dedup against currently-`triage` items; document the choice per producer. See ADR-046 + Gemini HIGH finding in iterate-2026-05-11-triage-inbox-1a code review.
 
+- **Gitignored test fixtures are absent in fresh worktrees/clones.** Fixture files whose names match a repo-wide gitignore pattern are untracked — e.g. `plugins/shipwright-adopt/tests/fixtures/nested-shipwright/webui/shipwright_run_config.json` is ignored by the `shipwright_*_config.json` rule. Such a file survives in a long-lived working copy but is NOT carried into a freshly-created `git worktree` (nor a fresh `git clone` / CI checkout). `test_nested_project_detector::test_detects_nested_shipwright_subproject` consequently fails in every iterate worktree until the fixture is re-hydrated (copy from the main repo, per the SKILL B1a re-hydration rule). Surfaced in iterate-2026-05-16-fix-adopt-review-config. Proper fix (out of scope there): force-track the fixture with `git add -f`, or rename it so the ignore rule misses it.
+
 ---
 
 ## Imported from `CONTRIBUTING.md`

--- a/.shipwright/agent_docs/decision-drops/iterate-2026-05-16-fix-adopt-review-config_001.json
+++ b/.shipwright/agent_docs/decision-drops/iterate-2026-05-16-fix-adopt-review-config_001.json
@@ -1,0 +1,13 @@
+{
+  "run_id": "iterate-2026-05-16-fix-adopt-review-config",
+  "date": "2026-05-16",
+  "section": "Iterate — bug: adopt external-review config defaults",
+  "title": "Adopt seeds External Review on; drops dead plan-config key",
+  "context": "shipwright-adopt's config_writer seeded shipwright_iterate_config.json with external_review.feedback_iterations: 0, which the shared resolver maps to status 'user_disabled' — External Review silently skipped for every onboarded repo. It also wrote a flat 'external_review_feedback_iterations' key into shipwright_plan_config.json that had zero readers repo-wide.",
+  "decision": "write_iterate_config now seeds feedback_iterations: 1, consistent with the shared default (shared/config/external_review.json) and greenfield /shipwright-project. write_plan_config no longer writes the dead flat key. Stale '=0' descriptions in dry_run_reporter.py and the adopt SKILL.md were corrected; the residual dead key was removed from the monorepo's own shipwright_plan_config.json.",
+  "consequences": "Adopted (brownfield) repos get External Review enabled by default, like greenfield. The no-API-key case is handled by the resolver's 'missing_keys' -> interactive prompt (Branch B), not a silent opt-out. Two regression tests guard both defects (producer->file->resolver round-trip; plan-config dead-key absence).",
+  "rationale": "A 0 seed claimed the user opted out when Adopt did so unilaterally and unannounced; brownfield code is higher-risk and benefits more from review. The flat plan-config key was never read — making plan-phase review project-steerable would require extending the resolver, deliberately out of scope for this bugfix.",
+  "rejected": "Keep feedback_iterations: 0 (disguised opt-out, contradicts greenfield default). Extend the resolver to read a plan-config key (scope expansion — only dead-key removal was in scope).",
+  "commit": "",
+  "architecture_impact": "none"
+}

--- a/.shipwright/agent_docs/iterates/iterate-2026-05-16-fix-adopt-review-config.json
+++ b/.shipwright/agent_docs/iterates/iterate-2026-05-16-fix-adopt-review-config.json
@@ -1,0 +1,10 @@
+{
+  "run_id": "iterate-2026-05-16-fix-adopt-review-config",
+  "date": "2026-05-16T12:53:47.148216Z",
+  "type": "bug",
+  "complexity": "small",
+  "branch": "iterate/fix-adopt-review-config",
+  "spec": null,
+  "tests_passed": true,
+  "adr": "iterate-2026-05-16-fix-adopt-review-config"
+}

--- a/.shipwright/agent_docs/session_handoff.md
+++ b/.shipwright/agent_docs/session_handoff.md
@@ -1,39 +1,36 @@
 ---
 canon_generated: true
-run_id: "iterate-2026-05-15-iterate-worktree-isolation"
+run_id: "iterate-2026-05-16-fix-adopt-review-config"
 phase: "iterate"
-reason: "iterate: unconditional worktree isolation"
-timestamp: "2026-05-16T08:29:21.629732+00:00"
+reason: "iterate: fix adopt external-review config defaults"
+timestamp: "2026-05-16T12:53:40.836265+00:00"
 ---
 
 # Session Handoff
 
-> Auto-generated 2026-05-16 08:29:21 UTC
+> Auto-generated 2026-05-16 12:53:40 UTC
 
 ## Session Info
 
-- **Session ID**: 8e60b80c-b748-453b-ab62-bc5e7b4659b8
-- **Timestamp**: 2026-05-16 08:29:21 UTC
-- **Reason**: iterate: unconditional worktree isolation
+- **Session ID**: fb04bce5-41b0-4629-baf5-bf3854659e19
+- **Timestamp**: 2026-05-16 12:53:40 UTC
+- **Reason**: iterate: fix adopt external-review config defaults
 
 ## Last Iterate
 
-- **Run ID**: iterate-2026-05-15-iterate-worktree-isolation
-- **Date**: 2026-05-16T08:26:54.760323Z
-- **Type**: change
-- **Complexity**: large
-- **Branch**: iterate/iterate-worktree-isolation
-- **ADR**: iterate-2026-05-15-iterate-worktree-isolation
+- **Run ID**: iterate-2026-05-16-fix-events-worktree-aware
+- **Date**: 2026-05-16T10:47:06.669217Z
+- **Type**: bug
+- **Complexity**: medium
+- **Branch**: iterate/fix-events-worktree-aware
+- **ADR**: iterate-2026-05-16-fix-events-worktree-aware
 - **Tests passed**: True
-- **Spec**: .shipwright/planning/iterate/2026-05-15-iterate-worktree-isolation.md
+- **Spec**: .shipwright/planning/iterate/2026-05-16-fix-events-worktree-aware.md
 
 ## Current Iterate Progress
 
-- **Branch**: iterate/iterate-worktree-isolation
-- **Run ID**: iterate-2026-05-15-iterate-worktree-isolation
-- **Spec**: .shipwright/planning/iterate/2026-05-15-iterate-worktree-isolation.md
-- **Complexity**: large (escape-hatch option 2 — force iterate; user-acknowledged over-threshold scope)
-- **External Review Marker**: stale (predates spec (2026-05-14T20:55:44))
+- **Branch**: iterate/fix-adopt-review-config
+- **External Review Marker**: completed (external_review_state.json @ 2026-05-16T09:46:59)
 
 ### Mandatory replay on Resume
 
@@ -51,8 +48,8 @@ Before dispatching to the handoff's Remaining phase, run these if missing:
 
 ## Git State
 
-- **Branch**: iterate/iterate-worktree-isolation
-- **Last Commit**: bcb4f37 Merge iterate/fix-rtm-adopt-worktree: worktree-aware RTM data collection
+- **Branch**: iterate/fix-adopt-review-config
+- **Last Commit**: 2a2c6fd chore(iterate): record F7 work_completed event for 34a7987
 - **Uncommitted Changes**: Yes
 
 ## Config Files to Read
@@ -68,22 +65,23 @@ Before dispatching to the handoff's Remaining phase, run these if missing:
 
 | Event | Type | Source | Date |
 |-------|------|--------|------|
+| evt-d57cc8ce | work_completed | iterate (events.jsonl worktree-awareness: F7/verifier/dashboard resolve the log via git-common-dir; leak-guard exempts it; dashboard embeds run_id) | 2026-05-16 |
 | evt-a3888caf | work_completed | iterate (RTM data collection: parse 6-column adopt FR tables + resolve shipwright_events.jsonl via git-common-dir for worktree finalization; fixes false 'Traceability coverage 0%' on adopted projects) | 2026-05-15 |
 | evt-84dbdf5e | work_completed | iterate (Triage Inbox Iterate 2: 4 additional producers (security + performance + F0.5 + drift) wired into append_triage_item_idempotent. CI producer DEFERRED. ADR-047.) | 2026-05-14 |
 | evt-32f2f1f4 | work_completed | iterate (Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI (rebased onto post-test-hygiene main; ADR renumbered 045→046)) | 2026-05-11 |
 | evt-3f488ddc | work_completed | iterate (Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI) | 2026-05-11 |
-| evt-c8a57331 | work_completed | iterate (known_issues scanner requires comment context; remove dead save_session_config — 16/16 green) | 2026-05-09 |
 
 ## Recovery
 
 - **Pipeline**: 1 phases completed
-- **Total work events**: 28
-- **Last iterate**: bug — RTM data collection: parse 6-column adopt FR tables + resolve shipwright_events.jsonl via git-common-dir for worktree finalization; fixes false 'Traceability coverage 0%' on adopted projects (2026-05-15)
+- **Total work events**: 29
+- **Last iterate**: bug — events.jsonl worktree-awareness: F7/verifier/dashboard resolve the log via git-common-dir; leak-guard exempts it; dashboard embeds run_id (2026-05-16)
 - **Resume**: `/shipwright-iterate` for next change, or `/shipwright-run` for new pipeline
 
 ## Recent Decisions
 
-### ADR-048: Worktree-aware RTM data collection: 6-column FR tables + git-common-dir event log
-- **Date:** 2026-05-15
-- **Section:** Iterate — bug: RTM 6-column spec + worktree event-log fixes
-- **Context:** Running /shipwright-iterate on a brownfield project adopted via /shipwright-adopt produced an RTM showing a false 'Traceability coverage 0%', which the check_rtm_coverage pre-commit hook soft-blocked. Two shipwright-compliance bugs: (A) the FR-table regex parsed only 3- and 5-column tables, never th
+### ADR-050: Worktree-aware event-log resolution
+- **Date:** 2026-05-16
+- **Section:** Iterate — bug: events.jsonl worktree-awareness + dashboard run_id WARN
+- **Run-ID:** iterate-2026-05-16-fix-events-worktree-aware
+- **Context:** Under /shipwright-iterate worktree isolation, F7 recorded its work_completed event at the literal --project-root (the ephemeral worktree), so the event was discarded on `git worktree remove` and never reached the main repo's shipwright_events.jsonl. The F11 verifier's check_e

--- a/.shipwright/compliance/change-history.md
+++ b/.shipwright/compliance/change-history.md
@@ -1,16 +1,16 @@
 # Commit Change Log
 
-Generated: 2026-05-16T10:46:57Z
-Total commits: 644
+Generated: 2026-05-16T12:53:40Z
+Total commits: 648
 
 ## Commit Distribution
 
 ```mermaid
 pie title Commit Types
     "feat" : 218
-    "fix" : 168
-    "chore" : 105
-    "docs" : 98
+    "fix" : 169
+    "chore" : 107
+    "docs" : 99
     "refactor" : 34
     "test" : 14
     "other" : 7
@@ -241,10 +241,11 @@ pie title Commit Types
 | 2026-03-20 | — | Task 02 — project templates (CLAUDE.md, agent_docs, CI) | c3a6d2f53bd3 |
 | 2026-03-20 | — | Task 01 — monorepo scaffolding + supabase-nextjs stack profile | 990a138a4690 |
 
-### Fixes (fix) — 168 commits
+### Fixes (fix) — 169 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-16 | iterate | worktree-aware event-log resolution | 34a79879a54d |
 | 2026-05-15 | compliance | worktree-aware RTM data collection | ea24bf4284d2 |
 | 2026-05-11 | triage | path-canon allowlist + use _AGENT_DOCS_DIRNAME constant | 734bba94d211 |
 | 2026-05-11 | triage | address external code review HIGH + MED findings | 0229b4c3b9f2 |
@@ -414,10 +415,12 @@ pie title Commit Types
 | 2026-03-21 | — | rename skill folders for clean slash commands | 5a8d77658fab |
 | 2026-03-20 | — | update README attribution to svenroth.ai | dd5de7f7d6ab |
 
-### Chores (chore) — 105 commits
+### Chores (chore) — 107 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-16 | iterate | record F7 work_completed event for 34a7987 | 2a2c6fd182c8 |
+| 2026-05-16 | release | v0.19.0 | 333baab12f49 |
 | 2026-05-15 | compliance | record F7 work_completed event for ea24bf4 | fd68dd347db7 |
 | 2026-05-14 | triage | post-F7 refresh of build_dashboard + compliance + handoff | 9f17372f5889 |
 | 2026-05-14 | triage | append F7 work_completed event for iterate-2 commit | 2f55b21975f6 |
@@ -524,10 +527,11 @@ pie title Commit Types
 | 2026-03-28 | — | add shipwright-run uv.lock | ef1cc1ad180c |
 | 2026-03-20 | — | initial commit with spec and task list | 07ca9c1de51c |
 
-### Documentation (docs) — 98 commits
+### Documentation (docs) — 99 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-16 | iterate | fix SKILL.md run_id format + stale F11 events.jsonl grep | 70f52f49f207 |
 | 2026-05-16 | — | align ASCII pipeline diagrams with profile-driven deploy | bd5a0b955ef1 |
 | 2026-05-16 | — | document performance budgets + honest deploy-target framing | c9a442e0c28e |
 | 2026-05-16 | — | document the python-plugin-monorepo stack profile | 2e1f1fcec211 |
@@ -701,7 +705,7 @@ pie title Commit Types
 
 | Metric | Value |
 |--------|-------|
-| Total commits | 644 |
+| Total commits | 648 |
 | AI-assisted commits | 0 |
-| Human-authored commits | 644 |
+| Human-authored commits | 648 |
 

--- a/.shipwright/compliance/dashboard.md
+++ b/.shipwright/compliance/dashboard.md
@@ -1,6 +1,6 @@
 # Compliance Dashboard
 
-Generated: 2026-05-16T10:46:57Z
+Generated: 2026-05-16T12:53:40Z
 Profile: python-plugin-monorepo
 Scope: library
 
@@ -10,18 +10,18 @@ Scope: library
 |--------|-------|--------|
 | Pipeline phases completed | 1/7 | WARN |
 | Work events (build) | 0 sections | WARN |
-| Work events (iterate) | 28 changes | INFO |
-| All unit tests passing | 312/312 | PASS |
+| Work events (iterate) | 29 changes | INFO |
+| All unit tests passing | 2519/2526 | WARN |
 | All sections reviewed | 0/0 | WARN |
-| Architecture decisions | 48 ADRs | INFO |
-| Iterate tests passing | 26/28 iterations tested | WARN |
+| Architecture decisions | 50 ADRs | INFO |
+| Iterate tests passing | 27/29 iterations tested | WARN |
 | Dependencies | 5 packages | INFO |
 | Copyleft risk | 0 | PASS |
 
 ## Project Velocity
 
-- Iterate: 28 changes (2026-05-02 → 2026-05-15)
-- Last activity: 2026-05-15
+- Iterate: 29 changes (2026-05-02 → 2026-05-16)
+- Last activity: 2026-05-16
 
 ## External LLM Review Evidence
 

--- a/.shipwright/compliance/sbom.md
+++ b/.shipwright/compliance/sbom.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-05-16T10:46:57Z
+Generated: 2026-05-16T12:53:40Z
 
 ## Summary
 

--- a/.shipwright/compliance/test-evidence.md
+++ b/.shipwright/compliance/test-evidence.md
@@ -1,45 +1,46 @@
 # Test Evidence Report
 
-Generated: 2026-05-16T10:46:57Z
+Generated: 2026-05-16T12:53:40Z
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total test checkpoints | 28 |
-| Total unit tests (latest) | 312/312 |
+| Total test checkpoints | 29 |
+| Total unit tests (latest) | 2519/2526 |
 | New tests from iterations | +19 |
 
 ## Test Progression
 
 | # | Event | Source | New Tests | Suite Total | Result | Date |
 |---|-------|--------|-----------|-------------|--------|------|
-| 1 | RTM data collection: parse 6-column adopt FR tables + resolve shipwright_events.jsonl via git-common-dir for worktree finalization; fixes false 'Traceability coverage 0%' on adopted projects | iterate | +0 | 312/312 | PASS | 2026-05-15 |
-| 2 | Triage Inbox Iterate 2: 4 additional producers (security + performance + F0.5 + drift) wired into append_triage_item_idempotent. CI producer DEFERRED. ADR-047. | iterate | +0 | 40/40 | PASS | 2026-05-14 |
-| 3 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI (rebased onto post-test-hygiene main; ADR renumbered 045→046) | iterate | +0 | 1642/1649 | FAIL | 2026-05-11 |
-| 4 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI | iterate | +0 | 1642/1649 | FAIL | 2026-05-11 |
-| 5 | known_issues scanner requires comment context; remove dead save_session_config — 16/16 green | iterate | +0 | 16/16 | PASS | 2026-05-09 |
-| 6 | evt-f66286bf | iterate | +0 | — | — | 2026-05-07 |
-| 7 | evt-623a29ad | iterate | +0 | — | — | 2026-05-07 |
-| 8 | F0.5 empirical-test backfill | iterate | +0 | 1575/1575 | PASS | 2026-05-06 |
-| 9 | F0.5 End-to-End Verification Gate | iterate | +0 | 1548/1548 | PASS | 2026-05-06 |
-| 10 | hooks-consistency parser handles quoted commands — 27/27 green | iterate | +0 | 1297/1297 | PASS | 2026-05-06 |
-| 11 | post-migration canon cleanup — 9 tests green | iterate | +0 | 1270/1270 | PASS | 2026-05-06 |
-| 12 | loader deep-merges per-project shipwright_iterate_config.json + cascade helper | iterate | +0 | 34/34 | PASS | 2026-05-05 |
-| 13 | verifier accepts drop-dir entries + dashboard short-SHAs | iterate | +0 | 32/32 | PASS | 2026-05-05 |
-| 14 | adopt writes shipwright_iterate_config.json with documented opt-out schema | iterate | +0 | 241/241 | PASS | 2026-05-05 |
-| 15 | FR-table parser accepts 5-col adopt format + drift protection | iterate | +0 | 1594/1628 | FAIL | 2026-05-05 |
-| 16 | post-F7 housekeeping + AC-13 P5 fix (active install path) for plugin-hook-registration | iterate | +0 | 12/12 | PASS | 2026-05-05 |
-| 17 | plugin-owned suggest_iterate hook (ADR-030); retired hook_installer + 7 SKILL.md stanzas + A6 verifier | iterate | +0 | 1691/1716 | FAIL | 2026-05-05 |
-| 18 | F runner contract mandates reviews (ADR-029) | iterate | +0 | 188/188 | PASS | 2026-05-04 |
-| 19 | iterate: review-driven hardening (ADR-028 / campaign iterate-skill-hardening Sub-Iterate E) | iterate | +0 | 1539/1539 | PASS | 2026-05-04 |
-| 20 | test plugin: boundary coverage report (campaign iterate-skill-hardening Sub-Iterate D, ADR-027) | iterate | +19 | 19/19 | PASS | 2026-05-03 |
-| 21 | changelog MSYS path-mangling linter | iterate | +0 | 19/19 | PASS | 2026-05-03 |
-| 22 | hooks.json quoting (deferred from ADR-020) | iterate | +0 | 13/13 | PASS | 2026-05-03 |
-| 23 | iterate fix: parse_env_file inline-comment stripping + lib copy sync | iterate | +0 | 53/53 | PASS | 2026-05-03 |
-| 24 | iterate: adopt scaffolds .env.local with profile + framework keys (ADR-021) | iterate | +0 | 47/47 | PASS | 2026-05-03 |
-| 25 | suggest_iterate hook quoted-path + Shape A/B upgrade-in-place | iterate | +0 | 249/249 | PASS | 2026-05-03 |
-| 26 | fix hook_installer Shape A -> B | iterate | +0 | 5/5 | PASS | 2026-05-03 |
-| 27 | shipwright-adopt durable fixes (Sub-2A drift detection, 2B test-fixture filter, 2C compliance_bridge sys.path) | iterate | +0 | 233/233 | PASS | 2026-05-02 |
-| 28 | post-adoption framework cleanup (Sub-1A through 1D) | iterate | +0 | 225/225 | PASS | 2026-05-02 |
+| 1 | events.jsonl worktree-awareness: F7/verifier/dashboard resolve the log via git-common-dir; leak-guard exempts it; dashboard embeds run_id | iterate | +0 | 2519/2526 | FAIL | 2026-05-16 |
+| 2 | RTM data collection: parse 6-column adopt FR tables + resolve shipwright_events.jsonl via git-common-dir for worktree finalization; fixes false 'Traceability coverage 0%' on adopted projects | iterate | +0 | 312/312 | PASS | 2026-05-15 |
+| 3 | Triage Inbox Iterate 2: 4 additional producers (security + performance + F0.5 + drift) wired into append_triage_item_idempotent. CI producer DEFERRED. ADR-047. | iterate | +0 | 40/40 | PASS | 2026-05-14 |
+| 4 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI (rebased onto post-test-hygiene main; ADR renumbered 045→046) | iterate | +0 | 1642/1649 | FAIL | 2026-05-11 |
+| 5 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI | iterate | +0 | 1642/1649 | FAIL | 2026-05-11 |
+| 6 | known_issues scanner requires comment context; remove dead save_session_config — 16/16 green | iterate | +0 | 16/16 | PASS | 2026-05-09 |
+| 7 | evt-f66286bf | iterate | +0 | — | — | 2026-05-07 |
+| 8 | evt-623a29ad | iterate | +0 | — | — | 2026-05-07 |
+| 9 | F0.5 empirical-test backfill | iterate | +0 | 1575/1575 | PASS | 2026-05-06 |
+| 10 | F0.5 End-to-End Verification Gate | iterate | +0 | 1548/1548 | PASS | 2026-05-06 |
+| 11 | hooks-consistency parser handles quoted commands — 27/27 green | iterate | +0 | 1297/1297 | PASS | 2026-05-06 |
+| 12 | post-migration canon cleanup — 9 tests green | iterate | +0 | 1270/1270 | PASS | 2026-05-06 |
+| 13 | loader deep-merges per-project shipwright_iterate_config.json + cascade helper | iterate | +0 | 34/34 | PASS | 2026-05-05 |
+| 14 | verifier accepts drop-dir entries + dashboard short-SHAs | iterate | +0 | 32/32 | PASS | 2026-05-05 |
+| 15 | adopt writes shipwright_iterate_config.json with documented opt-out schema | iterate | +0 | 241/241 | PASS | 2026-05-05 |
+| 16 | FR-table parser accepts 5-col adopt format + drift protection | iterate | +0 | 1594/1628 | FAIL | 2026-05-05 |
+| 17 | post-F7 housekeeping + AC-13 P5 fix (active install path) for plugin-hook-registration | iterate | +0 | 12/12 | PASS | 2026-05-05 |
+| 18 | plugin-owned suggest_iterate hook (ADR-030); retired hook_installer + 7 SKILL.md stanzas + A6 verifier | iterate | +0 | 1691/1716 | FAIL | 2026-05-05 |
+| 19 | F runner contract mandates reviews (ADR-029) | iterate | +0 | 188/188 | PASS | 2026-05-04 |
+| 20 | iterate: review-driven hardening (ADR-028 / campaign iterate-skill-hardening Sub-Iterate E) | iterate | +0 | 1539/1539 | PASS | 2026-05-04 |
+| 21 | test plugin: boundary coverage report (campaign iterate-skill-hardening Sub-Iterate D, ADR-027) | iterate | +19 | 19/19 | PASS | 2026-05-03 |
+| 22 | changelog MSYS path-mangling linter | iterate | +0 | 19/19 | PASS | 2026-05-03 |
+| 23 | hooks.json quoting (deferred from ADR-020) | iterate | +0 | 13/13 | PASS | 2026-05-03 |
+| 24 | iterate fix: parse_env_file inline-comment stripping + lib copy sync | iterate | +0 | 53/53 | PASS | 2026-05-03 |
+| 25 | iterate: adopt scaffolds .env.local with profile + framework keys (ADR-021) | iterate | +0 | 47/47 | PASS | 2026-05-03 |
+| 26 | suggest_iterate hook quoted-path + Shape A/B upgrade-in-place | iterate | +0 | 249/249 | PASS | 2026-05-03 |
+| 27 | fix hook_installer Shape A -> B | iterate | +0 | 5/5 | PASS | 2026-05-03 |
+| 28 | shipwright-adopt durable fixes (Sub-2A drift detection, 2B test-fixture filter, 2C compliance_bridge sys.path) | iterate | +0 | 233/233 | PASS | 2026-05-02 |
+| 29 | post-adoption framework cleanup (Sub-1A through 1D) | iterate | +0 | 225/225 | PASS | 2026-05-02 |
 

--- a/.shipwright/compliance/traceability-matrix.md
+++ b/.shipwright/compliance/traceability-matrix.md
@@ -1,6 +1,6 @@
 # Requirements Traceability Matrix
 
-Generated: 2026-05-16T10:46:57Z
+Generated: 2026-05-16T12:53:40Z
 
 ## Requirements Coverage
 
@@ -16,7 +16,7 @@ Generated: 2026-05-16T10:46:57Z
 | [FR-01.08](../../.shipwright/planning/01-adopted/spec.md#fr-0108) | Deploy to configured targets with smoke testing and rollback... | Should | evt-e3d2949e, evt-ca7b7d64 | 225/225 → 13/13 | 2026-05-03 (iter) | COVERED |
 | [FR-01.09](../../.shipwright/planning/01-adopted/spec.md#fr-0109) | Parse Conventional Commits from git history, generate Keep-a... | Must | evt-e3d2949e, evt-ca7b7d64 | 225/225 → 13/13 | 2026-05-03 (iter) | COVERED |
 | [FR-01.10](../../.shipwright/planning/01-adopted/spec.md#fr-0110) | Generate audit-ready compliance documentation (RTM, test evi... | Must | evt-e3d2949e, evt-ca7b7d64, evt-30338dac, evt-a3888caf | 225/225 → 312/312 | 2026-05-15 (iter) | FAIL |
-| [FR-01.11](../../.shipwright/planning/01-adopted/spec.md#fr-0111) | Complexity-adaptive SDLC for ongoing changes — auto-detects ... | Must | evt-e3d2949e, evt-ca7b7d64, evt-da156299, evt-7620210f +1 | 225/225 → 12/12 | 2026-05-05 (iter) | FAIL |
+| [FR-01.11](../../.shipwright/planning/01-adopted/spec.md#fr-0111) | Complexity-adaptive SDLC for ongoing changes — auto-detects ... | Must | evt-e3d2949e, evt-ca7b7d64, evt-da156299, evt-7620210f +2 | 225/225 → 2519/2526 | 2026-05-16 (iter) | FAIL |
 | [FR-01.12](../../.shipwright/planning/01-adopted/spec.md#fr-0112) | Local browser preview — start dev server for the target proj... | May | evt-e3d2949e, evt-ca7b7d64 | 225/225 → 13/13 | 2026-05-03 (iter) | COVERED |
 | [FR-01.13](../../.shipwright/planning/01-adopted/spec.md#fr-0113) | Onboard an existing (brownfield) repository into the Shipwri... | Must | evt-e3d2949e, evt-273bbb54, evt-b0b9c422, evt-ca7b7d64 +2 | 225/225 → 1594/1628 | 2026-05-05 (iter) | FAIL |
 
@@ -52,6 +52,7 @@ Generated: 2026-05-16T10:46:57Z
 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI (rebased onto post-test-hygiene main; ADR renumbered 045→046) | iterate | feature |  | 1642/1649 | f638908 | 2026-05-11 |
 | Triage Inbox Iterate 2: 4 additional producers (security + performance + F0.5 + drift) wired into append_triage_item_idempotent. CI producer DEFERRED. ADR-047. | iterate | feature |  | 40/40 | aab9bd7 | 2026-05-14 |
 | RTM data collection: parse 6-column adopt FR tables + resolve shipwright_events.jsonl via git-common-dir for worktree finalization; fixes false 'Traceability coverage 0%' on adopted projects | iterate | bug | FR-01.10 | 312/312 | ea24bf4 | 2026-05-15 |
+| events.jsonl worktree-awareness: F7/verifier/dashboard resolve the log via git-common-dir; leak-guard exempts it; dashboard embeds run_id | iterate | bug | FR-01.11 | 2519/2526 | 34a7987 | 2026-05-16 |
 
 ## Coverage Summary
 
@@ -59,7 +60,7 @@ Generated: 2026-05-16T10:46:57Z
 |--------|-------|
 | Total splits built | 0 |
 | Build sections | 0 |
-| Iterate changes | 28 |
+| Iterate changes | 29 |
 | Requirements total | 13 |
 | Requirements verified | 13/13 |
 | Must-have verified | 10/10 |

--- a/CHANGELOG-unreleased.d/Fixed/iterate-2026-05-16-fix-adopt-review-config_001.md
+++ b/CHANGELOG-unreleased.d/Fixed/iterate-2026-05-16-fix-adopt-review-config_001.md
@@ -1,0 +1,1 @@
+shipwright-adopt no longer silently disables External Review for onboarded repos — shipwright_iterate_config.json is now seeded with external_review.feedback_iterations: 1, matching the shared default and greenfield projects

--- a/CHANGELOG-unreleased.d/Fixed/iterate-2026-05-16-fix-adopt-review-config_002.md
+++ b/CHANGELOG-unreleased.d/Fixed/iterate-2026-05-16-fix-adopt-review-config_002.md
@@ -1,0 +1,1 @@
+shipwright-adopt no longer writes the unused external_review_feedback_iterations key into adopt-generated shipwright_plan_config.json

--- a/plugins/shipwright-adopt/scripts/lib/config_writer.py
+++ b/plugins/shipwright-adopt/scripts/lib/config_writer.py
@@ -67,7 +67,6 @@ def write_plan_config(project_root: Path, *, split_name: str) -> Path:
             "has no planned sections — existing code is treated as retroactively complete. "
             "Use /shipwright-iterate for all future changes."
         ),
-        "external_review_feedback_iterations": 0,
         "updated_at": _utc_now_iso(),
     }
     path = project_root / "shipwright_plan_config.json"
@@ -104,15 +103,20 @@ def write_build_config(
 
 
 def write_iterate_config(project_root: Path) -> Path:
-    """Write shipwright_iterate_config.json with the documented opt-out schema.
+    """Write shipwright_iterate_config.json with the documented review schema.
 
     Schema (per plugins/shipwright-iterate/skills/iterate/references/iteration-reviews.md
     and plugins/shipwright-iterate/agents/sub-iterate-runner.md):
 
       - external_review.feedback_iterations: controls plan/iterate-mode external
-        LLM review. 0 = user_disabled (Branch C). Default 0 here mirrors the
-        flat key in write_plan_config — adopted projects opt out of plan/iterate-
-        mode review until the operator flips it on.
+        LLM review. Seeded to 1 — consistent with the shared default in
+        shared/config/external_review.json and with what /shipwright-project
+        seeds for greenfield projects (External Review on by default). Adopt
+        does NOT pre-emptively opt out: when no API key is set, the shared
+        resolver (get_external_review_status) returns "missing_keys", which
+        triggers an interactive prompt — the no-key case is already handled
+        correctly without a silent opt-out. A seed of 0 would instead resolve
+        to "user_disabled", a disguised opt-out the operator never chose.
       - external_code_review.enabled: controls the code-review CASCADE (an
         independent gate per iteration-reviews.md:191-194). Default true so
         the cascade runs by default; user flips to false at project level
@@ -120,7 +124,7 @@ def write_iterate_config(project_root: Path) -> Path:
     """
     config = {
         "external_review": {
-            "feedback_iterations": 0,
+            "feedback_iterations": 1,
         },
         "external_code_review": {
             "enabled": True,

--- a/plugins/shipwright-adopt/scripts/lib/dry_run_reporter.py
+++ b/plugins/shipwright-adopt/scripts/lib/dry_run_reporter.py
@@ -84,7 +84,7 @@ def plan_standard_writes(
         ProposedWrite("shipwright_project_config.json", "create", "splits + requirements"),
         ProposedWrite("shipwright_plan_config.json", "create", "adopted, empty sections"),
         ProposedWrite("shipwright_build_config.json", "create", "adopted-baseline section"),
-        ProposedWrite("shipwright_iterate_config.json", "create", "external_review.feedback_iterations=0, external_code_review.enabled=true"),
+        ProposedWrite("shipwright_iterate_config.json", "create", "external_review.feedback_iterations=1, external_code_review.enabled=true"),
         ProposedWrite("shipwright_compliance_config.json", "create", "seeded_by_adopt=true"),
         ProposedWrite("shipwright_run_config.json", "create", "status=complete, written LAST"),
         ProposedWrite("shipwright_events.jsonl", "create", "1x adopted event + backfilled commits"),

--- a/plugins/shipwright-adopt/skills/adopt/SKILL.md
+++ b/plugins/shipwright-adopt/skills/adopt/SKILL.md
@@ -783,7 +783,7 @@ write_iterate_config(Path('.'))
 ```
 
 This writes the config with the documented defaults
-(`external_review.feedback_iterations: 0`,
+(`external_review.feedback_iterations: 1`,
 `external_code_review.enabled: true`). Both fields are operator opt-out
 knobs — flip after the file exists, no re-adopt needed. The framework
 ignores the file's absence (defaults stay in effect), so this is purely

--- a/plugins/shipwright-adopt/tests/test_config_writer.py
+++ b/plugins/shipwright-adopt/tests/test_config_writer.py
@@ -1,9 +1,27 @@
 """Unit tests for config_writer.write_all."""
 
+import importlib.util
 import json
 from pathlib import Path
 
-from lib.config_writer import write_all, write_iterate_config
+from lib.config_writer import write_all, write_iterate_config, write_plan_config
+
+
+def _load_shared_resolver():
+    """Load shared/scripts/lib/external_review_config.py by file path.
+
+    Importing it as ``lib.external_review_config`` would collide with the
+    adopt plugin's own ``lib`` namespace package already pinned in
+    sys.modules by ``from lib.config_writer import ...`` (see ADR-045).
+    Loading by explicit file path side-steps the ``lib`` namespace entirely.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    mod_path = repo_root / "shared" / "scripts" / "lib" / "external_review_config.py"
+    spec = importlib.util.spec_from_file_location("external_review_config", mod_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_writes_all_configs_in_order(tmp_path: Path) -> None:
@@ -88,8 +106,9 @@ def test_no_sync_skips_sync_config(tmp_path: Path) -> None:
 def test_iterate_config_written_with_documented_schema(tmp_path: Path) -> None:
     """write_all must emit shipwright_iterate_config.json with the schema
     documented in iteration-reviews.md (external_review.feedback_iterations
-    + external_code_review.enabled). Defaults are conservative:
-    feedback_iterations=0 (matches plan-config opt-out), code-review
+    + external_code_review.enabled). Defaults match the framework:
+    feedback_iterations=1 (consistent with the shared default and what
+    greenfield /shipwright-project seeds — External Review on), code-review
     cascade enabled=true (cascade runs, user can flip off).
     """
     write_all(
@@ -104,9 +123,10 @@ def test_iterate_config_written_with_documented_schema(tmp_path: Path) -> None:
 
     iterate = json.loads(iterate_path.read_text(encoding="utf-8"))
 
-    # Schema: external_review.feedback_iterations (controls plan/iterate-mode review)
+    # Schema: external_review.feedback_iterations (controls plan/iterate-mode review).
+    # Seeded to 1 — consistent with the shared default and greenfield projects.
     assert "external_review" in iterate
-    assert iterate["external_review"]["feedback_iterations"] == 0
+    assert iterate["external_review"]["feedback_iterations"] == 1
 
     # Schema: external_code_review.enabled (controls code-review cascade — independent gate)
     assert "external_code_review" in iterate
@@ -162,6 +182,51 @@ def test_iterate_config_idempotent_overwrite(tmp_path: Path) -> None:
     assert first["external_review"] == second["external_review"]
     assert first["external_code_review"] == second["external_code_review"]
     assert first["seeded_by_adopt"] == second["seeded_by_adopt"]
+
+
+def test_iterate_config_external_review_not_user_disabled(tmp_path: Path) -> None:
+    """Boundary Probe (producer -> file on disk -> shared resolver consumer).
+
+    Defect-1 regression guard. write_iterate_config seeds
+    external_review.feedback_iterations; the shared resolver
+    (get_external_review_status) maps that to a three-way status. A seed of
+    0 resolves to "user_disabled" -> External Review is silently skipped — a
+    disguised opt-out the operator never chose. The adopt-seeded value MUST
+    resolve to a non-disabled status, consistent with the shared default
+    (shared/config/external_review.json) and greenfield /shipwright-project.
+    """
+    resolver = _load_shared_resolver()
+
+    # Producer -> file on disk.
+    write_iterate_config(tmp_path)
+
+    # Consumer: deep-merge the adopt-written config over the shared default.
+    merged = resolver.load_review_config(project_root=tmp_path)
+
+    # The seeded value is the enabled default (1), not the 0 opt-out.
+    assert merged["external_review"]["feedback_iterations"] == 1
+
+    # The resolver must NOT classify this as an explicit user opt-out.
+    status = resolver.get_external_review_status(merged)
+    assert status != "user_disabled", (
+        f"adopt-seeded iterate config resolves to {status!r} — a disguised "
+        "opt-out; expected 'available' or 'missing_keys'"
+    )
+    assert status in ("available", "missing_keys")
+
+
+def test_plan_config_omits_dead_external_review_key(tmp_path: Path) -> None:
+    """Defect-2 regression guard. write_plan_config used to emit a flat
+    "external_review_feedback_iterations" key into shipwright_plan_config.json.
+    The shared resolver only reads the nested external_review.feedback_iterations
+    from shipwright_iterate_config.json — the flat key had zero readers
+    repo-wide. It must not be written.
+    """
+    path = write_plan_config(tmp_path, split_name="01-adopted")
+    plan = json.loads(path.read_text(encoding="utf-8"))
+    assert "external_review_feedback_iterations" not in plan
+    # Defensive: no nested external_review block snuck in as a replacement either.
+    assert "external_review" not in plan
 
 
 def test_custom_completed_steps(tmp_path: Path) -> None:

--- a/shipwright_plan_config.json
+++ b/shipwright_plan_config.json
@@ -3,6 +3,5 @@
   "sections": [],
   "manifest": null,
   "note": "This project was adopted into Shipwright. Split '01-adopted' has no planned sections \u2014 existing code is treated as retroactively complete. Use /shipwright-iterate for all future changes.",
-  "external_review_feedback_iterations": 0,
   "updated_at": "2026-05-02T18:37:57.864025+00:00"
 }

--- a/shipwright_test_results.json
+++ b/shipwright_test_results.json
@@ -1,41 +1,36 @@
 {
   "iterate_latest": {
-    "run_id": "iterate-2026-05-16-fix-events-worktree-aware",
+    "run_id": "iterate-2026-05-16-fix-adopt-review-config",
     "date": "2026-05-16",
     "unit": {
       "status": "passed",
-      "passed": 2519,
-      "total": 2526,
-      "note": "F0 fresh full run, per-suite (separate 'tests' packages run separately): shared/tests 1760, shared/scripts/tests 172, shared/scripts/tools/tests 38, plugins/shipwright-iterate/tests 237, plugins/shipwright-compliance/tests 312. The 7 failures (test_hooks.py TestCheckSecrets x5 + TestCheckFileSize x1, test_artifact_path_canon.py compliance-migrated x1) reproduce identically on base origin/main — pre-existing baseline, 0 regressions from this iterate. F0 scope = the suites that consume the changed shared/scripts modules; the other 9 phase-plugin suites are no-op-affected (worktree-aware resolution is identity outside a worktree)."
+      "passed": 304,
+      "total": 304,
+      "note": "Full plugins/shipwright-adopt suite (270) + shared/tests/test_external_review_config.py resolver suite (34) — the producer and consumer halves of the changed shipwright_iterate_config.json boundary. 0 regressions."
     },
-    "integration": {
-      "status": "passed",
-      "passed": 110,
-      "total": 110,
-      "note": "integration-tests/ incl. new test_events_log_parity.py (3: shared resolver vs compliance data_collector agree on main/worktree/non-git). 2 deselected (slow marker)."
-    },
+    "integration": {"status": "not_run", "passed": 0, "total": 0, "note": "No CRUD/DB changes — config-writer default-value bugfix."},
     "pgtap": {"status": "not_run", "passed": 0, "total": 0, "note": "No SQL/RLS changes."},
     "e2e": {
       "status": "passed",
-      "passed": 81,
-      "total": 81,
-      "note": "F0.5 surface=cli — pytest over shared/tests/{test_events_log,test_events_log_ssot,test_verify_iterate_finalization,test_worktree_isolation_lib}.py. The boundary round-trip test inside test_verify_iterate_finalization.py drives producer record_event -> main log -> consumer verifier end-to-end."
+      "passed": 8,
+      "total": 8,
+      "note": "F0.5 surface=cli — pytest over plugins/shipwright-adopt/tests/test_config_writer.py. Includes test_iterate_config_external_review_not_user_disabled, the producer (write_iterate_config) -> file -> shared resolver (get_external_review_status) round-trip that drives the fixed boundary end-to-end."
     },
-    "design_fidelity": {"status": "not_run", "passed": 0, "total": 0, "note": "No UI — library/framework repo."},
+    "design_fidelity": {"status": "not_run", "passed": 0, "total": 0, "note": "No UI — Claude Code plugin monorepo."},
     "smoke": {"status": "not_run", "note": "No browser/server surface."},
     "surface_verification": {
       "surface": "cli",
-      "runner": "uv run --extra dev pytest shared/tests/test_events_log.py shared/tests/test_events_log_ssot.py shared/tests/test_verify_iterate_finalization.py shared/tests/test_worktree_isolation_lib.py -p no:cacheprovider",
+      "runner": "uv run --directory plugins/shipwright-adopt --extra dev pytest tests/test_config_writer.py --color=no",
       "exit_code": 0,
-      "tests_run": 81,
-      "evidence_path": ".shipwright/runs/iterate-2026-05-16-fix-events-worktree-aware/surface_verification.json",
-      "timestamp": "2026-05-16T10:36:07Z",
+      "tests_run": 8,
+      "evidence_path": ".shipwright/runs/iterate-2026-05-16-fix-adopt-review-config/surface_verification.log",
+      "timestamp": "2026-05-16T12:50:31.402Z",
       "attempts": 1,
-      "note": "Single shared/tests package — avoids the cross-tests-package collection collision; covers the worktree-aware helper, the drift meta-test, the F11 verifier worktree path + producer->consumer round-trip, and the leak-guard event-log exemption."
+      "note": "Boundary Probe (touches_io_boundary): the round-trip test feeds real write_iterate_config output through the real shared external_review_config resolver and asserts status != 'user_disabled'."
     },
     "degraded": [
-      "7 pre-existing baseline test failures on origin/main (test_hooks.py TestCheckSecrets x5 + TestCheckFileSize x1, test_artifact_path_canon.py compliance-migrated x1) — verified identical on the base commit, NOT introduced by this iterate.",
-      "External LLM review required enabling: shipwright_iterate_config.json carried the adopt-seeded external_review.feedback_iterations: 0 (opt-out); flipped to 1 (user-approved) so the medium-complexity external review could run."
+      "Pre-existing ruff F401 (unused typing.Any import) at plugins/shipwright-adopt/scripts/lib/dry_run_reporter.py:7 — present on base origin/main, NOT introduced by this iterate; left untouched to keep the bugfix diff focused.",
+      "test_nested_project_detector::test_detects_nested_shipwright_subproject failed initially in the fresh worktree: its fixture plugins/shipwright-adopt/tests/fixtures/nested-shipwright/webui/shipwright_run_config.json is gitignored (shipwright_*_config.json rule) and not carried into worktrees. Re-hydrated per SKILL B1a; full adopt suite then 270/270. See conventions.md Learnings."
     ]
   }
 }


### PR DESCRIPTION
## Bugfix — `shipwright-adopt` External-Review configuration

Two defects in `plugins/shipwright-adopt/scripts/lib/config_writer.py` that affected every repo onboarded via `/shipwright-adopt`.

### Defect 1 — silent, disguised External-Review opt-out
`write_iterate_config` seeded `shipwright_iterate_config.json` with `external_review.feedback_iterations: 0`. The shared resolver (`get_external_review_status`) maps `0` → status `user_disabled` → External Review is skipped with no message.

- `user_disabled` claims the operator opted out — they never did; Adopt did so unilaterally.
- Greenfield `/shipwright-project` seeds `1` (review on). Adopted repos got `0` — opposite defaults in the same tool family.
- The no-API-key case is already handled correctly: the resolver returns `missing_keys` → interactive prompt (Branch B). A pre-emptive opt-out was never needed.
- Brownfield code is higher-risk and benefits *more* from review.

**Fix:** seed `feedback_iterations: 1`, consistent with the shared default and greenfield. `external_code_review.enabled` stays `true`. Docstring corrected.

### Defect 2 — dead key in plan config
`write_plan_config` wrote a flat `external_review_feedback_iterations` key into `shipwright_plan_config.json`. A repo-wide grep confirmed **zero readers** — the resolver only consumes the nested `external_review.feedback_iterations` from `shipwright_iterate_config.json`.

**Fix:** removed the dead key. (Per-project plan-phase review steering would need a resolver extension — deliberately out of scope.)

### Also corrected
- Stale `=0` descriptions in `dry_run_reporter.py` and the adopt `SKILL.md`.
- The residual dead key in the monorepo's own `shipwright_plan_config.json`, so the key now appears nowhere except the regression test that guards it.

### Tests
- New `test_iterate_config_external_review_not_user_disabled` — producer→file→shared-resolver round-trip (Boundary Probe), asserts status ≠ `user_disabled`.
- New `test_plan_config_omits_dead_external_review_key` — guards Defect 2.
- Updated `test_iterate_config_written_with_documented_schema`.
- Both new tests fail before the fix, pass after (RED→GREEN verified).
- Full adopt suite 270/270, shared resolver suite 34/34. F0.5 surface=cli green.

Run-ID: iterate-2026-05-16-fix-adopt-review-config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
