### PR TITLE
feat(compliance): mode-aware dashboard + Why-warn column + Triage open indicator (Iterate B.1)

### DIFF
--- a/.shipwright/planning/adr/055-compliance-dashboard-mode-aware.md
+++ b/.shipwright/planning/adr/055-compliance-dashboard-mode-aware.md
@@ -1,0 +1,124 @@
+# ADR-055 — Compliance Dashboard mode-aware indicators (B.1)
+
+> Long-form spec backing the iterate-2026-05-21-b1-compliance-dashboard
+> ADR drop.
+
+## Audience principle
+
+Same as B0 ADR-054: solo dev today, leadwright Phase 3. The dashboard
+should answer "is anything wrong, and if so where do I look?" — in one
+glance. Misleading WARN rows (the `1/7 WARN` for an adopted project
+that will *never* run a 7-phase pipeline) actively erode trust in the
+indicator. Every WARN must be either actionable or unequivocally
+correct.
+
+## Decisions (B.1)
+
+### D1. Adopted-mode detection via `run_config.adoption` (not `scope`)
+
+The artifact-polish plan's original wording — "lese `run_config.scope`
+(adopt vs greenfield)" — was wrong. Empirically `scope` carries values
+like `"library"` / `"full_app"`, orthogonal to adoption status. The
+authoritative signal is the presence of the `adoption` object written
+by `/shipwright-adopt`.
+
+The check lives in `_is_adopted(run_config)` and is intentionally tiny
+(`return isinstance(run_config.get("adoption"), dict) and bool(...)`)
+so future adoption-marker fields (a v2 of the adoption object, say)
+don't break it.
+
+### D2. Pipeline-phases row → `n/a (adopted)` (not hidden)
+
+For adopted projects the `Pipeline phases completed` row stays in the
+dashboard but renders as `n/a (adopted)` with INFO status. Rationale:
+
+- The reader (human or leadwright) sees that the dashboard understands
+  the project's lineage. A missing row is ambiguous ("did the
+  indicator break?"); an explicit `n/a` is informative.
+- INFO (not PASS) because the project genuinely never ran the
+  pipeline — claiming PASS would imply phases were completed.
+
+### D3. Hide `Work events (build)` and `All sections reviewed` for adopted
+
+These two rows ARE removed entirely. Different reasoning from D2:
+
+- They report counts (`0 sections`, `0/0 reviewed`) that are
+  structurally `0` for adopted projects — the project was onboarded
+  with existing code, not built section by section.
+- An `0 sections WARN` is more confusing than the absent row.
+- The Iterate-specific rows (`Work events (iterate)`, `Iterate tests
+  passing`) stay because they're meaningful in both modes.
+
+### D4. Why-warn column — static one-line pointers, no dynamic analysis
+
+The new 4th column carries a per-indicator pointer string on WARN
+rows. The strings are inline-templated in `_quality_indicators_events`,
+e.g.:
+
+- Unit tests WARN → `"{failing}/{total} failing — see test-evidence.md"`
+- Pipeline phases WARN → `"{n} phase(s) pending — see shipwright_events.jsonl"`
+- Iterate tests WARN → `"{n} iterate(s) without tests — see test-evidence.md"`
+- Copyleft risk WARN → `"{n} copyleft license(s) detected — see sbom.md"`
+- Sections-reviewed WARN → `"{n} section(s) unreviewed — see change-history.md"`
+- Triage open WARN → `"{signal} actionable item(s) — see ../agent_docs/triage_inbox.md"`
+
+Rejected: dynamic analysis (e.g. "iterates 4, 7, 9 regressed"). The
+dashboard is a launchpad, not a triage tool. Deep diagnosis lives
+in the Triage Inbox (B0). Solo-dev pragmatism: simple templates win.
+
+### D5. Triage open — split signal vs info; only signal triggers WARN
+
+Mirrors the inbox's signal-first render from B0 ADR-054 D6. Value
+formats:
+
+| Open state | Rendered value | Status |
+|------------|----------------|--------|
+| 0 signal, 0 info | `0 open` | PASS |
+| N signal, 0 info | `N open` | WARN |
+| 0 signal, M info | `0 open (M info)` | PASS |
+| N signal, M info | `N open (M info)` | WARN |
+
+Dismissed / promoted / snoozed items don't contribute. Items with
+malformed severity are skipped silently (tolerant reader matches
+`triage.read_all_items`).
+
+### D6. Only the event-based path is touched
+
+`_quality_indicators_legacy` (the pre-event-log path) is left
+unchanged. Adopted projects always have events (their iterates
+emit them), so the legacy path is greenfield-only. Less to verify.
+
+## What landed in B.1 vs forward-looking
+
+| Decision | Realized in this iterate? |
+|----------|--------------------------|
+| D1 Adopted-mode detection      | **Yes** |
+| D2 Pipeline-phases n/a row     | **Yes** |
+| D3 Hide build-section rows     | **Yes** |
+| D4 Why-warn column             | **Yes** |
+| D5 Triage open indicator       | **Yes** |
+| D6 Legacy path unchanged       | **Yes (intentional non-change)** |
+
+## Consequences
+
+- Adopted-project dashboards (shipwright monorepo itself, webui) no
+  longer carry the misleading `1/7 WARN` row.
+- Operators see "where to look next" inline on every WARN row.
+- The Triage Inbox gets a permanent surface on the compliance home
+  page — operators don't have to remember to check it.
+
+## Rejected (recorded for future me)
+
+- **Hide pipeline row entirely for adopted** — ambiguous (could look
+  like a bug). Explicit `n/a` is clearer.
+- **Generate Why-warn dynamically** — over-engineering for solo dev;
+  static pointers are sufficient.
+- **Make the dashboard a HTML page with hyperlinks** — out of scope;
+  markdown plays nice with VS Code preview and CI artifacts.
+
+## See also
+
+- Iterate spec: `.shipwright/planning/iterate/2026-05-21-b1-compliance-dashboard-mode-aware.md`
+- Compliance report: `plugins/shipwright-compliance/scripts/lib/compliance_report.py`
+- Triage schema: `shared/schemas/triage_item.schema.json` (B0 / ADR-054)
+- Earlier ADRs: ADR-046 (Triage Inbox), ADR-054 (Triage Producer Contract — B0).

