### PR TITLE
chore(canon): allowlist .shipwright/planning/adr/**.md in compliance migration

### DIFF
--- a/shared/scripts/lib/artifact_migrations.py
+++ b/shared/scripts/lib/artifact_migrations.py
@@ -148,6 +148,12 @@ ALLOWLIST: dict[str, list[str]] = {
         # inbox-1a after external/code review captures landed under
         # .shipwright/planning/iterate/.
         ".shipwright/planning/iterate/**.json",
+        # iterate-2026-05-21-triage-producer-contract (A.3 / B0+) — long-form
+        # ADR spec files (e.g. `054-triage-producer-contract.md`,
+        # `055-compliance-dashboard-mode-aware.md`) discuss
+        # `shipwright-compliance` and `compliance_report.py` as plugin /
+        # phase names by design. Same class as the iterate-spec entry above.
+        ".shipwright/planning/adr/**.md",
         # Layer 2 setup-contract test — intentionally asserts that the legacy
         # path is NOT created. Must reference legacy by name to do so.
         "shared/tests/test_setup_writes_canonical.py",
@@ -217,6 +223,12 @@ ALLOWLIST: dict[str, list[str]] = {
         # inbox-1a after external/code review captures landed under
         # .shipwright/planning/iterate/.
         ".shipwright/planning/iterate/**.json",
+        # iterate-2026-05-21-triage-producer-contract (A.3 / B0+) — long-form
+        # ADR spec files (e.g. `054-triage-producer-contract.md`,
+        # `055-compliance-dashboard-mode-aware.md`) discuss
+        # `shipwright-compliance` and `compliance_report.py` as plugin /
+        # phase names by design. Same class as the iterate-spec entry above.
+        ".shipwright/planning/adr/**.md",
         # Layer-2 setup-contract test references both paths by design
         "shared/tests/test_setup_writes_canonical.py",
         # Migration tooling (CLI + helpers) takes artifact name as argument
@@ -279,6 +291,12 @@ ALLOWLIST: dict[str, list[str]] = {
         # inbox-1a after external/code review captures landed under
         # .shipwright/planning/iterate/.
         ".shipwright/planning/iterate/**.json",
+        # iterate-2026-05-21-triage-producer-contract (A.3 / B0+) — long-form
+        # ADR spec files (e.g. `054-triage-producer-contract.md`,
+        # `055-compliance-dashboard-mode-aware.md`) discuss
+        # `shipwright-compliance` and `compliance_report.py` as plugin /
+        # phase names by design. Same class as the iterate-spec entry above.
+        ".shipwright/planning/adr/**.md",
         "shipwright_project_config.json",
         # Layer-2 setup-contract test references both paths by design
         "shared/tests/test_setup_writes_canonical.py",
@@ -379,6 +397,12 @@ ALLOWLIST: dict[str, list[str]] = {
         # inbox-1a after external/code review captures landed under
         # .shipwright/planning/iterate/.
         ".shipwright/planning/iterate/**.json",
+        # iterate-2026-05-21-triage-producer-contract (A.3 / B0+) — long-form
+        # ADR spec files (e.g. `054-triage-producer-contract.md`,
+        # `055-compliance-dashboard-mode-aware.md`) discuss
+        # `shipwright-compliance` and `compliance_report.py` as plugin /
+        # phase names by design. Same class as the iterate-spec entry above.
+        ".shipwright/planning/adr/**.md",
         # Layer-2 setup-contract test references both paths by design
         "shared/tests/test_setup_writes_canonical.py",
         # Edge-case test file that intentionally references both paths (introduced in designs migration)


### PR DESCRIPTION
## Summary

Tiny follow-up to Iterate B.1: the ADR spec folder convention introduced in A.3 (PR #49) wasn't covered by the canon-lint allowlist. B.1's ADR spec file (`055-compliance-dashboard-mode-aware.md`) contains the literal string `compliance_report.py` as a code-path reference and tripped the compliance-migration drift check on the default branch.

Add `.shipwright/planning/adr/**.md` to all four migration allowlists (planning, agent_docs, designs, compliance) — same class as the existing `.shipwright/planning/iterate/**.md` entry.

## Verification

- [x] `shared/tests/test_artifact_path_canon.py` — 4 passed
- [x] `shared/tests/` — 2101 passed (was 2100 with 1 fail on default branch before this fix)

Generated with Claude Code