### PR TITLE
fix(iterate): resolve decision-drop directory against the main repo (worktree-aware)

### DIFF
--- a/.shipwright/agent_docs/build_dashboard.md
+++ b/.shipwright/agent_docs/build_dashboard.md
@@ -1,10 +1,11 @@
 # Project Activity Dashboard
-> Updated: 2026-05-19 09:08 UTC | Session: 20d4584e-8a2e-48f1-9448-b325b5b63c7d | Run: iterate-2026-05-19-github-triage-importer
+> Updated: 2026-05-19 19:00 UTC | Session: d827c8c6-8c58-4f61-8cfe-cce6f9b7d878 | Run: iterate-2026-05-19-fix-decision-drop-worktree
 
-## Recent Changes (36 iterations)
+## Recent Changes (37 iterations)
 
 | Type | Description | Tests | Commit | FRs | Date |
 |------|-------------|-------|--------|-----|------|
+| feature | github-triage-importer | 1856/1856 | ff51a8c | FR-01.14 | 2026-05-19 |
 | change | phase-quality auditor recognises drop-dir changelog, adopted spec path, and iterate/adopt completion evidence (C1/C5/S1 check-side fixes) | 1817/1817 | 40599de |  | 2026-05-18 |
 | bug | harden activated CI workflows: scanners, CI-aware test, CodeQL guard | 337/340 | d85210f |  | 2026-05-18 |
 | bug | fix 17 launch-blocker test failures (Windows python3 stub + 6 smaller groups) | 3507/3507 | 21cef22 |  | 2026-05-18 |
@@ -43,7 +44,7 @@
 | change | post-adoption framework cleanup (Sub-1A through 1D) | 225/225 | 3db485b | FR-01.01, FR-01.02, FR-01.03 | 2026-05-02 |
 
 ## Test Status
-Last run: 2026-05-19 | Unit: 1856/1856 | Smoke: not_run | (iterate)
+Last run: 2026-05-19 | Unit: 1983/1983 | Smoke: not_run | (iterate)
 
 ## Pipeline
 

--- a/.shipwright/agent_docs/iterates/iterate-2026-05-19-fix-decision-drop-worktree.json
+++ b/.shipwright/agent_docs/iterates/iterate-2026-05-19-fix-decision-drop-worktree.json
@@ -1,0 +1,10 @@
+{
+  "run_id": "iterate-2026-05-19-fix-decision-drop-worktree",
+  "date": "2026-05-19T19:00:56.560106Z",
+  "type": "bug",
+  "complexity": "small",
+  "branch": "iterate/fix-decision-drop-worktree",
+  "spec": null,
+  "tests_passed": true,
+  "adr": "iterate-2026-05-19-fix-decision-drop-worktree"
+}

--- a/.shipwright/agent_docs/session_handoff.md
+++ b/.shipwright/agent_docs/session_handoff.md
@@ -1,44 +1,40 @@
 ---
 canon_generated: true
-run_id: "iterate-2026-05-19-github-triage-importer"
+run_id: "iterate-2026-05-19-fix-decision-drop-worktree"
 phase: "iterate"
-reason: "iterate: github-triage-importer"
-timestamp: "2026-05-19T09:08:25.731447+00:00"
+reason: "iterate: fix write_decision_drop.py worktree-awareness"
+timestamp: "2026-05-19T19:00:56.388503+00:00"
 ---
 
 # Session Handoff
 
-> Auto-generated 2026-05-19 09:08:25 UTC
+> Auto-generated 2026-05-19 19:00:56 UTC
 
 ## Session Info
 
-- **Session ID**: 20d4584e-8a2e-48f1-9448-b325b5b63c7d
-- **Timestamp**: 2026-05-19 09:08:25 UTC
-- **Reason**: iterate: github-triage-importer
+- **Session ID**: d827c8c6-8c58-4f61-8cfe-cce6f9b7d878
+- **Timestamp**: 2026-05-19 19:00:56 UTC
+- **Reason**: iterate: fix write_decision_drop.py worktree-awareness
 
 ## Last Iterate
 
-- **Run ID**: iterate-2026-05-18-phase-quality-check-fixes
-- **Date**: 2026-05-18T21:25:20.770866Z
-- **Type**: change
+- **Run ID**: iterate-2026-05-19-github-triage-importer
+- **Date**: 2026-05-19T09:08:25.909304Z
+- **Type**: feature
 - **Complexity**: medium
-- **Branch**: iterate/phase-quality-check-fixes
-- **ADR**: iterate-2026-05-18-phase-quality-check-fixes
+- **Branch**: iterate/github-triage-importer
+- **ADR**: iterate-2026-05-19-github-triage-importer
 - **Tests passed**: True
-- **Spec**: .shipwright/planning/iterate/2026-05-18-phase-quality-check-fixes.md
+- **Spec**: .shipwright/planning/iterate/2026-05-19-github-triage-importer.md
 
 ## Current Iterate Progress
 
-- **Branch**: iterate/github-triage-importer
-- **Run ID**: iterate-2026-05-19-github-triage-importer
-- **Spec**: .shipwright/planning/iterate/2026-05-19-github-triage-importer.md
-- **Complexity**: medium
-- **External Review Marker**: stale (predates spec (2026-05-18T20:58:58))
+- **Branch**: iterate/fix-decision-drop-worktree
+- **External Review Marker**: skipped_user_opt_out (external_review_state.json @ 2026-05-18T20:58:58)
 
 ### Mandatory replay on Resume
 
 Before dispatching to the handoff's Remaining phase, run these if missing:
-- Step 4 — External LLM Review (marker missing/stale)
 - Finalization (F0–F11) after all mandatory phases pass
 
 ## Legacy build state
@@ -52,8 +48,8 @@ Before dispatching to the handoff's Remaining phase, run these if missing:
 
 ## Git State
 
-- **Branch**: iterate/github-triage-importer
-- **Last Commit**: 4b50b75 Merge pull request #37 from svenroth-ai/iterate/phase-quality-check-fixes
+- **Branch**: iterate/fix-decision-drop-worktree
+- **Last Commit**: 44b28e7 Merge pull request #39 from svenroth-ai/iterate/github-triage-importer
 - **Uncommitted Changes**: Yes
 
 ## Config Files to Read
@@ -69,17 +65,17 @@ Before dispatching to the handoff's Remaining phase, run these if missing:
 
 | Event | Type | Source | Date |
 |-------|------|--------|------|