--- a/.shipwright/planning/iterate/2026-05-21-b1-compliance-dashboard-mode-aware.md
+++ b/.shipwright/planning/iterate/2026-05-21-b1-compliance-dashboard-mode-aware.md
@@ -1,0 +1,102 @@
+# Iterate Spec: b1-compliance-dashboard-mode-aware
+
+- **Run ID:** iterate-2026-05-21-b1-compliance-dashboard-mode-aware
+- **Type:** feature
+- **Complexity:** small
+- **Status:** draft
+
+## Goal
+
+Iterate B.1 from the artifact-polish plan: turn the Compliance Dashboard
+from a generic "1/7 WARN" surface into a mode-aware, signal-first
+indicator board.
+
+Three changes:
+
+1. **Mode-aware indicators** — adopted projects render
+   `Pipeline phases completed: n/a (adopted)` instead of the misleading
+   `1/7 WARN`; the `Work events (build)` and `All sections reviewed`
+   rows are hidden entirely (structurally N/A for adopted, not "not run
+   yet").
+2. **Why-warn column** — every quality-indicator table gains a 4th
+   column carrying a one-line diagnostic pointer on WARN rows so the
+   operator knows where to look. Empty for PASS / INFO / n/a.
+3. **Triage open indicator** — new row counting open items in
+   `.shipwright/triage.jsonl`. Signal severity (`critical/high/medium/
+   low`) prominent; info-severity shown in parentheses
+   (`"3 open (1 info)"`), consistent with the inbox's signal-first
+   render decided in B0 ADR-054 D6.
+
+## Plan-correction (empirically observed)
+
+The artifact-polish plan said "lese `run_config.scope` (adopt vs
+greenfield)". That's wrong — `scope` carries values like `"library"` /
+`"full_app"`, orthogonal to adoption status. The real signal is the
+presence of `run_config.adoption` (with `adopted_at`,
+`commit_at_adoption`, ...). This iterate uses the empirically correct
+check.
+
+## Acceptance Criteria
+
+- [ ] **AC-1** When `run_config.adoption` is set, the `Pipeline phases
+  completed` row renders `| Pipeline phases completed | n/a (adopted) |
+  INFO |  |` — no fake-WARN.
+
+- [ ] **AC-2** When `run_config.adoption` is set, the `Work events
+  (build)` and `All sections reviewed` rows are absent from the
+  rendered dashboard.
+
+- [ ] **AC-3** When `run_config.adoption` is unset (greenfield), all
+  three rows (Pipeline phases, Work events build, All sections
+  reviewed) render with real progress numbers and PASS/WARN status as
+  today.
+
+- [ ] **AC-4** Every quality-indicator table starts with the header
+  `| Metric | Value | Status | Why warn? |` and separator
+  `|--------|-------|--------|-----------|`.
+
+- [ ] **AC-5** WARN rows have a non-empty Why-warn cell with a
+  pointer to the relevant artifact (e.g. `"see test-evidence.md"`,
+  `"see sbom.md"`). PASS / INFO / n/a rows have an empty cell.
+
+- [ ] **AC-6** A new `Triage open` row appears in every event-based
+  dashboard. With no open items: `| Triage open | 0 open | PASS |  |`.
+  With signal items only: `| Triage open | N open | WARN | N
+  actionable item(s) — see ../agent_docs/triage_inbox.md |`. With
+  info-only items: `| Triage open | 0 open (M info) | PASS |  |`. With
+  both: `| Triage open | N open (M info) | WARN | ... |`.
+
+- [ ] **AC-7** Dismissed and promoted items don't contribute to the
+  count.
+
+## Out of scope
+
+- Layer column for tests (B.3).
+- "FRs without tests" / "FRs with stale verification" Coverage Summary
+  in RTM (B.4).
+- Mode-aware behaviour for the legacy `_quality_indicators_legacy`
+  path — only the event-based path is touched. Legacy is the
+  pre-event-log path; adopted projects always have events.
+- Restructuring `compliance_report.py` (now 386 lines, over the
+  300-line guideline). Sensible follow-up split: `lib/quality_indicators.py`
+  + `lib/dashboard_sections.py`. Tracked but not in this iterate.
+
+## Implementation notes
+
+- Mode detection lives in `_is_adopted(run_config)` — checks for a
+  truthy `adoption` dict.
+- Triage open counts come from a new `_triage_open_counts(project_root)`
+  helper that reads `shared/scripts/triage.py::read_all_items` and
+  partitions by `info` vs everything else. Tolerant of missing /
+  corrupt file (returns `(0, 0)`).
+- Why-warn column uses inline per-indicator pointers — no dynamic
+  reflection; intentional simplicity. The dashboard is a launchpad,
+  not a triage tool (the Triage Inbox is, post-B0).
+
+## Verification
+
+- `uv run --extra dev pytest plugins/shipwright-compliance/tests/test_compliance_report.py -v`
+  — 22 passed (was 9; +13 new B.1 tests).
+- Full compliance suite (`plugins/shipwright-compliance/tests/`):
+  348 passed.
+- Full shared suite (`shared/tests/`): 2101 passed.

