### PR TITLE
fix(triage): gate gh-security action-unit emit on artifact stub in test fixture

### DIFF
--- a/.shipwright/agent_docs/build_dashboard.md
+++ b/.shipwright/agent_docs/build_dashboard.md
@@ -1,5 +1,5 @@
 # Project Activity Dashboard
-> Updated: 2026-05-21 06:11 UTC | Session: f990b8ca-e767-4745-861f-9a142fcc95a4 | Run: iterate-2026-05-21-post-43-hygiene
+> Updated: 2026-05-21 12:31 UTC | Session: f8d0bbbe-d15f-480c-9e68-5c0eff518455 | Run: iterate-2026-05-21-fix-gh-security-emit-gate-symmetry
 
 ## Recent Changes (37 iterations)
 
@@ -44,7 +44,7 @@
 | change | post-adoption framework cleanup (Sub-1A through 1D) | 225/225 | 3db485b | FR-01.01, FR-01.02, FR-01.03 | 2026-05-02 |
 
 ## Test Status
-Last run: 2026-05-21 | Unit: 2048/2048 | Integration: 110/110 | Smoke: not_run | (iterate)
+Last run: 2026-05-21 | Unit: 2101/2113 | Smoke: not_run | (iterate)
 
 ## Pipeline
 

--- a/.shipwright/agent_docs/iterates/iterate-2026-05-21-fix-gh-security-emit-gate-symmetry.json
+++ b/.shipwright/agent_docs/iterates/iterate-2026-05-21-fix-gh-security-emit-gate-symmetry.json
@@ -1,0 +1,10 @@
+{
+  "run_id": "iterate-2026-05-21-fix-gh-security-emit-gate-symmetry",
+  "date": "2026-05-21T12:31:08.078768Z",
+  "type": "bug",
+  "complexity": "small",
+  "branch": "iterate/fix-gh-security-emit-gate-symmetry",
+  "spec": null,
+  "tests_passed": true,
+  "adr": "iterate-2026-05-21-fix-gh-security-emit-gate-symmetry"
+}

--- a/.shipwright/agent_docs/session_handoff.md
+++ b/.shipwright/agent_docs/session_handoff.md
@@ -1,35 +1,34 @@
 ---
 canon_generated: true
-run_id: "iterate-2026-05-21-post-43-hygiene"
+run_id: "iterate-2026-05-21-fix-gh-security-emit-gate-symmetry"
 phase: "iterate"
-reason: "iterate: post-#43 hygiene"
-timestamp: "2026-05-21T06:11:46.762633+00:00"
+reason: "iterate: fix-gh-security-emit-gate-symmetry"
+timestamp: "2026-05-21T12:31:00.366340+00:00"
 ---
 
 # Session Handoff
 
-> Auto-generated 2026-05-21 06:11:46 UTC
+> Auto-generated 2026-05-21 12:31:00 UTC
 
 ## Session Info
 
-- **Session ID**: f990b8ca-e767-4745-861f-9a142fcc95a4
-- **Timestamp**: 2026-05-21 06:11:46 UTC
-- **Reason**: iterate: post-#43 hygiene
+- **Session ID**: f8d0bbbe-d15f-480c-9e68-5c0eff518455
+- **Timestamp**: 2026-05-21 12:31:00 UTC
+- **Reason**: iterate: fix-gh-security-emit-gate-symmetry
 
 ## Last Iterate
 
-- **Run ID**: iterate-2026-05-21-security-artifact-producer
-- **Date**: 2026-05-20T22:59:00.667988Z
-- **Type**: feature
-- **Complexity**: medium
-- **Branch**: iterate/security-artifact-producer
-- **ADR**: iterate-2026-05-21-security-artifact-producer
+- **Run ID**: iterate-2026-05-21-post-43-hygiene
+- **Date**: 2026-05-21T06:11:49.195117Z
+- **Type**: bug
+- **Complexity**: small
+- **Branch**: iterate/post-43-hygiene
+- **ADR**: iterate-2026-05-21-post-43-hygiene
 - **Tests passed**: True
-- **Spec**: .shipwright/planning/iterate/2026-05-21-security-artifact-producer.md
 
 ## Current Iterate Progress
 
