### PR TITLE
feat(adopt): Mermaid architecture diagram + drift-sync marker (Iterate A.1)

### DIFF
--- a/.shipwright/agent_docs/architecture.md
+++ b/.shipwright/agent_docs/architecture.md
@@ -1,43 +1,31 @@
 # Architecture — shipwright
+<!-- shipwright:architecture v=2 last-sync=932e0d221ea1 -->
 
 ## System Overview
 
-+----------------------------------------------------------+
-| Claude Code (host)                                       |
-|   loads plugins from ~/.claude/plugins/cache/shipwright/ |
-+----------------------------------------------------------+
-        |
-        v
-+---------------------+    +--------------------------------+
-| plugins/            |    | shared/                        |
-|   shipwright-run    |--->|   scripts/  (lib, tools, hooks)|
-|   shipwright-project|--->|   profiles/ (stack + deploy)   |
-|   shipwright-plan   |--->|   templates/                   |
-|   shipwright-design |--->|   prompts/  (review prompts)   |
-|   shipwright-build  |--->|   config/   (defaults)         |
-|   shipwright-test   |    +--------------------------------+
-|   shipwright-security|              ^
-|   shipwright-deploy |               | reads/writes
-|   shipwright-changelog              |
-|   shipwright-compliance ------------+
-|   shipwright-iterate |
-|   shipwright-preview |
-|   shipwright-adopt   |
-+---------------------+
-        |
-        | writes/reads in target project
-        v
-+----------------------------------------------------------+
-| Target project                                           |
-|   CLAUDE.md                                              |
-|   shipwright_*_config.json (run, project, plan, build,   |
-|                             iterate, compliance, sync,   |
-|                             ...)                         |
-|   shipwright_events.jsonl                                |
-|   .shipwright/                                           |
-|     agent_docs/  planning/  compliance/  designs/        |
-|     adopt/  reviews/                                     |
-+----------------------------------------------------------+
+```mermaid
+flowchart TB
+  CC["Claude Code (host)<br/>loads plugins from ~/.claude/plugins/cache/shipwright/"]
+
+  subgraph plugins["plugins/"]
+    direction TB
+    P["shipwright-run<br/>shipwright-project<br/>shipwright-plan<br/>shipwright-design<br/>shipwright-build<br/>shipwright-test<br/>shipwright-security<br/>shipwright-deploy<br/>shipwright-changelog<br/>shipwright-compliance<br/>shipwright-iterate<br/>shipwright-preview<br/>shipwright-adopt"]
+  end
+
+  subgraph shared["shared/"]
+    direction TB
+    S["scripts/ (lib, tools, hooks)<br/>profiles/ (stack + deploy)<br/>templates/<br/>prompts/ (review prompts)<br/>config/ (defaults)"]
+  end
+
+  subgraph target["Target project"]
+    direction TB
+    T["CLAUDE.md<br/>shipwright_*_config.json<br/>shipwright_events.jsonl<br/>.shipwright/<br/>&nbsp;&nbsp;agent_docs/ planning/ compliance/ designs/<br/>&nbsp;&nbsp;adopt/ reviews/"]
+  end
+
+  CC --> plugins
+  plugins -- "reads/writes" --> shared
+  plugins -- "writes/reads" --> target
+```
 
 ## Stack
 