--- a/CHANGELOG-unreleased.d/Changed/iterate-2026-05-21-b1-compliance-dashboard-mode-aware_001.md
+++ b/CHANGELOG-unreleased.d/Changed/iterate-2026-05-21-b1-compliance-dashboard-mode-aware_001.md
@@ -1,0 +1,1 @@
+Compliance Dashboard: mode-aware indicators (adopted projects show `n/a (adopted)` for pipeline phases; hide structurally-N/A build-section rows), new Why-warn 4th column with per-indicator diagnostic pointers, new Triage open indicator surfacing `.shipwright/triage.jsonl` status (Iterate B.1).

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1049,7 +1049,7 @@ Together with preventive Canon and reactive Phase-Quality, it's a three-layer qu
 - `shipwright_audit_report.json` — structured payload; every finding carries a `source` field (`detective-only` or `preventive-rerun`).
 
 **What the auto-background generator produces** (unchanged from v6):
-- `.shipwright/compliance/dashboard.md` -- Start-here overview with quality indicators, project velocity, and links.
+- `.shipwright/compliance/dashboard.md` -- Start-here overview with quality indicators, project velocity, and links. Mode-aware (Iterate B.1, 2026-05-21): adopted projects (`run_config.adoption` set) render `Pipeline phases completed: n/a (adopted)` instead of a fake `1/7 WARN` and hide the structurally-N/A `Work events (build)` + `All sections reviewed` rows. Every WARN row carries a 4th `Why warn?` column with a one-line diagnostic pointer (`"X failing — see test-evidence.md"`, `"see sbom.md"`, ...). A `Triage open` indicator surfaces the count of open items in `.shipwright/triage.jsonl` (signal severities prominent, info-severity shown in parens — `"3 open (1 info)"`) so the inbox status lives on the compliance home page.
 - `.shipwright/compliance/traceability-matrix.md` -- Every requirement mapped to the work events that verify it, with a "Last Verified" column.
 - `.shipwright/compliance/test-evidence.md` -- Test results across unit / integration / pgTAP / smoke / E2E / consistency / visual, with pass/fail counts and skip reasons.
 - `.shipwright/compliance/change-history.md` -- All commits + decisions (from `.shipwright/agent_docs/decision_log.md`) + version tags.

--- a/plugins/shipwright-compliance/scripts/lib/compliance_report.py
+++ b/plugins/shipwright-compliance/scripts/lib/compliance_report.py
@@ -17,11 +17,66 @@ if str(_SHARED_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SHARED_SCRIPTS))
 from markdown_table import escape_cell  # noqa: E402
 