+| evt-c4e5298b | work_completed | iterate (github-triage-importer) | 2026-05-19 |
 | evt-9355640f | work_completed | iterate (phase-quality auditor recognises drop-dir changelog, adopted spec path, and iterate/adopt completion evidence (C1/C5/S1 check-side fixes)) | 2026-05-18 |
 | evt-51590a74 | work_completed | iterate (harden activated CI workflows: scanners, CI-aware test, CodeQL guard) | 2026-05-18 |
 | evt-7078b787 | work_completed | iterate (fix 17 launch-blocker test failures (Windows python3 stub + 6 smaller groups)) | 2026-05-18 |
 | evt-16154172 | work_completed | iterate (triage detector dedup + auto-resolve (rebased onto #31)) | 2026-05-16 |
-| evt-8659999c | work_completed | iterate (spec-impact classification gate: enforce ADD/MODIFY/REMOVE/NONE on every feature/change iterate (F7 record_event + F11 verifier gates, Group D5 audit, Removed Requirements convention)) | 2026-05-16 |
 
 ## Recovery
 
 - **Pipeline**: 1 phases completed
-- **Total work events**: 36
-- **Last iterate**: change — phase-quality auditor recognises drop-dir changelog, adopted spec path, and iterate/adopt completion evidence (C1/C5/S1 check-side fixes) (2026-05-18)
+- **Total work events**: 37
+- **Last iterate**: feature — github-triage-importer (2026-05-19)
 - **Resume**: `/shipwright-iterate` for next change, or `/shipwright-run` for new pipeline
 
 ## Recent Decisions

--- a/.shipwright/compliance/change-history.md
+++ b/.shipwright/compliance/change-history.md
@@ -1,15 +1,15 @@
 # Commit Change Log
 
-Generated: 2026-05-19T09:08:25Z
-Total commits: 665
+Generated: 2026-05-19T19:00:56Z
+Total commits: 667
 
 ## Commit Distribution
 
 ```mermaid
 pie title Commit Types
-    "feat" : 220
+    "feat" : 221
     "fix" : 175
-    "chore" : 114
+    "chore" : 115
     "docs" : 99
     "refactor" : 34
     "test" : 15
@@ -19,10 +19,11 @@ pie title Commit Types
 
 ## Changes by Type
 
-### Features (feat) — 220 commits
+### Features (feat) — 221 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-19 | triage | import GitHub findings into the triage inbox | ff51a8cc80f1 |
 | 2026-05-16 | spec | backfill FR-01.14 (Triage Inbox) + link 7 historical feature events | 805d268a9dc3 |
 | 2026-05-16 | iterate | enforce spec-impact classification on every feature/change iterate | 5544ea3b6e38 |
 | 2026-05-16 | iterate | unconditional worktree isolation for /shipwright-iterate | 42e65d7e0032 |
@@ -424,10 +425,11 @@ pie title Commit Types
 | 2026-03-21 | — | rename skill folders for clean slash commands | 5a8d77658fab |
 | 2026-03-20 | — | update README attribution to svenroth.ai | dd5de7f7d6ab |
 
-### Chores (chore) — 114 commits
+### Chores (chore) — 115 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-19 | — | remove gitignore entry for deleted triage handoff doc | 90af09980d93 |
 | 2026-05-18 | compliance | regenerate artefacts after launch-blocker fix iterate | a12455cc3128 |
 | 2026-05-18 | — | add CODE_OF_CONDUCT and activate CI workflows for public launch | 2671c69b9155 |
 | 2026-05-18 | — | scrub local identifiers for public release | b9d1d8564074 |
@@ -728,7 +730,7 @@ pie title Commit Types
 
 | Metric | Value |
 |--------|-------|
-| Total commits | 665 |
+| Total commits | 667 |
 | AI-assisted commits | 0 |
-| Human-authored commits | 665 |
+| Human-authored commits | 667 |
 

--- a/.shipwright/compliance/dashboard.md
+++ b/.shipwright/compliance/dashboard.md
@@ -1,6 +1,6 @@
 # Compliance Dashboard
 
-Generated: 2026-05-19T09:08:25Z
+Generated: 2026-05-19T19:00:56Z
 Profile: python-plugin-monorepo
 Scope: library
 
@@ -10,18 +10,18 @@ Scope: library
 |--------|-------|--------|
 | Pipeline phases completed | 1/7 | WARN |
 | Work events (build) | 0 sections | WARN |
-| Work events (iterate) | 36 changes | INFO |
-| All unit tests passing | 1817/1817 | PASS |
+| Work events (iterate) | 37 changes | INFO |
+| All unit tests passing | 1856/1856 | PASS |
 | All sections reviewed | 0/0 | WARN |
 | Architecture decisions | 53 ADRs | INFO |
-| Iterate tests passing | 34/36 iterations tested | WARN |
+| Iterate tests passing | 35/37 iterations tested | WARN |
 | Dependencies | 5 packages | INFO |
 | Copyleft risk | 0 | PASS |
 
 ## Project Velocity
 
-- Iterate: 36 changes (2026-05-02 → 2026-05-18)
-- Last activity: 2026-05-18
+- Iterate: 37 changes (2026-05-02 → 2026-05-19)
+- Last activity: 2026-05-19
 
 ## External LLM Review Evidence
 

--- a/.shipwright/compliance/sbom.md
+++ b/.shipwright/compliance/sbom.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-05-19T09:08:25Z
+Generated: 2026-05-19T19:00:56Z
 
 ## Summary
 

--- a/.shipwright/compliance/test-evidence.md
+++ b/.shipwright/compliance/test-evidence.md
@@ -1,53 +1,54 @@
 # Test Evidence Report
 
-Generated: 2026-05-19T09:08:25Z
+Generated: 2026-05-19T19:00:56Z
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total test checkpoints | 36 |
-| Total unit tests (latest) | 1817/1817 |
+| Total test checkpoints | 37 |
+| Total unit tests (latest) | 1856/1856 |
 | New tests from iterations | +19 |
 
 ## Test Progression
 
 | # | Event | Source | New Tests | Suite Total | Result | Date |
 |---|-------|--------|-----------|-------------|--------|------|
-| 1 | phase-quality auditor recognises drop-dir changelog, adopted spec path, and iterate/adopt completion evidence (C1/C5/S1 check-side fixes) | iterate | +0 | 1817/1817 | PASS | 2026-05-18 |
-| 2 | harden activated CI workflows: scanners, CI-aware test, CodeQL guard | iterate | +0 | 337/340 | FAIL | 2026-05-18 |
-| 3 | fix 17 launch-blocker test failures (Windows python3 stub + 6 smaller groups) | iterate | +0 | 3507/3507 | PASS | 2026-05-18 |
-| 4 | triage detector dedup + auto-resolve (rebased onto #31) | iterate | +0 | 1776/1783 | FAIL | 2026-05-16 |
-| 5 | spec-impact classification gate: enforce ADD/MODIFY/REMOVE/NONE on every feature/change iterate (F7 record_event + F11 verifier gates, Group D5 audit, Removed Requirements convention) | iterate | +0 | 140/140 | PASS | 2026-05-16 |
-| 6 | triage detector dedup + auto-resolve | iterate | +0 | 1776/1783 | FAIL | 2026-05-16 |
-| 7 | fix adopt external-review config defaults | iterate | +0 | 304/304 | PASS | 2026-05-16 |
-| 8 | events.jsonl worktree-awareness: F7/verifier/dashboard resolve the log via git-common-dir; leak-guard exempts it; dashboard embeds run_id | iterate | +0 | 2519/2526 | FAIL | 2026-05-16 |
-| 9 | RTM data collection: parse 6-column adopt FR tables + resolve shipwright_events.jsonl via git-common-dir for worktree finalization; fixes false 'Traceability coverage 0%' on adopted projects | iterate | +0 | 312/312 | PASS | 2026-05-15 |
-| 10 | Triage Inbox Iterate 2: 4 additional producers (security + performance + F0.5 + drift) wired into append_triage_item_idempotent. CI producer DEFERRED. ADR-047. | iterate | +0 | 40/40 | PASS | 2026-05-14 |
-| 11 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI (rebased onto post-test-hygiene main; ADR renumbered 045→046) | iterate | +0 | 1642/1649 | FAIL | 2026-05-11 |
-| 12 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI | iterate | +0 | 1642/1649 | FAIL | 2026-05-11 |
-| 13 | known_issues scanner requires comment context; remove dead save_session_config — 16/16 green | iterate | +0 | 16/16 | PASS | 2026-05-09 |
-| 14 | evt-f66286bf | iterate | +0 | — | — | 2026-05-07 |
-| 15 | evt-623a29ad | iterate | +0 | — | — | 2026-05-07 |
-| 16 | F0.5 empirical-test backfill | iterate | +0 | 1575/1575 | PASS | 2026-05-06 |
-| 17 | F0.5 End-to-End Verification Gate | iterate | +0 | 1548/1548 | PASS | 2026-05-06 |
-| 18 | hooks-consistency parser handles quoted commands — 27/27 green | iterate | +0 | 1297/1297 | PASS | 2026-05-06 |
-| 19 | post-migration canon cleanup — 9 tests green | iterate | +0 | 1270/1270 | PASS | 2026-05-06 |
-| 20 | loader deep-merges per-project shipwright_iterate_config.json + cascade helper | iterate | +0 | 34/34 | PASS | 2026-05-05 |
-| 21 | verifier accepts drop-dir entries + dashboard short-SHAs | iterate | +0 | 32/32 | PASS | 2026-05-05 |
-| 22 | adopt writes shipwright_iterate_config.json with documented opt-out schema | iterate | +0 | 241/241 | PASS | 2026-05-05 |
-| 23 | FR-table parser accepts 5-col adopt format + drift protection | iterate | +0 | 1594/1628 | FAIL | 2026-05-05 |
-| 24 | post-F7 housekeeping + AC-13 P5 fix (active install path) for plugin-hook-registration | iterate | +0 | 12/12 | PASS | 2026-05-05 |
-| 25 | plugin-owned suggest_iterate hook (ADR-030); retired hook_installer + 7 SKILL.md stanzas + A6 verifier | iterate | +0 | 1691/1716 | FAIL | 2026-05-05 |
-| 26 | F runner contract mandates reviews (ADR-029) | iterate | +0 | 188/188 | PASS | 2026-05-04 |
-| 27 | iterate: review-driven hardening (ADR-028 / campaign iterate-skill-hardening Sub-Iterate E) | iterate | +0 | 1539/1539 | PASS | 2026-05-04 |
-| 28 | test plugin: boundary coverage report (campaign iterate-skill-hardening Sub-Iterate D, ADR-027) | iterate | +19 | 19/19 | PASS | 2026-05-03 |
-| 29 | changelog MSYS path-mangling linter | iterate | +0 | 19/19 | PASS | 2026-05-03 |
-| 30 | hooks.json quoting (deferred from ADR-020) | iterate | +0 | 13/13 | PASS | 2026-05-03 |
-| 31 | iterate fix: parse_env_file inline-comment stripping + lib copy sync | iterate | +0 | 53/53 | PASS | 2026-05-03 |
-| 32 | iterate: adopt scaffolds .env.local with profile + framework keys (ADR-021) | iterate | +0 | 47/47 | PASS | 2026-05-03 |
-| 33 | suggest_iterate hook quoted-path + Shape A/B upgrade-in-place | iterate | +0 | 249/249 | PASS | 2026-05-03 |
-| 34 | fix hook_installer Shape A -> B | iterate | +0 | 5/5 | PASS | 2026-05-03 |
-| 35 | shipwright-adopt durable fixes (Sub-2A drift detection, 2B test-fixture filter, 2C compliance_bridge sys.path) | iterate | +0 | 233/233 | PASS | 2026-05-02 |
-| 36 | post-adoption framework cleanup (Sub-1A through 1D) | iterate | +0 | 225/225 | PASS | 2026-05-02 |
+| 1 | github-triage-importer | iterate | +0 | 1856/1856 | PASS | 2026-05-19 |
+| 2 | phase-quality auditor recognises drop-dir changelog, adopted spec path, and iterate/adopt completion evidence (C1/C5/S1 check-side fixes) | iterate | +0 | 1817/1817 | PASS | 2026-05-18 |
+| 3 | harden activated CI workflows: scanners, CI-aware test, CodeQL guard | iterate | +0 | 337/340 | FAIL | 2026-05-18 |
+| 4 | fix 17 launch-blocker test failures (Windows python3 stub + 6 smaller groups) | iterate | +0 | 3507/3507 | PASS | 2026-05-18 |
+| 5 | triage detector dedup + auto-resolve (rebased onto #31) | iterate | +0 | 1776/1783 | FAIL | 2026-05-16 |
+| 6 | spec-impact classification gate: enforce ADD/MODIFY/REMOVE/NONE on every feature/change iterate (F7 record_event + F11 verifier gates, Group D5 audit, Removed Requirements convention) | iterate | +0 | 140/140 | PASS | 2026-05-16 |
+| 7 | triage detector dedup + auto-resolve | iterate | +0 | 1776/1783 | FAIL | 2026-05-16 |
+| 8 | fix adopt external-review config defaults | iterate | +0 | 304/304 | PASS | 2026-05-16 |
+| 9 | events.jsonl worktree-awareness: F7/verifier/dashboard resolve the log via git-common-dir; leak-guard exempts it; dashboard embeds run_id | iterate | +0 | 2519/2526 | FAIL | 2026-05-16 |
+| 10 | RTM data collection: parse 6-column adopt FR tables + resolve shipwright_events.jsonl via git-common-dir for worktree finalization; fixes false 'Traceability coverage 0%' on adopted projects | iterate | +0 | 312/312 | PASS | 2026-05-15 |
+| 11 | Triage Inbox Iterate 2: 4 additional producers (security + performance + F0.5 + drift) wired into append_triage_item_idempotent. CI producer DEFERRED. ADR-047. | iterate | +0 | 40/40 | PASS | 2026-05-14 |
+| 12 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI (rebased onto post-test-hygiene main; ADR renumbered 045→046) | iterate | +0 | 1642/1649 | FAIL | 2026-05-11 |
+| 13 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI | iterate | +0 | 1642/1649 | FAIL | 2026-05-11 |
+| 14 | known_issues scanner requires comment context; remove dead save_session_config — 16/16 green | iterate | +0 | 16/16 | PASS | 2026-05-09 |
+| 15 | evt-f66286bf | iterate | +0 | — | — | 2026-05-07 |
+| 16 | evt-623a29ad | iterate | +0 | — | — | 2026-05-07 |
+| 17 | F0.5 empirical-test backfill | iterate | +0 | 1575/1575 | PASS | 2026-05-06 |
+| 18 | F0.5 End-to-End Verification Gate | iterate | +0 | 1548/1548 | PASS | 2026-05-06 |
+| 19 | hooks-consistency parser handles quoted commands — 27/27 green | iterate | +0 | 1297/1297 | PASS | 2026-05-06 |
+| 20 | post-migration canon cleanup — 9 tests green | iterate | +0 | 1270/1270 | PASS | 2026-05-06 |
+| 21 | loader deep-merges per-project shipwright_iterate_config.json + cascade helper | iterate | +0 | 34/34 | PASS | 2026-05-05 |
+| 22 | verifier accepts drop-dir entries + dashboard short-SHAs | iterate | +0 | 32/32 | PASS | 2026-05-05 |
+| 23 | adopt writes shipwright_iterate_config.json with documented opt-out schema | iterate | +0 | 241/241 | PASS | 2026-05-05 |
+| 24 | FR-table parser accepts 5-col adopt format + drift protection | iterate | +0 | 1594/1628 | FAIL | 2026-05-05 |
+| 25 | post-F7 housekeeping + AC-13 P5 fix (active install path) for plugin-hook-registration | iterate | +0 | 12/12 | PASS | 2026-05-05 |
+| 26 | plugin-owned suggest_iterate hook (ADR-030); retired hook_installer + 7 SKILL.md stanzas + A6 verifier | iterate | +0 | 1691/1716 | FAIL | 2026-05-05 |
+| 27 | F runner contract mandates reviews (ADR-029) | iterate | +0 | 188/188 | PASS | 2026-05-04 |
+| 28 | iterate: review-driven hardening (ADR-028 / campaign iterate-skill-hardening Sub-Iterate E) | iterate | +0 | 1539/1539 | PASS | 2026-05-04 |
+| 29 | test plugin: boundary coverage report (campaign iterate-skill-hardening Sub-Iterate D, ADR-027) | iterate | +19 | 19/19 | PASS | 2026-05-03 |
+| 30 | changelog MSYS path-mangling linter | iterate | +0 | 19/19 | PASS | 2026-05-03 |
+| 31 | hooks.json quoting (deferred from ADR-020) | iterate | +0 | 13/13 | PASS | 2026-05-03 |
+| 32 | iterate fix: parse_env_file inline-comment stripping + lib copy sync | iterate | +0 | 53/53 | PASS | 2026-05-03 |
+| 33 | iterate: adopt scaffolds .env.local with profile + framework keys (ADR-021) | iterate | +0 | 47/47 | PASS | 2026-05-03 |
+| 34 | suggest_iterate hook quoted-path + Shape A/B upgrade-in-place | iterate | +0 | 249/249 | PASS | 2026-05-03 |
+| 35 | fix hook_installer Shape A -> B | iterate | +0 | 5/5 | PASS | 2026-05-03 |
+| 36 | shipwright-adopt durable fixes (Sub-2A drift detection, 2B test-fixture filter, 2C compliance_bridge sys.path) | iterate | +0 | 233/233 | PASS | 2026-05-02 |
+| 37 | post-adoption framework cleanup (Sub-1A through 1D) | iterate | +0 | 225/225 | PASS | 2026-05-02 |
 

--- a/.shipwright/compliance/traceability-matrix.md
+++ b/.shipwright/compliance/traceability-matrix.md
@@ -1,6 +1,6 @@
 # Requirements Traceability Matrix
 
-Generated: 2026-05-19T09:08:25Z
+Generated: 2026-05-19T19:00:56Z
 
 ## Requirements Coverage
 
@@ -19,7 +19,7 @@ Generated: 2026-05-19T09:08:25Z
 | [FR-01.11](../../.shipwright/planning/01-adopted/spec.md#fr-0111) | Complexity-adaptive SDLC for ongoing changes — auto-detects ... | Must | evt-e3d2949e, evt-ca7b7d64, evt-da156299, evt-7620210f +5 | 225/225 → 140/140 | 2026-05-16 (iter) | FAIL |
 | [FR-01.12](../../.shipwright/planning/01-adopted/spec.md#fr-0112) | Local browser preview — start dev server for the target proj... | May | evt-e3d2949e, evt-ca7b7d64 | 225/225 → 13/13 | 2026-05-03 (iter) | COVERED |
 | [FR-01.13](../../.shipwright/planning/01-adopted/spec.md#fr-0113) | Onboard an existing (brownfield) repository into the Shipwri... | Must | evt-e3d2949e, evt-273bbb54, evt-b0b9c422, evt-aab7ddbd +3 | 225/225 → 1594/1628 | 2026-05-05 (iter) | FAIL |
-| [FR-01.14](../../.shipwright/planning/01-adopted/spec.md#fr-0114) | Pre-backlog triage buffer — findings from local hooks/scans/... | Must | evt-3f488ddc, evt-32f2f1f4, evt-84dbdf5e | 1642/1649 → 40/40 | 2026-05-14 (iter) | FAIL |
+| [FR-01.14](../../.shipwright/planning/01-adopted/spec.md#fr-0114) | Pre-backlog triage buffer — findings from local hooks/scans/... | Must | evt-3f488ddc, evt-32f2f1f4, evt-84dbdf5e, evt-c4e5298b | 1642/1649 → 1856/1856 | 2026-05-19 (iter) | FAIL |
 
 ## Verification Timeline
 
@@ -61,6 +61,7 @@ Generated: 2026-05-19T09:08:25Z
 | fix 17 launch-blocker test failures (Windows python3 stub + 6 smaller groups) | iterate | bug |  | 3507/3507 | 21cef22 | 2026-05-18 |
 | harden activated CI workflows: scanners, CI-aware test, CodeQL guard | iterate | bug |  | 337/340 | d85210f | 2026-05-18 |
 | phase-quality auditor recognises drop-dir changelog, adopted spec path, and iterate/adopt completion evidence (C1/C5/S1 check-side fixes) | iterate | change |  | 1817/1817 | 40599de | 2026-05-18 |
+| github-triage-importer | iterate | feature | FR-01.14 | 1856/1856 | ff51a8c | 2026-05-19 |
 
 ## Coverage Summary
 
@@ -68,7 +69,7 @@ Generated: 2026-05-19T09:08:25Z
 |--------|-------|
 | Total splits built | 0 |
 | Build sections | 0 |
-| Iterate changes | 36 |
+| Iterate changes | 37 |
 | Requirements total | 14 |
 | Requirements verified | 14/14 |
 | Must-have verified | 11/11 |

--- a/CHANGELOG-unreleased.d/Fixed/iterate-2026-05-19-fix-decision-drop-worktree_001.md
+++ b/CHANGELOG-unreleased.d/Fixed/iterate-2026-05-19-fix-decision-drop-worktree_001.md
@@ -1,0 +1,1 @@
+Iterate decision-drop ADRs are no longer lost on worktree cleanup — write_decision_drop, aggregate_decisions, and the F11 finalization verifier now resolve the decision-drops directory against the main repo (worktree-aware, mirroring resolve_events_path)

--- a/shared/scripts/lib/events_log.py
+++ b/shared/scripts/lib/events_log.py
@@ -14,6 +14,14 @@ reach the main log.
 directory even from inside a linked worktree, and its parent is the
 canonical project root that owns the event log.
 
+That git-common-dir resolution is exposed on its own as
+``resolve_main_repo_root`` — the generic worktree-aware primitive shared
+with the decision-drop directory resolver in
+``tools/write_decision_drop.py`` and ``tools/aggregate_decisions.py``. The
+decision-drop staging dir is repo-scoped for the same reason the event log
+is, and an iterate worktree's copy is discarded by ``git worktree remove``
+before ``/shipwright-changelog`` can aggregate it.
+
 Relationship to ``shipwright-compliance``'s
 ``data_collector._resolve_events_path``
 ----------------------------------------------------------------------
@@ -66,21 +74,26 @@ def _git_env() -> dict[str, str]:
     return env
 
 
-def resolve_events_path(project_root: Path | str) -> Path:
-    """Return the path to ``shipwright_events.jsonl``, git-worktree-aware.
+def resolve_main_repo_root(project_root: Path | str) -> Path | None:
+    """Return the MAIN repo's working-tree root, git-worktree-aware.
 
-    From inside a linked git worktree this resolves to the **main** repo's
-    event log; in a plain checkout — or when git is unavailable — it is
-    identical to ``project_root / EVENT_FILE`` (behavior unchanged).
+    From inside a linked git worktree this resolves to the **main** repo
+    root (the worktree's ``--git-common-dir`` parent); in a plain checkout
+    it is the repo's own top level. Returns ``None`` when ``project_root``
+    is not a git repository, or when git is unavailable / returns an
+    unexpected layout — callers then fall back to ``project_root`` itself.
 
     A ``warnings.warn`` diagnostic is emitted only when git is *broken*
-    (binary missing, timeout) or returns an *unexpected* layout. A plain
-    "not a git repository" answer is silent: that is a definitive,
-    no-data-loss result — a non-git project's log genuinely lives at
-    ``project_root / EVENT_FILE``.
+    (binary missing, timeout, empty / unexpected output). A plain "not a
+    git repository" answer returns ``None`` *silently*: that is a
+    definitive, no-data-loss result — a non-git project's artifacts
+    genuinely live next to ``project_root``.
+
+    Shared primitive behind :func:`resolve_events_path` and the
+    worktree-aware decision-drop directory resolver in
+    ``tools/write_decision_drop.py`` / ``tools/aggregate_decisions.py``.
     """
     project_root = Path(project_root)
-    fallback = project_root / EVENT_FILE
 
     try:
         proc = subprocess.run(
@@ -97,26 +110,28 @@ def resolve_events_path(project_root: Path | str) -> Path:
         # git binary missing / un-spawnable / hung — we cannot tell whether
         # this is a worktree, so a fallback here MAY be silent data loss.
         warnings.warn(
-            f"resolve_events_path: git unavailable for {project_root} "
-            f"({exc!r}) — falling back to {fallback}. An iterate worktree "
-            "run may write a throwaway event log.",
+            f"resolve_main_repo_root: git unavailable for {project_root} "
+            f"({exc!r}) — the caller falls back to {project_root} itself. "
+            "An iterate worktree run may write a throwaway, soon-discarded "
+            "artifact.",
             stacklevel=2,
         )
-        return fallback
+        return None
 
     if proc.returncode != 0:
         # Definitive "not a git repository" — the fallback is correct, not
         # a failure. Silent by design (non-git projects + test tmp dirs).
-        return fallback
+        return None
 
     common_dir = proc.stdout.strip()
     if not common_dir:
         warnings.warn(
-            f"resolve_events_path: `git rev-parse --git-common-dir` returned "
-            f"empty output in {project_root} — falling back to {fallback}.",
+            f"resolve_main_repo_root: `git rev-parse --git-common-dir` "
+            f"returned empty output in {project_root} — the caller falls "
+            f"back to {project_root} itself.",
             stacklevel=2,
         )
-        return fallback
+        return None
 
     common_path = Path(common_dir)
     if not common_path.is_absolute():
@@ -125,17 +140,32 @@ def resolve_events_path(project_root: Path | str) -> Path:
         common_path = (project_root / common_path).resolve()
 
     # `--git-common-dir` returns the MAIN repo's .git directory; its parent
-    # is the canonical project root that owns the event log. A linked
-    # worktree's *git-dir* is `.git/worktrees/<name>`, but its *common* dir
-    # is the top-level `.git` — so this is worktree-correct. Defensive: only
-    # trust a path that actually ends in ".git".
+    # is the canonical project root. A linked worktree's *git-dir* is
+    # `.git/worktrees/<name>`, but its *common* dir is the top-level `.git`
+    # — so this is worktree-correct. Defensive: only trust a path that
+    # actually ends in ".git".
     if common_path.name == ".git":
-        return common_path.parent / EVENT_FILE
+        return common_path.parent
 
     warnings.warn(
-        f"resolve_events_path: unexpected git-common-dir {str(common_path)!r} "
-        f"(not a `.git` directory) for {project_root} — falling back to "
-        f"{fallback}.",
+        f"resolve_main_repo_root: unexpected git-common-dir "
+        f"{str(common_path)!r} (not a `.git` directory) for {project_root} "
+        f"— the caller falls back to {project_root} itself.",
         stacklevel=2,
     )
-    return fallback
+    return None
+
+
+def resolve_events_path(project_root: Path | str) -> Path:
+    """Return the path to ``shipwright_events.jsonl``, git-worktree-aware.
+
+    From inside a linked git worktree this resolves to the **main** repo's
+    event log; in a plain checkout — or when git is unavailable — it is
+    identical to ``project_root / EVENT_FILE`` (behavior unchanged).
+
+    Thin derivation of :func:`resolve_main_repo_root` — see that function
+    for the git-resolution and ``warnings.warn`` diagnostic semantics.
+    """
+    project_root = Path(project_root)
+    main_root = resolve_main_repo_root(project_root)
+    return (main_root or project_root) / EVENT_FILE

--- a/shared/scripts/tools/aggregate_decisions.py
+++ b/shared/scripts/tools/aggregate_decisions.py
@@ -34,6 +34,7 @@ _SCRIPTS_ROOT = Path(__file__).resolve().parents[1]
 if str(_SCRIPTS_ROOT) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_ROOT))
 
+from lib.events_log import resolve_main_repo_root  # noqa: E402
 from lib.file_lock import LockTimeout, file_lock  # noqa: E402
 from tools.write_decision_log import (  # noqa: E402
     DECISION_LOG_HEADER,
@@ -51,7 +52,18 @@ class DecisionAggregatorError(RuntimeError):
 
 
 def drop_dir(project_root: Path) -> Path:
-    return project_root / ".shipwright" / "agent_docs" / DROP_DIRNAME
+    """Resolve ``.shipwright/agent_docs/decision-drops/``, git-worktree-aware.
+
+    Symmetric with ``write_decision_drop.drop_dir`` — the producer (iterate
+    F3) and the consumer (this aggregator) MUST agree on where the drop
+    files live, or aggregation silently misses them. See that function for
+    the worktree rationale. ``/shipwright-changelog`` runs the aggregator on
+    the main repo, so this resolves to ``project_root`` itself there; the
+    worktree-awareness keeps producer/consumer in lock step regardless.
+    """
+    project_root = Path(project_root)
+    root = resolve_main_repo_root(project_root) or project_root
+    return root / ".shipwright" / "agent_docs" / DROP_DIRNAME
 
 
 def _snapshot_drops(dd: Path) -> list[Path]:
@@ -93,6 +105,15 @@ def aggregate(
 ) -> dict:
     """Fold every decision-drop into ``decision_log.md``. Returns a summary."""
     project_root = Path(project_root).resolve()
+    # Deliberate asymmetry: ``dd`` (the gitignored decision-drop STAGING dir)
+    # is repo-scoped and resolved worktree-aware, exactly like the event log
+    # — a drop written from an iterate worktree lives next to the main repo.
+    # ``log_path`` (and architecture.md, via _append_architecture_update) is
+    # a TRACKED, committed artifact and stays ``project_root``-relative: it
+    # belongs to whichever checkout the aggregator is invoked on.
+    # ``/shipwright-changelog`` runs the aggregator on the main repo, so the
+    # two resolve to the same root in practice — but the distinction is
+    # load-bearing if the aggregator is ever invoked elsewhere.
     log_path = project_root / ".shipwright" / "agent_docs" / "decision_log.md"
     dd = drop_dir(project_root)
 

--- a/shared/scripts/tools/verifiers/iterate_checks.py
+++ b/shared/scripts/tools/verifiers/iterate_checks.py
@@ -29,7 +29,7 @@ _SCRIPTS_ROOT = Path(__file__).resolve().parents[2]
 if str(_SCRIPTS_ROOT) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_ROOT))
 
-from lib.events_log import resolve_events_path  # noqa: E402
+from lib.events_log import resolve_events_path, resolve_main_repo_root  # noqa: E402
 from lib.iterate_entry import (  # noqa: E402
     MIGRATION_QUARANTINED_COUNT_KEY,
     find_entry_by_run_id,
@@ -111,7 +111,13 @@ def check_adr_in_iterate_history(project_root: Path, run_id: str) -> CheckResult
     # match) so a run-id that merely starts with "adr-" is not misread as a
     # numbered ADR.
     if not re.fullmatch(r"(?i)ADR-\d+", adr_id.strip()):
-        drop_dir = project_root / ".shipwright" / "agent_docs" / "decision-drops"
+        # Worktree-aware: iterate F3 writes the decision-drop next to the
+        # MAIN repo (write_decision_drop.drop_dir), but this verifier runs
+        # at F11 with project_root = the iterate worktree. Resolve the drop
+        # dir against the main repo, or the pending-drop branch never
+        # matches and a freshly-written ADR is reported missing.
+        drop_root = resolve_main_repo_root(project_root) or project_root
+        drop_dir = drop_root / ".shipwright" / "agent_docs" / "decision-drops"
         if drop_dir.is_dir():
             safe = sanitize_run_id_for_filename(adr_id)
             if any(p.name.startswith(f"{safe}_") for p in drop_dir.glob("*.json")):

--- a/shared/scripts/tools/write_decision_drop.py
+++ b/shared/scripts/tools/write_decision_drop.py
@@ -43,6 +43,7 @@ _SCRIPTS_ROOT = Path(__file__).resolve().parents[1]
 if str(_SCRIPTS_ROOT) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_ROOT))
 
+from lib.events_log import resolve_main_repo_root  # noqa: E402
 from lib.iterate_entry import sanitize_run_id_for_filename  # noqa: E402
 
 DROP_DIRNAME = "decision-drops"  # under .shipwright/agent_docs/
@@ -55,7 +56,21 @@ class DecisionDropError(RuntimeError):
 
 
 def drop_dir(project_root: Path) -> Path:
-    return project_root / ".shipwright" / "agent_docs" / DROP_DIRNAME
+    """Resolve ``.shipwright/agent_docs/decision-drops/``, git-worktree-aware.
+
+    Iterate F3 runs inside an ephemeral worktree (unconditional isolation).
+    The worktree's drop dir is destroyed by ``git worktree remove`` before
+    ``/shipwright-changelog``'s ``aggregate_decisions.py`` can fold the drop
+    into ``decision_log.md`` — so the drop MUST be written next to the MAIN
+    repo, the directory the aggregator reads. In a plain checkout (or when
+    git is unavailable) this is identical to
+    ``project_root/.shipwright/agent_docs/decision-drops`` — behavior
+    unchanged. Mirrors ``lib.events_log.resolve_events_path``; kept in lock
+    step with ``aggregate_decisions.drop_dir`` (drift = silently lost ADRs).
+    """
+    project_root = Path(project_root)
+    root = resolve_main_repo_root(project_root) or project_root
+    return root / ".shipwright" / "agent_docs" / DROP_DIRNAME
 
 
 def _atomic_exclusive_write(target: Path, content: str) -> None:
@@ -177,7 +192,15 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
-    print(str(path.relative_to(Path(args.project_root).resolve())))
+    # The drop is written next to the MAIN repo (worktree-aware drop_dir),
+    # which is ABOVE --project-root when F3 runs inside an iterate worktree —
+    # `relative_to` would then raise ValueError. Show the path relative to
+    # --project-root when it is genuinely below it, else the absolute path.
+    try:
+        display = path.relative_to(Path(args.project_root).resolve())
+    except ValueError:
+        display = path
+    print(str(display))
     print(
         f"decision-drop written for run_id={args.run_id} — ADR-NNN assigned "
         "at /shipwright-changelog release time.",

--- a/shared/tests/conftest.py
+++ b/shared/tests/conftest.py
@@ -136,3 +136,37 @@ def git_origin_repo(tmp_path):
     _git(work, "push", "origin", "main")
     _git(work, "remote", "set-head", "origin", "main")
     return work, origin
+
+
+@pytest.fixture
+def make_worktree():
+    """Factory: ``make_worktree(work, slug)`` adds a linked git worktree.
+
+    Creates ``<work>/.worktrees/<slug>`` on branch ``iterate/<slug>`` from
+    ``main`` and returns its path. Shared by every worktree-isolation test
+    (events-log resolution, decision-drop resolution, finalization checks)
+    so the ``git worktree add`` invocation lives in exactly one place.
+    """
+    def _make(work: Path, slug: str) -> Path:
+        wt = work / ".worktrees" / slug
+        subprocess.run(
+            ["git", "-C", str(work), "worktree", "add", str(wt),
+             "-b", f"iterate/{slug}", "main"],
+            capture_output=True, text=True, check=True,
+        )
+        return wt
+
+    return _make
+
+
+@pytest.fixture
+def remove_worktree():
+    """Factory: ``remove_worktree(work, wt)`` tears a linked worktree down
+    the way iterate F11 cleanup (``git worktree remove --force``) does."""
+    def _remove(work: Path, wt: Path) -> None:
+        subprocess.run(
+            ["git", "-C", str(work), "worktree", "remove", "--force", str(wt)],
+            capture_output=True, text=True, check=True,
+        )
+
+    return _remove

--- a/shared/tests/test_aggregate_decisions.py
+++ b/shared/tests/test_aggregate_decisions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from tools.aggregate_decisions import aggregate
+from tools.aggregate_decisions import aggregate, drop_dir
 from tools.write_decision_drop import write_decision_drop
 
 
@@ -111,3 +111,14 @@ def test_architecture_impact_updates_architecture_md(tmp_path):
     _drop(tmp_path, "iterate-20260515-aaa", architecture_impact="component")
     aggregate(tmp_path)
     assert "ADR-001" in arch.read_text(encoding="utf-8")
+
+
+def test_drop_dir_resolves_main_repo_from_worktree(git_origin_repo, make_worktree):
+    """aggregate_decisions.drop_dir is worktree-aware — symmetric with
+    write_decision_drop.drop_dir, so the producer and the consumer never
+    disagree on where the drop files live."""
+    work, _ = git_origin_repo
+    wt = make_worktree(work, "agg-wt")
+    assert drop_dir(wt).resolve() == (
+        work / ".shipwright" / "agent_docs" / "decision-drops"
+    ).resolve()

--- a/shared/tests/test_decision_drop_ssot.py
+++ b/shared/tests/test_decision_drop_ssot.py
@@ -1,0 +1,145 @@
+"""SSoT drift-protection for decision-drop directory resolution.
+
+Iterate F3 writes one ADR JSON drop per run under
+``.shipwright/agent_docs/decision-drops/`` (``write_decision_drop.py``) and
+``/shipwright-changelog`` later folds them into ``decision_log.md``
+(``aggregate_decisions.py``). The drop dir is **repo-scoped**: an iterate run
+executes inside an ephemeral worktree whose copy ``git worktree remove``
+discards. Any code that may run from inside a worktree MUST resolve the drop
+dir against the MAIN repo via ``lib.events_log.resolve_main_repo_root`` — a
+raw ``project_root / ... / "decision-drops"`` join from inside a worktree
+reads/writes a throwaway copy.
+
+This meta-test mirrors ``test_events_log_ssot.py`` — the same registry-driven
+SSoT pattern (shipwright-iterate SKILL.md "Registry-driven SSoT meta-test
+rule"), in both directions:
+
+- Forward: every worktree-reachable decision-drop site uses the resolver.
+- Coverage: every raw decision-drop join in ``shared/scripts`` is either
+  worktree-aware or an allowlisted main-repo-only site (reason documented).
+- Reverse: every allowlist entry still exists and still has a raw join.
+
+Origin: every iterate ADR since unconditional worktree isolation was silently
+lost because ``write_decision_drop.py`` used a raw join — the verifier
+``iterate_checks.py`` shared the same latent bug
+(iterate-2026-05-19-fix-decision-drop-worktree).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SHARED_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+# Files that build a decision-drop path AND may run from inside an iterate
+# worktree — MUST resolve the dir worktree-aware via resolve_main_repo_root.
+_WORKTREE_REACHABLE = {
+    "tools/write_decision_drop.py",        # iterate F3 — the drop producer
+    "tools/verifiers/iterate_checks.py",   # iterate F11 finalization verifier
+}
+
+# Files that build a decision-drop path but run ONLY in main-repo phases,
+# where project_root is always the main repo so the raw join is correct.
+# If one of these is ever invoked from a worktree, move it to the resolver.
+_MAIN_REPO_ONLY = {
+    "tools/verifiers/common.py":
+        "C1/C4 phase-quality checks for build/adopt phase verifiers + the "
+        "Phase-Quality Stop hook — all run with project_root = main repo",
+}
+
+# NB: aggregate_decisions.py is the drop CONSUMER. /shipwright-changelog runs
+# it on the main repo, so it is not strictly worktree-reachable — but it
+# resolves the dir worktree-aware anyway to stay in lock step with the
+# producer (no producer/consumer drift). It therefore satisfies the coverage
+# check below as a worktree-aware file, and needs no allowlist entry.
+
+# A decision-drop path-join. Two shapes, because ``DROP_DIRNAME`` is an
+# ambiguous constant name — ``write_changelog_drop.py`` also defines a
+# ``DROP_DIRNAME`` (a DIFFERENT value, ``"CHANGELOG-unreleased.d"``):
+#   - the literal ``"decision-drops"`` path component — always a drop join;
+#   - ``/ DROP_DIRNAME``, but ONLY counted in a file that itself binds
+#     ``DROP_DIRNAME = "decision-drops"``.
+_LITERAL_JOIN_RE = re.compile(r"""/\s*\(?["']decision-drops["']""")
+_CONST_JOIN_RE = re.compile(r"/\s*\(?DROP_DIRNAME\b")
+_DECISION_DROP_CONST_RE = re.compile(
+    r"""DROP_DIRNAME\s*=\s*["']decision-drops["']"""
+)
+
+
+def _prod_py_files():
+    """All production .py under shared/scripts (test files excluded)."""
+    for p in sorted(_SHARED_SCRIPTS.rglob("*.py")):
+        rel = p.relative_to(_SHARED_SCRIPTS).as_posix()
+        if "/tests/" in f"/{rel}" or p.name.startswith("test_"):
+            continue
+        yield p, rel
+
+
+def _has_raw_join(path: Path) -> bool:
+    """True if the file builds a raw decision-drop path (ignoring # comments).
+
+    ``/ DROP_DIRNAME`` only counts when the file binds
+    ``DROP_DIRNAME = "decision-drops"`` — a same-named constant for an
+    unrelated drop dir (``write_changelog_drop.py``) must not match.
+    """
+    src = path.read_text(encoding="utf-8")
+    const_is_decision_drop = bool(_DECISION_DROP_CONST_RE.search(src))
+    for line in src.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        if _LITERAL_JOIN_RE.search(line):
+            return True
+        if const_is_decision_drop and _CONST_JOIN_RE.search(line):
+            return True
+    return False
+
+
+def test_worktree_reachable_drop_files_use_the_resolver():
+    """Forward: every worktree-reachable decision-drop site resolves the dir
+    via resolve_main_repo_root — never a raw worktree-local join."""
+    for rel in sorted(_WORKTREE_REACHABLE):
+        path = _SHARED_SCRIPTS / rel
+        assert path.exists(), f"_WORKTREE_REACHABLE entry {rel} no longer exists"
+        src = path.read_text(encoding="utf-8")
+        assert "resolve_main_repo_root" in src, (
+            f"{rel} builds a decision-drop path and is reached from inside an "
+            "iterate worktree, but does not resolve it via "
+            "events_log.resolve_main_repo_root — it would read/write a "
+            "throwaway worktree copy that `git worktree remove` discards."
+        )
+
+
+def test_no_unaccounted_raw_decision_drop_joins():
+    """Coverage: every raw decision-drop join in shared/scripts is either
+    worktree-aware (resolve_main_repo_root) or allowlisted main-repo-only."""
+    violations = []
+    for path, rel in _prod_py_files():
+        if not _has_raw_join(path):
+            continue
+        if "resolve_main_repo_root" in path.read_text(encoding="utf-8"):
+            continue  # worktree-aware — raw join is resolved against main repo
+        if rel in _MAIN_REPO_ONLY:
+            continue  # allowlisted; reason documented in _MAIN_REPO_ONLY
+        violations.append(rel)
+    assert not violations, (
+        "Raw `project_root / ... / decision-drops` join(s) in files that are "
+        f"neither worktree-aware nor allowlisted main-repo-only: {violations}. "
+        "Resolve the dir via events_log.resolve_main_repo_root, or — if the "
+        "file only ever runs in a main-repo phase — add it to _MAIN_REPO_ONLY "
+        "with a reason."
+    )
+
+
+def test_main_repo_only_allowlist_not_stale():
+    """Reverse: every _MAIN_REPO_ONLY entry still exists and still has a raw
+    decision-drop join — a file migrated to the resolver must be dropped."""
+    for rel in sorted(_MAIN_REPO_ONLY):
+        path = _SHARED_SCRIPTS / rel
+        assert path.exists(), (
+            f"_MAIN_REPO_ONLY entry {rel} no longer exists — drop it."
+        )
+        assert _has_raw_join(path), (
+            f"_MAIN_REPO_ONLY entry {rel} no longer builds a raw "
+            "decision-drop path — it was migrated; drop it from the allowlist."
+        )

--- a/shared/tests/test_events_log.py
+++ b/shared/tests/test_events_log.py
@@ -8,24 +8,17 @@ common-dir math must be verified on an actual linked worktree.
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
 
 import pytest
 
-from lib.events_log import EVENT_FILE, resolve_events_path
+from lib.events_log import (
+    EVENT_FILE,
+    resolve_events_path,
+    resolve_main_repo_root,
+)
 
-
-def _add_worktree(work: Path, slug: str) -> Path:
-    """Create a linked worktree under .worktrees/<slug> from local main."""
-    wt = work / ".worktrees" / slug
-    subprocess.run(
-        [
-            "git", "-C", str(work), "worktree", "add", str(wt),
-            "-b", f"iterate/{slug}", "main",
-        ],
-        capture_output=True, text=True, check=True,
-    )
-    return wt
+# Linked worktrees are created via the shared ``make_worktree`` fixture
+# (shared/tests/conftest.py).
 
 
 def test_main_repo_identity(git_origin_repo):
@@ -35,11 +28,11 @@ def test_main_repo_identity(git_origin_repo):
     assert resolved.resolve() == (work / EVENT_FILE).resolve()
 
 
-def test_worktree_resolves_to_main_log(git_origin_repo):
+def test_worktree_resolves_to_main_log(git_origin_repo, make_worktree):
     """From inside a linked worktree the log resolves to the MAIN repo —
     NOT the throwaway worktree copy that `git worktree remove` discards."""
     work, _ = git_origin_repo
-    wt = _add_worktree(work, "probe")
+    wt = make_worktree(work, "probe")
     resolved = resolve_events_path(wt)
     assert resolved.resolve() == (work / EVENT_FILE).resolve()
     assert resolved.resolve() != (wt / EVENT_FILE).resolve()
@@ -47,11 +40,11 @@ def test_worktree_resolves_to_main_log(git_origin_repo):
     assert resolved.parent.resolve() == work.resolve()
 
 
-def test_worktree_nested_path_resolved(git_origin_repo):
+def test_worktree_nested_path_resolved(git_origin_repo, make_worktree):
     """A worktree several levels under .worktrees/ still resolves cleanly
     (relative `--git-common-dir` output with `..` segments)."""
     work, _ = git_origin_repo
-    wt = _add_worktree(work, "deep-slug")
+    wt = make_worktree(work, "deep-slug")
     resolved = resolve_events_path(wt)
     assert resolved.resolve() == (work / EVENT_FILE).resolve()
 
@@ -132,3 +125,50 @@ def test_str_project_root_accepted(git_origin_repo):
     work, _ = git_origin_repo
     resolved = resolve_events_path(str(work))
     assert resolved.resolve() == (work / EVENT_FILE).resolve()
+
+
+# ---------------------------------------------------------------------------
+# resolve_main_repo_root — the generic git-worktree-aware primitive that both
+# resolve_events_path and write_decision_drop.drop_dir derive from.
+# ---------------------------------------------------------------------------
+
+
+def test_main_repo_root_plain_repo(git_origin_repo):
+    """In a plain checkout the main-repo root is the repo root itself."""
+    work, _ = git_origin_repo
+    assert resolve_main_repo_root(work).resolve() == work.resolve()
+
+
+def test_main_repo_root_from_worktree(git_origin_repo, make_worktree):
+    """From inside a linked worktree it resolves to the MAIN repo root —
+    NOT the ephemeral worktree that `git worktree remove` discards."""
+    work, _ = git_origin_repo
+    wt = make_worktree(work, "mrr-probe")
+    assert resolve_main_repo_root(wt).resolve() == work.resolve()
+
+
+def test_main_repo_root_non_git_returns_none_silently(tmp_path, recwarn):
+    """A non-git directory yields None SILENTLY — `git rev-parse` returncode
+    != 0 is a definitive 'not a repo', so callers fall back without a warning
+    that would spam every non-git project."""
+    assert resolve_main_repo_root(tmp_path) is None
+    assert len(recwarn) == 0
+
+
+def test_main_repo_root_git_unavailable_warns_then_none(tmp_path, monkeypatch):
+    """A broken/absent git binary warns before returning None — silent data
+    loss in a worktree run must stay visible. Exactly one diagnostic — a
+    second would mean a duplicated warn path."""
+    def _boom(*_args, **_kwargs):
+        raise OSError("git: command not found")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    with pytest.warns(UserWarning, match="git unavailable") as rec:
+        assert resolve_main_repo_root(tmp_path) is None
+    assert len(rec) == 1
+
+
+def test_main_repo_root_str_project_root_accepted(git_origin_repo):
+    """Accepts a str project_root, not only a Path."""
+    work, _ = git_origin_repo
+    assert resolve_main_repo_root(str(work)).resolve() == work.resolve()

--- a/shared/tests/test_verify_iterate_finalization.py
+++ b/shared/tests/test_verify_iterate_finalization.py
@@ -14,15 +14,8 @@ from pathlib import Path
 import pytest
 
 
-def _add_worktree(work: Path, slug: str) -> Path:
-    """Create a linked worktree under <work>/.worktrees/<slug> from main."""
-    wt = work / ".worktrees" / slug
-    subprocess.run(
-        ["git", "-C", str(work), "worktree", "add", str(wt),
-         "-b", f"iterate/{slug}", "main"],
-        capture_output=True, text=True, check=True,
-    )
-    return wt
+# Linked worktrees come from the shared ``make_worktree`` fixture
+# (shared/tests/conftest.py).
 
 
 def _agent_docs_root(tmp: Path) -> Path:
@@ -147,7 +140,7 @@ def test_events_fails_when_file_missing(tmp_path):
     assert result.ok is False
 
 
-def test_events_check_resolves_main_log_from_worktree(git_origin_repo):
+def test_events_check_resolves_main_log_from_worktree(git_origin_repo, make_worktree):
     """check_events_has_commit run from inside an iterate worktree must read
     the MAIN repo's event log — that is where F7 records the commit."""
     work, _ = git_origin_repo
@@ -155,12 +148,12 @@ def test_events_check_resolves_main_log_from_worktree(git_origin_repo):
         json.dumps({"type": "work_completed", "commit": "ma1nc0m"}) + "\n",
         encoding="utf-8",
     )
-    wt = _add_worktree(work, "probe")
+    wt = make_worktree(work, "probe")
     result = check_events_has_commit(wt, "ma1nc0m")
     assert result.ok is True
 
 
-def test_boundary_roundtrip_worktree_producer_to_verifier(git_origin_repo):
+def test_boundary_roundtrip_worktree_producer_to_verifier(git_origin_repo, make_worktree):
     """AC-6 boundary round-trip: an event WRITTEN from a worktree via
     record_event is READ BACK by the F11 verifier from that same worktree —
     both resolve the one canonical main-repo log. This pins producer and
@@ -168,7 +161,7 @@ def test_boundary_roundtrip_worktree_producer_to_verifier(git_origin_repo):
     from tools.record_event import append_event
 
     work, _ = git_origin_repo
-    wt = _add_worktree(work, "probe")
+    wt = make_worktree(work, "probe")
     append_event(wt, {"v": 1, "id": "evt-rt000001", "ts": "T",
                       "type": "work_completed", "source": "iterate",
                       "commit": "r0undtr1p"})
@@ -238,6 +231,34 @@ def test_adr_check_passes_with_pending_decision_drop(tmp_path):
     drops.mkdir(parents=True)
     (drops / "iterate-20260515-x_001.json").write_text("{}")
     result = check_adr_in_iterate_history(proj, "iterate-20260515-x")
+    assert result.ok is True
+    assert "decision-drop" in result.detail
+
+
+def test_adr_check_finds_decision_drop_in_main_repo_from_worktree(
+    git_origin_repo, make_worktree
+):
+    """F11 reality: check_adr_in_iterate_history runs with project_root = the
+    iterate worktree, but write_decision_drop writes the drop next to the
+    MAIN repo. The verifier must resolve the drop dir against the main repo
+    too — otherwise a freshly-written ADR is reported missing at F11."""
+    from tools.write_decision_drop import write_decision_drop
+
+    work, _ = git_origin_repo
+    run_id = "iterate-20260519-wt-adr"
+    wt = make_worktree(work, "wt-adr")
+    (wt / ".shipwright" / "agent_docs").mkdir(parents=True, exist_ok=True)
+    # F5c writes the iterate_history entry into the worktree (project_root).
+    (wt / "shipwright_run_config.json").write_text(
+        json.dumps({"iterate_history": [{"run_id": run_id, "adr": run_id}]}),
+        encoding="utf-8",
+    )
+    # F3 writes the decision-drop — worktree-aware, lands next to the MAIN repo.
+    write_decision_drop(
+        wt, run_id=run_id, section="Iterate — bug: x", title="x",
+        context="c", decision="d", consequences="k",
+    )
+    result = check_adr_in_iterate_history(wt, run_id)
     assert result.ok is True
     assert "decision-drop" in result.detail
 

--- a/shared/tests/test_write_decision_drop.py
+++ b/shared/tests/test_write_decision_drop.py
@@ -6,11 +6,16 @@ import json
 
 import pytest
 
+from tools.aggregate_decisions import aggregate
+from tools.aggregate_decisions import drop_dir as aggregate_drop_dir
 from tools.write_decision_drop import (
     DecisionDropError,
     drop_dir,
     write_decision_drop,
 )
+
+# Linked worktrees come from the shared ``make_worktree`` / ``remove_worktree``
+# fixtures (shared/tests/conftest.py).
 
 
 def _fields(**over):
@@ -73,3 +78,83 @@ def test_optional_fields_persisted(tmp_path):
     assert data["rationale"] == "because"
     assert data["rejected"] == "alt-a"
     assert data["architecture_impact"] == "convention"
+
+
+# ---------------------------------------------------------------------------
+# Worktree-awareness — iterate F3 runs inside an ephemeral worktree whose
+# .shipwright/agent_docs/decision-drops/ is destroyed by `git worktree
+# remove` before /shipwright-changelog can aggregate it. The drop MUST land
+# next to the MAIN repo. Mirrors lib.events_log.resolve_events_path.
+# ---------------------------------------------------------------------------
+
+
+def _main_drops(work):
+    return (work / ".shipwright" / "agent_docs" / "decision-drops").resolve()
+
+
+def test_drop_dir_plain_repo_is_repo_local(git_origin_repo):
+    """In a plain checkout drop_dir is repo-local — behavior unchanged."""
+    work, _ = git_origin_repo
+    assert drop_dir(work).resolve() == _main_drops(work)
+
+
+def test_drop_written_from_worktree_lands_in_main_repo(git_origin_repo, make_worktree):
+    """Core bug: F3 runs inside an iterate worktree; the drop must be written
+    to the MAIN repo, not the worktree copy."""
+    work, _ = git_origin_repo
+    wt = make_worktree(work, "drop-loc")
+    path = write_decision_drop(wt, **_fields())
+    assert path.resolve().parent == _main_drops(work)
+    # NOT inside the worktree — that copy dies with `git worktree remove`.
+    assert wt.resolve() not in path.resolve().parents
+
+
+def test_drop_survives_worktree_removal(git_origin_repo, make_worktree, remove_worktree):
+    """The round-trip the bug broke: a drop written from inside the worktree
+    must still exist after `git worktree remove` tears the worktree down."""
+    work, _ = git_origin_repo
+    wt = make_worktree(work, "drop-survive")
+    path = write_decision_drop(wt, **_fields())
+    assert path.exists()
+    remove_worktree(work, wt)
+    assert path.exists(), (
+        "decision-drop destroyed with the worktree — aggregate_decisions "
+        "would never fold it into decision_log.md"
+    )
+
+
+def test_drop_from_worktree_is_aggregated_from_main_repo(
+    git_origin_repo, make_worktree, remove_worktree
+):
+    """End-to-end producer->file->consumer round-trip across the worktree
+    boundary: F3 writes the drop from the worktree, the worktree is removed
+    (F11 cleanup), then /shipwright-changelog's aggregate runs on the MAIN
+    repo and must still see and fold the drop into decision_log.md."""
+    work, _ = git_origin_repo
+    wt = make_worktree(work, "drop-agg")
+    write_decision_drop(wt, **_fields(run_id="iterate-20260519-probe"))
+    remove_worktree(work, wt)
+    result = aggregate(work)
+    assert result["aggregated"] == 1
+    log = (
+        work / ".shipwright" / "agent_docs" / "decision_log.md"
+    ).read_text(encoding="utf-8")
+    assert "iterate-20260519-probe" in log
+
+
+@pytest.mark.parametrize("root_kind", ["plain", "worktree", "non-git"])
+def test_drop_dir_producer_consumer_parity(
+    git_origin_repo, tmp_path, make_worktree, root_kind
+):
+    """Drift protection (NOT a correctness test): write_decision_drop.drop_dir
+    (producer) and aggregate_decisions.drop_dir (consumer) must resolve the
+    SAME directory for the same input — divergence = silently lost ADRs.
+    That the resolved directory is *correct* is covered separately by
+    test_drop_dir_plain_repo_is_repo_local and
+    test_drop_written_from_worktree_lands_in_main_repo."""
+    if root_kind == "non-git":
+        root = tmp_path
+    else:
+        work, _ = git_origin_repo
+        root = work if root_kind == "plain" else make_worktree(work, "parity")
+    assert drop_dir(root).resolve() == aggregate_drop_dir(root).resolve()

--- a/shipwright_test_results.json
+++ b/shipwright_test_results.json
@@ -1,30 +1,33 @@
 {
   "iterate_latest": {
-    "run_id": "iterate-2026-05-19-github-triage-importer",
+    "run_id": "iterate-2026-05-19-fix-decision-drop-worktree",
     "date": "2026-05-19",
     "unit": {
       "status": "passed",
-      "passed": 1856,
-      "total": 1856,
-      "note": "Full shared/tests/ suite (F0) — medium FEATURE, GitHub findings triage producer. 1856 passed, 11 skipped, 0 failed. 34 new tests in test_github_triage.py. The run also fixed a pre-existing F0 failure inherited from origin/main (test_no_legacy_artifact_paths[planning-migrated]) — a self-referential canon-lint trip on conventions.md from iterate-2026-05-18; conventions.md added to ALLOWLIST in artifact_migrations.py."
+      "passed": 1983,
+      "total": 1983,
+      "note": "Combined F0 suite (shared/tests/ + integration-tests/) — 1983 passed, 11 skipped, 20 slow deselected, 0 failed. touches_shared_infra risk flag enforced the full suite. New tests: 5 resolve_main_repo_root cases, 7 decision-drop worktree/round-trip/parity cases, 1 verifier worktree case, 3 SSoT meta-tests."
     },
-    "integration": {"status": "not_run", "passed": 0, "total": 0, "note": "No CRUD/DB changes — pure Python producer + hook."},
-    "pgtap": {"status": "not_run", "passed": 0, "total": 0, "note": "No SQL/RLS changes."},
+    "integration": {
+      "status": "passed",
+      "passed": 0,
+      "total": 0,
+      "note": "integration-tests/ ran within the combined F0 unit run above and are all green — incl. test_events_log_parity.py (cross-plugin resolver parity, the drift-guard for the refactored resolve_events_path). Not counted separately."
+    },
+    "pgtap": {"status": "not_run", "passed": 0, "total": 0, "note": "No SQL/RLS changes — Python framework repo."},
     "e2e": {"status": "not_run", "passed": 0, "total": 0, "note": "No web/Playwright surface — library/framework repo. The cli surface is verified below (surface_verification)."},
     "design_fidelity": {"status": "not_run", "passed": 0, "total": 0, "note": "No UI."},
     "smoke": {"status": "not_run", "note": "No browser/server surface."},
     "surface_verification": {
       "surface": "cli",
-      "runner": "uv run --with pytest pytest shared/tests/test_github_triage.py -q --color=no",
+      "runner": "uv run --extra dev pytest shared/tests/test_write_decision_drop.py shared/tests/test_aggregate_decisions.py shared/tests/test_events_log.py shared/tests/test_decision_drop_ssot.py shared/tests/test_verify_iterate_finalization.py -q",
       "exit_code": 0,
-      "tests_run": 34,
-      "evidence_path": ".shipwright/runs/iterate-2026-05-19-github-triage-importer/surface_verification.log",
-      "timestamp": "2026-05-19T09:02:25.640Z",
+      "tests_run": 100,
+      "evidence_path": ".shipwright/runs/iterate-2026-05-19-fix-decision-drop-worktree/surface_verification.log",
+      "timestamp": "2026-05-19T18:56:09.888Z",
       "attempts": 1,
-      "note": "F0.5 cli surface — 34 tests for the GitHub triage importer (github_api + github_triage + the SessionStart hook), exit 0."
+      "note": "F0.5 cli surface — 100 tests driving the producer->file->consumer->verifier chain through real git worktrees (write_decision_drop from a worktree -> drop in the main repo -> aggregate_decisions folds it -> check_adr_in_iterate_history finds it), exit 0."
     },
-    "degraded": [
-      "External LLM review skipped — no API keys (openrouter/gemini/openai absent). Degraded Branch B Option 2: mandatory self-review (7/7) + internal code-reviewer subagent used instead; 5 review findings (MEDIUM-1/2/3, LOW-4/5) addressed before commit."
-    ]
+    "degraded": []
   }
 }


### PR DESCRIPTION
## Summary

Since unconditional worktree isolation (ADR-049), iterate F3 runs inside an ephemeral git worktree. `write_decision_drop.py` resolved the `decision-drops/` directory off `project_root` directly, so the drop landed in the worktree and was destroyed by `git worktree remove` before `/shipwright-changelog` could aggregate it — **every iterate ADR since ADR-049 was silently lost** from `decision_log.md`.

## Changes

- **`lib/events_log.py`** — extract `resolve_main_repo_root` (the git-common-dir primitive); `resolve_events_path` now derives from it (behavior-preserving — cross-plugin parity test green).
- **`write_decision_drop.py`** / **`aggregate_decisions.py`** — `drop_dir()` resolves the decision-drops directory against the MAIN repo; `main()` no longer crashes when the drop lands above `--project-root`.
- **`verifiers/iterate_checks.py`** — the F11 verifier `check_adr_in_iterate_history` resolves the drop dir worktree-aware too (surfaced during code review — it would otherwise fail F11 for every worktree run).
- **`test_decision_drop_ssot.py`** (new) — SSoT meta-test guarding every decision-drop path join (forward / coverage / reverse).
- Worktree test helpers consolidated into a shared `make_worktree` / `remove_worktree` conftest fixture.

`decision_log.md` and `architecture.md` stay `project_root`-relative (tracked, per-checkout artifacts). Non-git / broken-git callers fall back to `project_root` (behavior unchanged). The `decision-drops/` gitignore is unchanged.

## Verification

- Full suite: **1983 passed**, 11 skipped, 0 failed (`touches_shared_infra` → full suite).
- F0.5 cli surface: **100 tests** driving the producer→file→consumer→verifier chain through real git worktrees.
- Dogfooded — this run's own F3 decision-drop correctly landed in the main repo and survived worktree cleanup.

Run-ID: iterate-2026-05-19-fix-decision-drop-worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)