--- a/plugins/shipwright-adopt/scripts/lib/artifact_writer.py
+++ b/plugins/shipwright-adopt/scripts/lib/artifact_writer.py
@@ -9,6 +9,7 @@ NEVER silently overwritten — see `preserve_existing.py` for the policy.
 
 from __future__ import annotations
 
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -38,6 +39,48 @@ from lib.preserve_existing import (  # noqa: E402
 # real project ever reaches >999 ADRs, that's a Shipwright-wide
 # convention upgrade, not a silent serialisation choice in adopt.
 ADR_OUTPUT_MAX_NUMBER = 999
+
+# Architecture-marker format. The marker lives on line 2 of architecture.md
+# (after the H1 title) and lets the Iterate-C drift detector compare the
+# last-sync SHA against new ADRs with `architecture_impact ∈ {component,
+# data-flow}` since that commit. Bump ``v=`` whenever the marker grammar
+# changes; parsers stay tolerant of older versions ("v=1 / no marker"
+# behaves as "no last_sync recorded").
+ARCHITECTURE_MARKER_VERSION = 2
+NO_ARCHITECTURE_SYNC = "no-sync-recorded"
+_ARCHITECTURE_MARKER_RE = re.compile(
+    r"<!--\s*shipwright:architecture\s+v=(?P<version>\d+)\s+last-sync=(?P<sha>\S+)\s*-->"
+)
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+def render_architecture_marker(commit_sha: str | None) -> str:
+    """Render the architecture drift-detection HTML comment marker."""
+    if commit_sha and _COMMIT_SHA_RE.match(commit_sha):
+        last_sync = commit_sha
+    else:
+        last_sync = NO_ARCHITECTURE_SYNC
+    return (
+        f"<!-- shipwright:architecture v={ARCHITECTURE_MARKER_VERSION} "
+        f"last-sync={last_sync} -->"
+    )
+
+
+def parse_architecture_marker(content: str) -> dict[str, str] | None:
+    """Parse the architecture marker out of architecture.md content.
+
+    Returns ``None`` when no marker is present (pre-marker era — drift
+    detector should treat this as "no last_sync known"). A marker with
+    an invalid SHA is normalised to ``NO_ARCHITECTURE_SYNC`` so callers
+    can rely on the sha being either a real commit or that sentinel.
+    """
+    match = _ARCHITECTURE_MARKER_RE.search(content)
+    if not match:
+        return None
+    sha = match.group("sha")
+    if sha != NO_ARCHITECTURE_SYNC and not _COMMIT_SHA_RE.match(sha):
+        sha = NO_ARCHITECTURE_SYNC
+    return {"version": match.group("version"), "last_sync": sha}
 
 
 def _next_adr_start_number(project_root: Path) -> int:
@@ -148,6 +191,7 @@ def _render_architecture_md(
     data_flow_description: str,
     profile_name: str,
     see_also_links: list[str] | None = None,
+    commit_sha: str | None = None,
 ) -> str:
     runtime = _fmt_stack_line(stack.get("runtime", {}))
     frontend = _fmt_stack_line(stack.get("frontend", {}))
@@ -168,7 +212,9 @@ def _render_architecture_md(
             "_Existing user-facing documentation discovered by /shipwright-adopt._\n\n"
             + bullets + "\n"
         )
+    marker = render_architecture_marker(commit_sha)
     return f"""# Architecture — {project_name}
+{marker}
 
 ## System Overview
 
@@ -615,6 +661,7 @@ def write_agent_docs(
         architecture_diagram=architecture_diagram,
         data_flow_description=data_flow_description, profile_name=profile,
         see_also_links=user_facing_docs,
+        commit_sha=commit_sha,
     ), encoding="utf-8")
     record_preservation_action(
         project_root,

--- a/plugins/shipwright-adopt/scripts/lib/enrichment_fallback.py
+++ b/plugins/shipwright-adopt/scripts/lib/enrichment_fallback.py
@@ -55,12 +55,25 @@ def build_fallback_enrichment(
             "acceptance_draft": "TBD",
         })
 
+    # Mermaid flowchart so VS Code (and GitHub) render the diagram natively
+    # instead of treating ASCII art as a fenced code block. Layer-2 enrichment
+    # can replace this with a richer hand-authored diagram; the fallback keeps
+    # the output parseable without an LLM round-trip.
     layers = snapshot.get("folders", {}).get("layers", [])
-    diagram_lines = ["```", "  (auto-generated fallback diagram)", ""]
-    for layer in layers:
-        diagram_lines.append(f"  [{layer.get('name', '?')}]")
-        for path in (layer.get("paths") or [])[:5]:
-            diagram_lines.append(f"    - {path}")
+    diagram_lines = [
+        "```mermaid",
+        "flowchart TB",
+        "  %% auto-generated fallback diagram",
+    ]
+    if layers:
+        for idx, layer in enumerate(layers):
+            name = layer.get("name", "?")
+            paths = (layer.get("paths") or [])[:5]
+            label_lines = [name] + [f"- {p}" for p in paths]
+            label = "<br/>".join(label_lines)
+            diagram_lines.append(f"  L{idx}[\"{label}\"]")
+    else:
+        diagram_lines.append("  L0[\"(no layers detected)\"]")
     diagram_lines.append("```")
     architecture_diagram = "\n".join(diagram_lines)
 

--- a/plugins/shipwright-adopt/tests/test_artifact_writer.py
+++ b/plugins/shipwright-adopt/tests/test_artifact_writer.py
@@ -7,7 +7,12 @@ import pytest
 
 from lib.artifact_writer import (
     ADR_OUTPUT_MAX_NUMBER,
+    ARCHITECTURE_MARKER_VERSION,
+    NO_ARCHITECTURE_SYNC,
+    _render_architecture_md,
     _render_decision_log,
+    parse_architecture_marker,
+    render_architecture_marker,
     write_agent_docs,
     write_claude_md,
     write_spec,
@@ -232,3 +237,102 @@ def test_write_spec_has_fr_ids(tmp_path: Path) -> None:
     assert re.search(r"\bFR-\d+\.\d+\b", content)
     assert "Demo app." in content
     assert "CI pipeline must pass" in content
+
+
+# ---------------------------------------------------------------------------
+# Iterate A.1 — architecture marker (drift detector input)
+# ---------------------------------------------------------------------------
+
+
+def test_render_architecture_marker_with_valid_sha() -> None:
+    """A valid 7-40 char hex sha renders verbatim into the marker comment."""
+    marker = render_architecture_marker("abc1234")
+    assert "v=2" in marker
+    assert "last-sync=abc1234" in marker
+
+    long_sha = "0123456789abcdef0123456789abcdef01234567"  # 40 chars
+    assert f"last-sync={long_sha}" in render_architecture_marker(long_sha)
+
+
+def test_render_architecture_marker_falls_back_for_invalid_sha() -> None:
+    """Anything that isn't a valid commit-sha → ``no-sync-recorded`` sentinel."""
+    for bad in (None, "", "not-a-sha", "ABCDEF1", "abc12g4", "abc"):
+        marker = render_architecture_marker(bad)
+        assert NO_ARCHITECTURE_SYNC in marker, f"bad={bad!r}"
+        assert "v=2" in marker
+
+
+def test_parse_architecture_marker_round_trips() -> None:
+    """A rendered marker survives parse + lookup unchanged."""
+    sha = "abc1234"
+    marker = render_architecture_marker(sha)
+    parsed = parse_architecture_marker(f"# Heading\n{marker}\n\nbody")
+    assert parsed is not None
+    assert parsed["version"] == str(ARCHITECTURE_MARKER_VERSION)
+    assert parsed["last_sync"] == sha
+
+
+def test_parse_architecture_marker_missing_returns_none() -> None:
+    """Pre-marker era (no marker line) → None so callers fall back to "unknown"."""
+    assert parse_architecture_marker("# Architecture — Demo\n\nno marker here\n") is None
+
+
+def test_parse_architecture_marker_invalid_sha_normalises_to_sentinel() -> None:
+    """A marker carrying garbage in the sha slot is parsed but the sha is
+    normalised to ``NO_ARCHITECTURE_SYNC`` — callers never have to revalidate."""
+    marker = "<!-- shipwright:architecture v=2 last-sync=not-a-sha -->"
+    parsed = parse_architecture_marker(f"# H\n{marker}\n")
+    assert parsed is not None
+    assert parsed["last_sync"] == NO_ARCHITECTURE_SYNC
+    assert parsed["version"] == "2"
+
+
+def test_parse_architecture_marker_tolerates_v1() -> None:
+    """v=1 markers (pre-this-iterate) parse without error; drift detector
+    decides how to treat them."""
+    marker = "<!-- shipwright:architecture v=1 last-sync=abc1234 -->"
+    parsed = parse_architecture_marker(f"# H\n{marker}\n")
+    assert parsed is not None
+    assert parsed["version"] == "1"
+    assert parsed["last_sync"] == "abc1234"
+
+
+def test_render_architecture_md_embeds_marker(tmp_path: Path) -> None:
+    """The marker lives directly under the H1 so the drift detector can read
+    it without scanning the rest of the doc."""
+    md = _render_architecture_md(
+        project_name="Demo",
+        stack={"runtime": {}, "frontend": {}, "backend": {}, "database": {}, "auth": {}},
+        layers=[],
+        architecture_diagram="```mermaid\nflowchart TB\n  A-->B\n```",
+        data_flow_description="...",
+        profile_name="vite-hono",
+        commit_sha="abc1234",
+    )
+    lines = md.splitlines()
+    assert lines[0] == "# Architecture — Demo"
+    assert "shipwright:architecture" in lines[1]
+    assert "last-sync=abc1234" in lines[1]
+    assert "```mermaid" in md
+
+
+def test_write_agent_docs_writes_architecture_marker(tmp_path: Path) -> None:
+    """Smoke-test the writer end-to-end — the marker should land in
+    ``.shipwright/agent_docs/architecture.md`` with the commit_sha threaded
+    through from the caller."""
+    write_agent_docs(
+        tmp_path,
+        project_name="Demo", profile="vite-hono", scope="full_app",
+        stack={"runtime": {}, "frontend": {}, "backend": {}, "database": {}, "auth": {}},
+        layers=[], loc_by_layer={},
+        architecture_diagram="```mermaid\nflowchart TB\nA-->B\n```",
+        data_flow_description="",
+        conventions={}, conventions_prose="",
+        features_count=0, commits_total=1, contributors_total=1,
+        nested_excluded=[], commit_sha="abc1234", retroactive_adrs=[],
+    )
+    arch = (tmp_path / ".shipwright" / "agent_docs" / "architecture.md").read_text(
+        encoding="utf-8"
+    )
+    parsed = parse_architecture_marker(arch)
+    assert parsed == {"version": "2", "last_sync": "abc1234"}


### PR DESCRIPTION
## Summary

Iterate A.1 of the artifact-polish plan. Two surface changes:

- **Architecture marker.** Adopt now stamps a versioned HTML comment on line 2 of every newly-written `architecture.md`:
  `<!-- shipwright:architecture v=2 last-sync=<commit-sha> -->`. Iterate C.2's drift detector will compare the sha against ADRs with `architecture_impact ∈ {component, data-flow}` introduced after it. Invalid / missing shas normalise to `no-sync-recorded`; v=1 markers stay parseable (pre-marker fallback).
- **Mermaid fallback diagram.** `enrichment_fallback` emits a `flowchart TB` block instead of ASCII so VS Code renders the diagram natively. Layer-2 enrichment can still override with its own Mermaid prose; the contract for `_render_architecture_md(architecture_diagram=...)` is unchanged (caller wraps).
- **Manual project fix.** `c:/01_Development/shipwright/.shipwright/agent_docs/architecture.md` converted ASCII → Mermaid + marker pinned to current HEAD `932e0d221ea1`.

## Test plan

- [x] `uv run --extra dev pytest tests/test_artifact_writer.py -v` — 17 passed (8 new marker tests added)
- [x] `uv run --extra dev pytest tests/` (full adopt suite) — 278/278 passed
- [ ] Manual: VS Code markdown preview renders the new Mermaid block

## Notes

- `tests/test_artifact_writer.py` is now 338 lines (over the 300-line guideline). Splitting into per-area test files is deferred — non-blocking.
- Drift detector itself (Iterate C.2) consumes `parse_architecture_marker` later. A.1 only emits the marker; no consumer change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)