+# Triage Inbox count surfaces in the dashboard's Quality Indicators
+# section (Iterate B.1). Import is deferred to keep the test fixture
+# fallback path simple — a project with no `.shipwright/triage.jsonl`
+# yields an empty list, not a crash.
+try:
+    from triage import read_all_items as _read_triage_items  # noqa: E402
+except ImportError:  # pragma: no cover - triage helper always available in practice
+    _read_triage_items = None  # type: ignore[assignment]
+
 if TYPE_CHECKING:
     from scripts.lib.data_collector import ComplianceData
 
 
 _COPYLEFT_LICENSES = {"GPL", "LGPL", "AGPL", "MPL-2.0", "GPL-2.0", "GPL-3.0", "AGPL-3.0", "LGPL-2.1", "LGPL-3.0"}
+
+
+def _is_adopted(run_config: dict) -> bool:
+    """True when the project was onboarded via /shipwright-adopt.
+
+    The empirically correct signal is the presence of the `adoption`
+    object (carrying `adopted_at`, `commit_at_adoption`, ...). The
+    artifact-polish plan originally suggested checking `scope`, but
+    `scope` carries values like `"library"` / `"full_app"` — orthogonal
+    to adoption status (Iterate B.1, 2026-05-21).
+    """
+    adoption = run_config.get("adoption")
+    return isinstance(adoption, dict) and bool(adoption)
+
+
+_SIGNAL_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
+
+
+def _triage_open_counts(project_root: Path) -> tuple[int, int]:
+    """Return (signal_count, info_count) of open triage items.
+
+    Signal = severity ∈ ``_SIGNAL_SEVERITIES`` (critical/high/medium/low).
+    Info   = severity == "info".
+    Items with malformed / missing / unknown severity are skipped from
+    BOTH counts (ADR-055 D5 — tolerant reader, matches the schema enum
+    boundary so future severity-vocab expansions don't auto-promote to
+    signal until the dashboard is updated).
+    """
+    if _read_triage_items is None:
+        return (0, 0)
+    try:
+        items = _read_triage_items(project_root)
+    except Exception:  # pragma: no cover - tolerant of corrupt file
+        return (0, 0)
+    signal = 0
+    info = 0
+    for it in items:
+        if it.get("status") != "triage":
+            continue
+        sev = it.get("severity")
+        if sev in _SIGNAL_SEVERITIES:
+            signal += 1
+        elif sev == "info":
+            info += 1
+        # else: unknown severity → skipped silently per ADR-055 D5
+    return (signal, info)
 
 
 def generate(data: ComplianceData) -> str:
@@ -84,7 +139,25 @@ def generate(data: ComplianceData) -> str:
 
 
 def _quality_indicators_events(data: ComplianceData) -> list[str]:
-    """Quality indicators from event log."""
+    """Quality indicators from event log.
+
+    Iterate B.1 (2026-05-21) — three changes:
+    - **Mode-aware**: adopted projects don't run the pipeline phases,
+      so the "Pipeline phases completed" row renders ``n/a (adopted)``
+      instead of a fake ``1/7 WARN``; the build-sections + sections-
+      reviewed rows are hidden entirely (structurally N/A, not "not
+      run yet").
+    - **Why warn? column**: one-line diagnostic pointer on every WARN
+      row so the operator knows where to look. Empty cell for PASS /
+      INFO / n/a rows.
+    - **Triage open indicator**: new row counting open items in
+      ``.shipwright/triage.jsonl``. Signal severity (critical/high/
+      medium/low) prominent; info-severity shown in parentheses
+      consistent with the inbox's signal-first render (B0 ADR-054 D6).
+    """
+    run_config = data.configs.get("run", {})
+    adopted = _is_adopted(run_config)
+
     build_events = [we for we in data.work_events if we.source == "build"]
     iterate_events = [we for we in data.work_events if we.source == "iterate"]
 
@@ -109,28 +182,123 @@ def _quality_indicators_events(data: ComplianceData) -> list[str]:
     # Iterate test coverage
     iterate_tested = sum(1 for we in iterate_events if we.tests_total > 0)
 
+    # Triage open counts — signal vs info-severity (B0 ADR-054 D6).
+    triage_signal, triage_info = _triage_open_counts(data.project_root)
+
     lines = [
         "## Quality Indicators",
         "",
-        "| Metric | Value | Status |",
-        "|--------|-------|--------|",
-        f"| Pipeline phases completed | {len(completed_phases)}/{total_pipeline} | {_status_badge(len(completed_phases) >= total_pipeline)} |",
-        f"| Work events (build) | {len(build_events)} sections | {_status_badge(len(build_events) > 0)} |",
-        f"| Work events (iterate) | {len(iterate_events)} changes | INFO |",
-        f"| All unit tests passing | {latest_passed}/{latest_total} | {_status_badge(latest_passed == latest_total and latest_total > 0)} |",
-        f"| All sections reviewed | {reviewed}/{len(build_events)} | {_status_badge(reviewed == len(build_events) and len(build_events) > 0)} |",
-        f"| Architecture decisions | {total_decisions} ADRs | INFO |",
+        "| Metric | Value | Status | Why warn? |",
+        "|--------|-------|--------|-----------|",
     ]
 