-- **Branch**: iterate/post-43-hygiene
+- **Branch**: iterate/fix-gh-security-emit-gate-symmetry
 - **External Review Marker**: skipped_missing_keys (external_review_state.json @ 2026-05-20T12:00:00)
 
 ### Mandatory replay on Resume
@@ -48,8 +47,8 @@ Before dispatching to the handoff's Remaining phase, run these if missing:
 
 ## Git State
 
-- **Branch**: iterate/post-43-hygiene
-- **Last Commit**: 161375b Merge pull request #44 from svenroth-ai/iterate/security-artifact-producer
+- **Branch**: iterate/fix-gh-security-emit-gate-symmetry
+- **Last Commit**: f2aaf89 feat(triage): producer contract schema + RTM-link fields + inbox polish (Iterate B0) (#52)
 - **Uncommitted Changes**: Yes
 
 ## Config Files to Read

--- a/.shipwright/compliance/change-history.md
+++ b/.shipwright/compliance/change-history.md
@@ -1,16 +1,16 @@
 # Commit Change Log
 
-Generated: 2026-05-21T06:11:46Z
-Total commits: 673
+Generated: 2026-05-21T12:31:00Z
+Total commits: 681
 
 ## Commit Distribution
 
 ```mermaid
 pie title Commit Types
-    "feat" : 223
-    "fix" : 177
+    "feat" : 228
+    "fix" : 179
     "chore" : 116
-    "docs" : 100
+    "docs" : 101
     "refactor" : 34
     "test" : 15
     "other" : 7
@@ -19,10 +19,15 @@ pie title Commit Types
 
 ## Changes by Type
 
-### Features (feat) — 223 commits
+### Features (feat) — 228 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-21 | triage | producer contract schema + RTM-link fields + inbox polish (Iterate B0) (#52) | f2aaf89cfea2 |
+| 2026-05-21 | handoff | 4-stage session-id fallback chain (Iterate A.4) (#50) | 822f5fae9f45 |
+| 2026-05-21 | adr | hard-reject ADR field overflow + spec_ref + INDEX.md (A.3) (#49) | 9addb9a3b404 |
+| 2026-05-21 | adopt | Mermaid architecture diagram + drift-sync marker (Iterate A.1) (#48) | 32448078c4cd |
+| 2026-05-21 | compliance | SBOM lockfile + importlib.metadata + workspace-aware (Phase 0f) (#47) | 932e0d221ea1 |
 | 2026-05-21 | triage | ingest shipwright-security artifact as gh-security action-unit (Iterate C) | 6f5dd5f23a1d |
 | 2026-05-20 | triage | redesign Triage Inbox as launch-surface (action-units + launchPayload + CLI) | 7b67acf60d70 |
 | 2026-05-19 | triage | import GitHub findings into the triage inbox | ff51a8cc80f1 |
@@ -247,10 +252,12 @@ pie title Commit Types
 | 2026-03-20 | — | Task 02 — project templates (CLAUDE.md, agent_docs, CI) | c3a6d2f53bd3 |
 | 2026-03-20 | — | Task 01 — monorepo scaffolding + supabase-nextjs stack profile | 990a138a4690 |
 
-### Fixes (fix) — 177 commits
+### Fixes (fix) — 179 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-21 | build | section-builder.md JSON examples conform to result schema (#51) | 823225e0942c |
+| 2026-05-21 | meta | post-#43 hygiene — promote escape-cell drift test + allowlist test_results.json (#45) | 3b34fcaeb502 |
 | 2026-05-21 | shared | escape pipe and newline in markdown table cells (#43) | 46b9ac47da28 |
 | 2026-05-19 | iterate | resolve decision-drop directory against the main repo (worktree-aware) | 0d4d3d61e3c0 |
 | 2026-05-19 | hooks | make file-size guard a non-blocking crossing-only nudge | c76c9bec8451 |
@@ -550,10 +557,11 @@ pie title Commit Types
 | 2026-03-28 | — | add shipwright-run uv.lock | ef1cc1ad180c |
 | 2026-03-20 | — | initial commit with spec and task list | 07ca9c1de51c |
 
-### Documentation (docs) — 100 commits
+### Documentation (docs) — 101 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-21 | test-status | record Phase 0d FAIL-row dismissals (shipwright) (#46) | f2a180edf5b7 |
 | 2026-05-21 | spec | append FR-01.14 acceptance criteria for the artifact ingestion path | 861c0fd83d1d |
 | 2026-05-16 | iterate | fix SKILL.md run_id format + stale F11 events.jsonl grep | 70f52f49f207 |
 | 2026-05-16 | — | align ASCII pipeline diagrams with profile-driven deploy | bd5a0b955ef1 |
@@ -736,7 +744,7 @@ pie title Commit Types
 
 | Metric | Value |
 |--------|-------|
-| Total commits | 673 |
+| Total commits | 681 |
 | AI-assisted commits | 0 |
-| Human-authored commits | 673 |
+| Human-authored commits | 681 |
 

--- a/.shipwright/compliance/dashboard.md
+++ b/.shipwright/compliance/dashboard.md
@@ -1,6 +1,6 @@
 # Compliance Dashboard
 
-Generated: 2026-05-21T06:11:46Z
+Generated: 2026-05-21T12:31:00Z
 Profile: python-plugin-monorepo
 Scope: library
 
@@ -15,7 +15,7 @@ Scope: library
 | All sections reviewed | 0/0 | WARN |
 | Architecture decisions | 53 ADRs | INFO |
 | Iterate tests passing | 35/37 iterations tested | WARN |
-| Dependencies | 5 packages | INFO |
+| Dependencies | 8 packages | INFO |
 | Copyleft risk | 0 | PASS |
 
 ## Project Velocity
@@ -28,6 +28,7 @@ Scope: library
 | Split | Status | Provider | Findings | Self-review fallback | Reason |
 |-------|--------|----------|----------|----------------------|--------|
 | 01-adopted | missing | — | 0 | no | — |
+| adr | missing | — | 0 | no | — |
 
 ## Compliance Artifacts
 

--- a/.shipwright/compliance/sbom.md
+++ b/.shipwright/compliance/sbom.md
@@ -1,38 +1,43 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-05-21T06:11:46Z
+Generated: 2026-05-21T12:31:00Z
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Runtime dependencies | 3 |
+| Runtime dependencies | 6 |
 | Dev dependencies | 2 |
-| Total packages | 5 |
-| Unique licenses | 1 (unknown) |
+| Total packages | 8 |
+| Unique licenses | 3 (Apache-2.0, MIT, unknown) |
 | Copyleft licenses | 0 |
 
 ## License Distribution
 
 ```mermaid
 pie title License Distribution
-    "unknown" : 5
+    "MIT" : 4
+    "Apache-2.0" : 2
+    "unknown" : 2
 ```
 
 ## Runtime Dependencies
 
 | Package | Version | License |
 |---------|---------|---------|
-| jsonschema | 4.18 | unknown |
-| openai | 2.30.0 | unknown |
-| pyyaml | 6.0 | unknown |
+| google-genai | 1.0.0 | unknown |
+| jsonschema | 4.18 | MIT |
+| openai | 2.30.0 | Apache-2.0 |
+| openai | 1.0.0 | Apache-2.0 |
+| pyyaml | 6.0 | MIT |
+| requests | 2.31.0 | unknown |
 
 ## Dev Dependencies
 
 | Package | Version | License |
 |---------|---------|---------|
-| pytest | 8.0.0 | unknown |
-| pytest-mock | 3.12.0 | unknown |
+| pytest | 8.0.0 | MIT |
+| pytest-mock | 3.12.0 | MIT |
 
 ## License Compliance
 
@@ -40,13 +45,10 @@ No copyleft licenses detected. All dependencies are permissively licensed or unk
 
 ## Unknown Licenses
 
-**5 packages** have unknown licenses. Install dependencies (`npm install` / `uv sync`) and regenerate to detect licenses.
+**2 packages** have unknown licenses. Install dependencies (`npm install` / `uv sync`) and regenerate to detect licenses.
 
 | Package | Version | Type |
 |---------|---------|------|
-| jsonschema | 4.18 | runtime |
-| openai | 2.30.0 | runtime |
-| pytest | 8.0.0 | dev |
-| pytest-mock | 3.12.0 | dev |
-| pyyaml | 6.0 | runtime |
+| google-genai | 1.0.0 | runtime |
+| requests | 2.31.0 | runtime |
 

--- a/.shipwright/compliance/test-evidence.md
+++ b/.shipwright/compliance/test-evidence.md
@@ -1,6 +1,6 @@
 # Test Evidence Report
 
-Generated: 2026-05-21T06:11:46Z
+Generated: 2026-05-21T12:31:00Z
 
 ## Summary
 

--- a/.shipwright/compliance/traceability-matrix.md
+++ b/.shipwright/compliance/traceability-matrix.md
@@ -1,6 +1,6 @@
 # Requirements Traceability Matrix
 
-Generated: 2026-05-21T06:11:46Z
+Generated: 2026-05-21T12:31:00Z
 
 ## Requirements Coverage
 

--- a/CHANGELOG-unreleased.d/Fixed/iterate-2026-05-21-fix-gh-security-emit-gate-symmetry_001.md
+++ b/CHANGELOG-unreleased.d/Fixed/iterate-2026-05-21-fix-gh-security-emit-gate-symmetry_001.md
@@ -1,0 +1,1 @@
+Triage gh-security emit-gate test fixture: stub artifact-path fetchers in test_github_triage_action_units.py::_patch_api so the partial-fetch parametrize cases no longer leak real workflow runs from worktree gh context (4/4 cases now pass deterministically)

--- a/shared/tests/test_github_triage_action_units.py
+++ b/shared/tests/test_github_triage_action_units.py
@@ -136,6 +136,20 @@ def _patch_api(
     )
     monkeypatch.setattr(github_api, "fetch_workflow_runs", lambda branch: runs)
     monkeypatch.setattr(github_api, "owner_repo", lambda _: owner_repo_value)
+    # Stub the artifact-path fetchers (Iterate C). Without these, tests
+    # run inside a worktree whose origin has a real ``security.yml``
+    # workflow leak production data into the artifact fallback and emit
+    # an unintended ``gh-security:`` action-unit — defeating any
+    # partial-fetch assertions below. Action-unit tests targeting the
+    # API path explicitly opt out of the artifact path; per-artifact
+    # tests live in test_github_triage_artifact_fallback.py and patch
+    # these directly.
+    monkeypatch.setattr(
+        github_api, "latest_security_workflow_run", lambda: None,
+    )
+    monkeypatch.setattr(
+        github_api, "download_security_findings", lambda run_id: None,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/shipwright_test_results.json
+++ b/shipwright_test_results.json
@@ -1,28 +1,35 @@
 {
   "iterate_latest": {
-    "run_id": "iterate-2026-05-21-post-43-hygiene",
+    "run_id": "iterate-2026-05-21-fix-gh-security-emit-gate-symmetry",
     "date": "2026-05-21",
     "unit": {
       "status": "passed",
-      "passed": 2048,
-      "total": 2048,
-      "note": "Full shared/tests/ suite green (2048 passed, 12 skipped, 18 deselected, 0 failed). The pre-existing baseline failure from PR #42 is gone: PR #44 added record_event.py to ALLOWLIST while it was in flight, and this iterate adds shipwright_test_results.json to all 4 ALLOWLISTs in artifact_migrations.py (planning, designs, agent_docs, compliance migrations) so iterate-prose notes referencing pipeline-phase names by word don't false-trip the lint. Plus 6 new parametrized cases in plugins/shipwright-compliance/tests/test_markdown_table_wrap_drift.py promoting the one-shot probe from PR #43 to a permanent drift-test; verified empirically by un-wrapping one cell in change_history.py and re-running (test caught the regression and reported the specific generator+field pair)."
+      "passed": 2101,
+      "total": 2113
     },
     "integration": {
-      "status": "passed",
-      "passed": 110,
-      "total": 110,
-      "note": "integration-tests/ green — 110/110 (2 deselected as slow)."
+      "status": "not_run",
+      "passed": 0,
+      "total": 0
     },
-    "pgtap": {"status": "not_run", "passed": 0, "total": 0, "note": "No SQL/RLS changes."},
-    "e2e": {"status": "not_run", "passed": 0, "total": 0, "note": "No web surface — lint/test-only iterate."},
-    "design_fidelity": {"status": "not_run", "passed": 0, "total": 0, "note": "No UI."},
-    "smoke": {"status": "not_run", "note": "No browser/server surface."},
-    "degraded": [
-      {
-        "condition": "external_review_skipped_small_complexity",
-        "detail": "External LLM review skipped at small complexity per the Phase Matrix (skip / skip / auto / -). No risk flags fired. Self-review only."
-      }
-    ]
+    "pgtap": {
+      "status": "not_run",
+      "passed": 0,
+      "total": 0
+    },
+    "e2e": {
+      "status": "skipped",
+      "passed": 0,
+      "total": 0
+    },
+    "design_fidelity": {
+      "status": "skipped",
+      "passed": 0,
+      "total": 0
+    },
+    "smoke": {
+      "status": "not_run"
+    },
+    "degraded": []
   }
 }


### PR DESCRIPTION
## Summary

Fixes the 2 failing parametrize cases of
`test_security_emit_requires_both_feeds_succeeded`:

- `cs_failed_db_empty` (cs=None, db=[])
- `cs_failed_db_has_findings` (cs=None, db=[DB_CRITICAL])

## Diagnosis (differs from the brief)

The brief hypothesised an asymmetric API-path None check in
`shared/scripts/github_triage.py`. Investigation showed the API-path
emit gate at [github_triage.py:785-787](shared/scripts/github_triage.py#L785-L787)
is **already symmetric**:

```python
both_security_feeds_ok = (cs_alerts is not None and db_alerts is not None)
```

The actual leak is in the **test fixture**: Iterate C (commit
[6f5dd5f](https://github.com/svenroth-ai/shipwright/commit/6f5dd5f))
added the artifact fallback path at lines 740-755 + 870-885. The
pre-existing test (added in commit
[7b67acf](https://github.com/svenroth-ai/shipwright/commit/7b67acf),
**before** Iterate C) doesn't stub `latest_security_workflow_run` /
`download_security_findings` in its `_patch_api` helper. When the test
runs in a worktree with real `gh` CLI access (every dev machine), the
artifact path leaks real data from `svenroth-ai/shipwright`'s
`security.yml` workflow runs, materialises 35 findings, and emits a
`gh-security:acme/foo` dedup-key — even though `owner_repo` is patched.

I verified by tracing: `latest_security_workflow_run()` returned a
real run id 26195036492, `download_security_findings()` returned 35
real findings, `by_source["gh-security:artifact"] = 1`.

## Fix

Update `_patch_api` in
[test_github_triage_action_units.py](shared/tests/test_github_triage_action_units.py#L117-L138)
to also stub the two artifact functions to `None` by default. Production
code is unchanged. The artifact-fallback test suite
(`test_github_triage_artifact_fallback.py`) patches these explicitly
with its own fixture data, so its semantics are unaffected.

## Why no production change

Tightening the artifact-path gate (e.g., require `db_alerts is not None`,
or require both `cs` and `db` to be `None`) directly conflicts with
`test_no_ghas_with_dependabot_available_and_artifact_emits` and
`test_no_ghas_with_dependabot_available_and_clean_artifact_auto_resolves`,
which establish the artifact path as dependabot-orthogonal per
Iterate C external review code finding openai-4. No production-code
change satisfies both test invariants without breaking adjacent tests.

## Verification

- `uv run --extra dev pytest shared/tests/test_github_triage_action_units.py::test_security_emit_requires_both_feeds_succeeded -v` — **all 4 pass**
- `uv run --extra dev pytest shared/tests/test_github_triage_action_units.py shared/tests/test_github_triage.py shared/tests/test_github_triage_artifact_fallback.py` — **73 passed**
- `uv run --extra dev pytest shared/tests/` — **2101 passed, 12 skipped, 0 failed**

Fixes parametrize IDs:
`cs_failed_db_empty`, `cs_failed_db_has_findings`.

## Test plan

- [x] All 4 parametrize cases of `test_security_emit_requires_both_feeds_succeeded` pass
- [x] `test_security_partial_fetch_does_not_resolve_existing_item` still passes (now without environment dependency)
- [x] All 18 tests in `test_github_triage_artifact_fallback.py` still pass
- [x] Full `shared/tests/` suite green (2101 passed)

## Notes

F0 leak-guard flagged 6 paths in the main repo working tree owned by a
**concurrent** iterate (`iterate/b1-compliance-dashboard-mode-aware`) —
not from this run. My worktree had exactly 1 modified file (the test
fixture fix). Run-ID: `iterate-2026-05-21-fix-gh-security-emit-gate-symmetry`.

Run-ID: iterate-2026-05-21-fix-gh-security-emit-gate-symmetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)