+    # Pipeline phases — n/a for adopted, real progress for greenfield.
+    if adopted:
+        lines.append(
+            "| Pipeline phases completed | n/a (adopted) | INFO |  |"
+        )
+    else:
+        pipeline_ok = len(completed_phases) >= total_pipeline
+        pipeline_status = _status_badge(pipeline_ok)
+        pipeline_why = (
+            f"{total_pipeline - len(completed_phases)} phase(s) pending — see shipwright_events.jsonl"
+            if not pipeline_ok else ""
+        )
+        lines.append(
+            f"| Pipeline phases completed | {len(completed_phases)}/{total_pipeline} | "
+            f"{pipeline_status} | {pipeline_why} |"
+        )
+
+    # Build-sections + sections-reviewed: structurally N/A for adopted
+    # (the project was onboarded with existing code, not built section
+    # by section). Hide entirely instead of WARN-noise.
+    if not adopted:
+        build_ok = len(build_events) > 0
+        build_why = (
+            "no build events recorded — run /shipwright-build" if not build_ok else ""
+        )
+        lines.append(
+            f"| Work events (build) | {len(build_events)} sections | "
+            f"{_status_badge(build_ok)} | {build_why} |"
+        )
+
+    lines.append(
+        f"| Work events (iterate) | {len(iterate_events)} changes | INFO |  |"
+    )
+
+    tests_ok = latest_passed == latest_total and latest_total > 0
+    tests_why = (
+        f"{latest_total - latest_passed}/{latest_total} failing — see test-evidence.md"
+        if not tests_ok and latest_total > 0 else
+        "no test events recorded yet" if latest_total == 0 else ""
+    )
+    lines.append(
+        f"| All unit tests passing | {latest_passed}/{latest_total} | "
+        f"{_status_badge(tests_ok)} | {tests_why} |"
+    )
+
+    if not adopted:
+        review_ok = reviewed == len(build_events) and len(build_events) > 0
+        if not review_ok:
+            # Two WARN paths: (a) build_events==0 — pre-build greenfield;
+            # (b) build_events>0 but some unreviewed. Both get a diagnostic
+            # (ADR-055 D4 / AC-5: every WARN row carries a pointer).
+            if len(build_events) == 0:
+                review_why = "no build events yet — run /shipwright-build first"
+            else:
+                review_why = (
+                    f"{len(build_events) - reviewed} section(s) unreviewed — "
+                    "see change-history.md"
+                )
+        else:
+            review_why = ""
+        lines.append(
+            f"| All sections reviewed | {reviewed}/{len(build_events)} | "
+            f"{_status_badge(review_ok)} | {review_why} |"
+        )
+
+    lines.append(
+        f"| Architecture decisions | {total_decisions} ADRs | INFO |  |"
+    )
+
     if iterate_events:
-        lines.append(f"| Iterate tests passing | {iterate_tested}/{len(iterate_events)} iterations tested | {_status_badge(iterate_tested == len(iterate_events))} |")
+        iter_ok = iterate_tested == len(iterate_events)
+        iter_why = (
+            f"{len(iterate_events) - iterate_tested} iterate(s) without tests — see test-evidence.md"
+            if not iter_ok else ""
+        )
+        lines.append(
+            f"| Iterate tests passing | {iterate_tested}/{len(iterate_events)} iterations tested | "
+            f"{_status_badge(iter_ok)} | {iter_why} |"
+        )
 
-    lines.extend([
-        f"| Dependencies | {total_deps} packages | INFO |",
-        f"| Copyleft risk | {copyleft} | {_status_badge(copyleft == 0)} |",
-        "",
-    ])
+    lines.append(
+        f"| Dependencies | {total_deps} packages | INFO |  |"
+    )
 
+    copyleft_why = (
+        f"{copyleft} copyleft license(s) detected — see sbom.md"
+        if copyleft > 0 else ""
+    )
+    lines.append(
+        f"| Copyleft risk | {copyleft} | {_status_badge(copyleft == 0)} | {copyleft_why} |"
+    )
+
+    # Triage open — new B.1 indicator. WARN when any signal item is
+    # open; info-only counts surface as PASS with a non-empty Value.
+    triage_value = f"{triage_signal} open"
+    if triage_info:
+        triage_value += f" ({triage_info} info)"
+    triage_ok = triage_signal == 0
+    triage_why = (
+        f"{triage_signal} actionable item(s) — see ../agent_docs/triage_inbox.md"
+        if not triage_ok else ""
+    )
+    lines.append(
+        f"| Triage open | {triage_value} | {_status_badge(triage_ok)} | {triage_why} |"
+    )
+
+    lines.append("")
     return lines
 
 

--- a/plugins/shipwright-compliance/tests/test_compliance_report.py
+++ b/plugins/shipwright-compliance/tests/test_compliance_report.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from pathlib import Path
 
-from scripts.lib.data_collector import ComplianceData, DependencyInfo, collect_all
+from scripts.lib.data_collector import (
+    ComplianceData,
+    DependencyInfo,
+    WorkEvent,
+    collect_all,
+)
 from scripts.lib.compliance_report import generate, generate_file
+
+# Append triage items via the shared producer so test fixtures match
+# production wire-shape (B0 schema).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SHARED_SCRIPTS = _REPO_ROOT / "shared" / "scripts"
+if str(_SHARED_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SHARED_SCRIPTS))
+from triage import append_triage_item  # noqa: E402
 
 
 class TestGenerate:
@@ -71,3 +86,248 @@ class TestGenerateFile:
         assert path.name == "dashboard.md"
         content = path.read_text(encoding="utf-8")
         assert "# Compliance Dashboard" in content
+
+
+# ---------------------------------------------------------------------------
+# Iterate B.1 (2026-05-21) — mode-aware indicators + Why-warn + Triage open
+# ---------------------------------------------------------------------------
+
+
+def _build_event_data(
+    *,
+    project_root: Path,
+    adopted: bool,
+    work_events: list[WorkEvent] | None = None,
+    phase_events: list[dict] | None = None,
+) -> ComplianceData:
+    """Construct a ComplianceData with work_events present (the event-based
+    quality-indicator path that B.1 changes)."""
+    run_config = {"profile": "test", "scope": "full_app"}
+    if adopted:
+        run_config["adoption"] = {
+            "adopted_at": "2026-05-02T00:00:00Z",
+            "commit_at_adoption": "deadbeef",
+        }
+    data = ComplianceData(project_root=project_root)
+    data.timestamp = "2026-05-21T00:00:00Z"
+    data.configs = {"run": run_config}
+    data.work_events = work_events or [
+        WorkEvent(
+            id="evt-1", timestamp="2026-05-20T10:00:00Z", source="iterate",
+            tests_passed=12, tests_total=12, intent="feature",
+            description="add x",
+        ),
+    ]
+    data.phase_events = phase_events or []
+    return data
+
+
+class TestAdoptedModeIndicators:
+    """B.1 — adopted projects show n/a for pipeline phases and HIDE
+    build-section indicators that are structurally inapplicable."""
+
+    def test_adopted_pipeline_row_is_na(self, tmp_path: Path):
+        data = _build_event_data(project_root=tmp_path, adopted=True)
+        result = generate(data)
+        assert "| Pipeline phases completed | n/a (adopted) | INFO |" in result
+        # No fake-WARN row
+        assert "Pipeline phases completed | 0/7" not in result
+        assert "Pipeline phases completed | 1/7" not in result
+
+    def test_adopted_hides_build_sections_row(self, tmp_path: Path):
+        data = _build_event_data(project_root=tmp_path, adopted=True)
+        result = generate(data)
+        # Both rows that are structurally N/A for adopted projects:
+        assert "Work events (build)" not in result
+        assert "All sections reviewed" not in result
+
+    def test_greenfield_keeps_pipeline_and_section_rows(self, tmp_path: Path):
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        result = generate(data)
+        assert "Pipeline phases completed" in result
+        assert "Work events (build)" in result
+        assert "All sections reviewed" in result
+        assert "n/a (adopted)" not in result
+
+
+class TestWhyWarnColumn:
+    """B.1 — every quality-indicator table has a 'Why warn?' 4th column;
+    WARN rows carry a one-line diagnostic pointer, others stay empty."""
+
+    def test_header_has_why_warn_column(self, tmp_path: Path):
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        result = generate(data)
+        assert "| Metric | Value | Status | Why warn? |" in result
+        assert "|--------|-------|--------|-----------|" in result
+
+    def test_failing_tests_carry_diagnostic(self, tmp_path: Path):
+        events = [
+            WorkEvent(
+                id="evt-1", timestamp="2026-05-20T10:00:00Z", source="iterate",
+                tests_passed=8, tests_total=12, intent="feature",
+            ),
+        ]
+        data = _build_event_data(
+            project_root=tmp_path, adopted=False, work_events=events,
+        )
+        result = generate(data)
+        # The Why-warn cell mentions where to look
+        assert "4/12 failing" in result
+        assert "test-evidence.md" in result
+
+    def test_passing_tests_have_empty_diagnostic(self, tmp_path: Path):
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        result = generate(data)
+        # The All-unit-tests row ends with PASS + empty cell + closing bar.
+        # Look for the exact pattern.
+        assert "| All unit tests passing | 12/12 | PASS |  |" in result
+
+
+class TestTriageOpenIndicator:
+    """B.1 — new 'Triage open' indicator on every dashboard."""
+
+    def test_zero_open_items_passes(self, tmp_path: Path):
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        result = generate(data)
+        assert "| Triage open |" in result
+        assert "| Triage open | 0 open | PASS |  |" in result
+
+    def test_signal_items_warn_with_link(self, tmp_path: Path):
+        # Seed real triage items via the shared producer so the schema
+        # contract is exercised end-to-end.
+        append_triage_item(
+            tmp_path, source="phaseQuality", severity="high", kind="bug",
+            title="t", detail="d",
+        )
+        append_triage_item(
+            tmp_path, source="drift", severity="medium", kind="maintenance",
+            title="t2", detail="d2",
+        )
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        result = generate(data)
+        assert "| Triage open | 2 open | WARN |" in result
+        assert "../agent_docs/triage_inbox.md" in result
+
+    def test_info_only_items_pass_with_info_count(self, tmp_path: Path):
+        append_triage_item(
+            tmp_path, source="drift", severity="info", kind="maintenance",
+            title="info-1", detail="d",
+        )
+        append_triage_item(
+            tmp_path, source="drift", severity="info", kind="maintenance",
+            title="info-2", detail="d",
+        )
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        result = generate(data)
+        # PASS because no signal items — info shown in parens (B0 D6 mirror)
+        assert "| Triage open | 0 open (2 info) | PASS |  |" in result
+
+    def test_mixed_signal_and_info_renders_both_counts(self, tmp_path: Path):
+        append_triage_item(
+            tmp_path, source="phaseQuality", severity="high", kind="bug",
+            title="signal", detail="d",
+        )
+        append_triage_item(
+            tmp_path, source="drift", severity="info", kind="maintenance",
+            title="noise", detail="d",
+        )
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        result = generate(data)
+        assert "| Triage open | 1 open (1 info) | WARN |" in result
+        assert "1 actionable item" in result
+
+    def test_dismissed_items_not_counted(self, tmp_path: Path):
+        from triage import mark_status
+
+        item_id = append_triage_item(
+            tmp_path, source="phaseQuality", severity="high", kind="bug",
+            title="t", detail="d",
+        )
+        mark_status(tmp_path, item_id, new_status="dismissed", by="test")
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        result = generate(data)
+        assert "| Triage open | 0 open | PASS |  |" in result
+
+
+class TestB1RegressionGuards:
+    """Make sure existing indicators still render correctly under the new
+    4-column layout."""
+
+    def test_dependencies_row_still_present(self, tmp_path: Path):
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        data.dependencies = [
+            DependencyInfo("react", "19.0.0", "runtime", "MIT"),
+        ]
+        result = generate(data)
+        # 4-column row with explicit empty Why-warn cell
+        assert "| Dependencies | 1 packages | INFO |  |" in result
+
+    def test_copyleft_warn_carries_diagnostic(self, tmp_path: Path):
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        data.dependencies = [
+            DependencyInfo("gpl-pkg", "1.0.0", "runtime", "GPL-3.0"),
+        ]
+        result = generate(data)
+        assert "| Copyleft risk | 1 | WARN |" in result
+        assert "1 copyleft license(s)" in result
+        assert "sbom.md" in result
+
+
+class TestB1ReviewFindingFixes:
+    """Regression coverage for findings from the B.1 self-review pass."""
+
+    def test_greenfield_no_build_events_review_row_has_diagnostic(
+        self, tmp_path: Path,
+    ):
+        """Review H1: a greenfield project with only iterate events (no
+        build events yet) used to render `All sections reviewed | 0/0 |
+        WARN | |` — empty Why-warn cell, violates AC-5. Fix renders a
+        pointer to /shipwright-build."""
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        # default _build_event_data gives one iterate event, zero build events
+        result = generate(data)
+        # WARN row with a non-empty diagnostic
+        assert (
+            "| All sections reviewed | 0/0 | WARN | "
+            "no build events yet — run /shipwright-build first |"
+        ) in result
+
+    def test_malformed_severity_skipped_silently(self, tmp_path: Path):
+        """Review M1 / ADR-055 D5: an item with severity outside the
+        canonical enum is skipped from BOTH signal and info counts."""
+        # Bypass append_triage_item's enum validation by hand-writing the
+        # JSONL — simulates a corrupt-file scenario.
+        triage_dir = tmp_path / ".shipwright"
+        triage_dir.mkdir()
+        (triage_dir / "triage.jsonl").write_text(
+            json.dumps({"v": 1, "schema": "triage", "created": "2026-05-21T00:00:00Z"})
+            + "\n"
+            # malformed: severity is bogus
+            + json.dumps({
+                "event": "append", "id": "trg-deadbeef",
+                "ts": "2026-05-21T01:00:00Z",
+                "originalTs": "2026-05-21T01:00:00Z",
+                "source": "test", "severity": "URGENT",
+                "kind": "bug", "title": "t", "detail": "d",
+                "status": "triage",
+                "suggestedPriority": "P0", "suggestedDomain": "engineering",
+            })
+            + "\n",
+            encoding="utf-8",
+        )
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        result = generate(data)
+        # Malformed item doesn't bump either counter
+        assert "| Triage open | 0 open | PASS |  |" in result
+
+    def test_signal_severity_whitelist_explicit(self, tmp_path: Path):
+        """All four signal severities (critical/high/medium/low) contribute
+        to the signal count."""
+        for sev in ("critical", "high", "medium", "low"):
+            append_triage_item(
+                tmp_path, source="test", severity=sev, kind="bug",
+                title=f"t-{sev}", detail="d",
+            )
+        data = _build_event_data(project_root=tmp_path, adopted=False)
+        result = generate(data)
+        assert "| Triage open | 4 open | WARN |" in result


### PR DESCRIPTION
## Summary

Iterate B.1 from the artifact-polish plan. Three changes to the Compliance Dashboard's Quality Indicators:

### 1. Mode-aware indicators

Adopted projects (`run_config.adoption` set) render `Pipeline phases completed: n/a (adopted) INFO` instead of the misleading `1/7 WARN`, and hide the structurally-N/A `Work events (build)` + `All sections reviewed` rows. Greenfield keeps all three rows with real progress.

**Plan-correction:** The artifact-polish plan said "lese `run_config.scope` (adopt vs greenfield)" but `scope` carries values like `library / full_app` — orthogonal. The real signal is the presence of `run_config.adoption`. ADR-055 documents this correction.

### 2. Why-warn 4th column

Every WARN row carries an inline one-line diagnostic pointer (`"X/Y failing — see test-evidence.md"`, `"see sbom.md"`, ...). Empty cell for PASS / INFO / n/a. Static per-indicator templates — the dashboard is a launchpad, deep diagnosis lives in the Triage Inbox (B0).

### 3. Triage open indicator

New row counts open items in `.shipwright/triage.jsonl`, partitioned signal vs info per B0 ADR-054 D6. Formats:

- `0 open` → PASS
- `N open` → WARN
- `0 open (M info)` → PASS
- `N open (M info)` → WARN

Dismissed/promoted items don't contribute. Items with malformed/unknown severity are skipped silently from BOTH counts (matches the schema enum boundary).

## Design decisions

Long form at [`.shipwright/planning/adr/055-compliance-dashboard-mode-aware.md`](.shipwright/planning/adr/055-compliance-dashboard-mode-aware.md). All 6 decisions (D1-D6) realized in this PR. F3 decision-drop carries `--spec-ref` pointing at the ADR — dogfoods A.3's spec-folder convention.

## Self-review

Independent code-review pass (general-purpose agent) caught two issues, both fixed inline before merge:

- **H1 (real bug):** greenfield project with only iterate events (no build events yet) rendered `All sections reviewed | 0/0 | WARN |  |` — empty Why-warn cell, violates AC-5. Fix renders `"no build events yet — run /shipwright-build first"`.
- **M1 (ADR↔impl drift):** `_triage_open_counts` was treating any non-info severity as signal (incl. malformed). ADR-055 D5 promises silent skip on malformed. Tightened to explicit whitelist `{critical, high, medium, low}` matching the B0 schema enum boundary.
- **L2 (test gap):** added regression covering the H1 scenario.

## Out of scope

- Layer column for tests (B.3).
- "FRs without tests" Coverage Summary in RTM (B.4).
- Mode-aware behavior for the legacy `_quality_indicators_legacy` path — only event-based path is touched. Adopted projects always have events.
- Restructuring `compliance_report.py` (now 387 lines, over the 300-line guideline). Sensible follow-up split tracked but not in this PR.

## Test plan

- [x] `plugins/shipwright-compliance/tests/test_compliance_report.py` — 25 passed (was 9; +16 new: 13 B.1 + 3 review-fix)
- [x] `plugins/shipwright-compliance/tests/` — 351 passed (was 348)
- [x] `shared/tests/` — 2101 passed (no regression)

## Doc updates (CLAUDE.md-mandated)

- `docs/guide.md` § 4.10 updated with the mode-aware + Why-warn + Triage-open behavior.
- No `docs/hooks-and-pipeline.md` change needed (no hooks, no pipeline-phase change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)