### PR TITLE
security: fix nosemgrep attribution (PR #68 follow-up, 13 SAST findings)

### DIFF
--- a/plugins/shipwright-adopt/scripts/lib/compliance_bridge.py
+++ b/plugins/shipwright-adopt/scripts/lib/compliance_bridge.py
@@ -100,6 +100,8 @@ def run_lib_fallback(project_root: Path) -> dict[str, Any]:
         ("compliance_report", f"{_COMPLIANCE_DIR}/dashboard.md"),
     ]:
         try:
+            # `mod_name` comes from the hardcoded for-loop allowlist above (sbom_generator, change_history, etc.), not user input.
+            # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
             mod = importlib.import_module(f"lib.{mod_name}")
             out = mod.generate(data) if hasattr(mod, "generate") else None
             if out is not None:

--- a/plugins/shipwright-compliance/scripts/audit/audit_adapters.py
+++ b/plugins/shipwright-compliance/scripts/audit/audit_adapters.py
@@ -142,8 +142,8 @@ def verify_imports(symbols: list[tuple[str, str, int]] | None = None) -> None:
 
     for module_path, symbol, min_arity in symbols:
         try:
-            # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
             # `module_path` comes from the hardcoded REQUIRED_SYMBOLS constant (no user input).
+            # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
             mod = importlib.import_module(module_path)
         except ImportError as exc:
             errors.append(f"{module_path}: module not importable ({exc})")

--- a/plugins/shipwright-deploy/scripts/lib/jelastic_client.py
+++ b/plugins/shipwright-deploy/scripts/lib/jelastic_client.py
@@ -52,8 +52,8 @@ class JelasticClient:
         req.add_header("Content-Type", "application/x-www-form-urlencoded")
 
         try:
-            # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             # URL is constructed from self.api_url (Jelastic API endpoint configured at client init) + a fixed endpoint path.
+            # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             with urllib.request.urlopen(req, timeout=60) as response:
                 body = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as e:

--- a/plugins/shipwright-test/scripts/lib/test_runner.py
+++ b/plugins/shipwright-test/scripts/lib/test_runner.py
@@ -88,10 +88,9 @@ def run_tests(command: str, cwd: str | None = None) -> dict:
         # (npm.cmd, yarn.cmd, pnpm.cmd) which subprocess cannot resolve with shell=False.
         # `command` comes from the trusted shipwright profile configuration (testing.commands.*),
         # not from user input. Profile files are project-internal and version-controlled.
-        # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
         proc = subprocess.run(
             command,
-            shell=True,
+            shell=True,  # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
             capture_output=True,
             text=True,
             encoding="utf-8",

--- a/plugins/shipwright-test/scripts/lib/test_runner.py
+++ b/plugins/shipwright-test/scripts/lib/test_runner.py
@@ -84,11 +84,11 @@ def run_tests(command: str, cwd: str | None = None) -> dict:
     start = time.monotonic()
 
     try:
-        # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
         # shell=True is required for cross-platform support of Windows .cmd shims
         # (npm.cmd, yarn.cmd, pnpm.cmd) which subprocess cannot resolve with shell=False.
         # `command` comes from the trusted shipwright profile configuration (testing.commands.*),
         # not from user input. Profile files are project-internal and version-controlled.
+        # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true
         proc = subprocess.run(
             command,
             shell=True,

--- a/shared/scripts/dev_server.py
+++ b/shared/scripts/dev_server.py
@@ -408,8 +408,8 @@ def _http_probe(url: str, timeout: float = 2.0) -> bool:
     """Issue a GET; accept 2xx/3xx as ready. Errors / 4xx / 5xx → not ready."""
     try:
         req = urllib.request.Request(url, method="GET")
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         # URL targets a local dev service (localhost/127.0.0.1 + configured port); not driven by external user input.
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             status = resp.status
             return 200 <= status < 400

--- a/shared/scripts/lib/phase_quality.py
+++ b/shared/scripts/lib/phase_quality.py
@@ -576,8 +576,8 @@ def run_workflow_checks(phase: str, project_root: Path, run_id: str) -> list[dic
     skip_ids = skipped_check_ids()
     try:
         import importlib
-        # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
         # `module_name` comes from the internal _WORKFLOW_PHASE_DISPATCH allowlist (no user input).
+        # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
         module = importlib.import_module(f"tools.verifiers.{module_name}")
         findings = module.run(project_root, run_id)
     except Exception as exc:  # noqa: BLE001
@@ -609,8 +609,8 @@ def _dispatch_shared_category(
     skip_ids = skipped_check_ids()
     try:
         import importlib
-        # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
         # `module_name` is a caller-supplied internal verifier name (Infra/Trace/Quality), not user input.
+        # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
         module = importlib.import_module(f"tools.verifiers.{module_name}")
         findings = module.run(phase, project_root)
     except Exception as exc:  # noqa: BLE001

--- a/shared/scripts/lib/worktree_isolation.py
+++ b/shared/scripts/lib/worktree_isolation.py
@@ -104,8 +104,8 @@ def run_git(
     - ``TimeoutExpired`` kills + reaps so no zombie git.exe lingers.
     - ``check=True`` raises :class:`GitError` on non-zero exit.
     """
-    # nosemgrep: python.lang.compatibility.python36.python36-compatibility-Popen1,python.lang.compatibility.python36.python36-compatibility-Popen2
     # `encoding` and `errors` kwargs are available since Python 3.6 — the project requires 3.11+ (see pyproject.toml).
+    # nosemgrep: python.lang.compatibility.python36.python36-compatibility-Popen1,python.lang.compatibility.python36.python36-compatibility-Popen2
     proc = subprocess.Popen(
         ["git", "--no-pager", "-C", str(cwd), *args],
         stdout=subprocess.PIPE,

--- a/shared/scripts/smoke_test.py
+++ b/shared/scripts/smoke_test.py
@@ -58,8 +58,8 @@ def run_smoke_test(
         req = urllib.request.Request(url, method="GET")
         req.add_header("User-Agent", "shipwright-smoke-test/0.1")
 
-        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         # Smoke-test target URL comes from the deploy config (operator-supplied at deploy time).
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
         with urllib.request.urlopen(req, timeout=timeout) as response:
             elapsed = (time.monotonic() - start) * 1000
             result["status_code"] = response.status
@@ -88,8 +88,8 @@ def run_smoke_test(
             req = urllib.request.Request(health_url, method="GET")
             req.add_header("User-Agent", "shipwright-smoke-test/0.1")
 
-            # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             # Health URL is the smoke-test URL + a configured health-check path; both from deploy config.
+            # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             with urllib.request.urlopen(req, timeout=timeout) as response:
                 body = response.read().decode("utf-8")
                 try:

--- a/shared/scripts/tools/list_iterate_branches.py
+++ b/shared/scripts/tools/list_iterate_branches.py
@@ -76,8 +76,8 @@ def run_git(
       for calls where non-zero is semantic (e.g., ``merge-base
       --is-ancestor`` returns 0/1 as truth values).
     """
-    # nosemgrep: python.lang.compatibility.python36.python36-compatibility-Popen1,python.lang.compatibility.python36.python36-compatibility-Popen2
     # `encoding` and `errors` kwargs are available since Python 3.6 — the project requires 3.11+ (see pyproject.toml).
+    # nosemgrep: python.lang.compatibility.python36.python36-compatibility-Popen1,python.lang.compatibility.python36.python36-compatibility-Popen2
     proc = subprocess.Popen(
         ["git", "--no-pager", "-C", str(cwd), *args],
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary

**Follow-up to [PR #68](https://github.com/svenroth-ai/shipwright/pull/68).** The post-merge security scan on main ([run 26312616253](https://github.com/svenroth-ai/shipwright/actions/runs/26312616253)) revealed that 12 of the 13 nosemgrep suppressions in PR #68 did not take effect — semgrep requires the `# nosemgrep:` comment to be **immediately adjacent** to the flagged line, but PR #68 placed a justification comment between them.

| Worked in PR #68 | Did NOT work |
|---|---|
| ✅ performance_check.py (nosemgrep was on adjacent line) | ❌ All other 12 sites (justification comment in between) |

This commit swaps the comment order from `nosemgrep + justification + code` to `justification + nosemgrep + code` in 11 files, and adds a missing nosemgrep to `compliance_bridge.py:103` (the `__import__` → `importlib.import_module` refactor in PR #68 moved the finding from the prompt-injection scanner into semgrep's `non-literal-import` rule).

Expected post-merge scan: **13 → 0 findings.**

## Affected files

- `shared/scripts/lib/worktree_isolation.py` (Popen Py3.6 compat false-positive)
- `shared/scripts/tools/list_iterate_branches.py` (same)
- `plugins/shipwright-compliance/scripts/audit/audit_adapters.py` (importlib allowlist)
- `shared/scripts/lib/phase_quality.py` (importlib allowlist, 2 sites)
- `plugins/shipwright-deploy/scripts/lib/jelastic_client.py` (config-driven urllib)
- `shared/scripts/dev_server.py` (localhost urllib)
- `shared/scripts/smoke_test.py` (deploy-config urllib, 2 sites)
- `plugins/shipwright-test/scripts/lib/test_runner.py` (Windows .cmd shell=True)
- `plugins/shipwright-adopt/scripts/lib/compliance_bridge.py` (NEW finding from PR #68 refactor)

## Test plan

- [ ] CI security scan runs on this branch — should report 0 findings
- [ ] CI unit tests still pass (no behavioral change, only comment-line reordering + 1 added comment)
- [ ] Manual: verify each modified line in the diff to confirm nosemgrep is now adjacent

## Notes

The justification text is unchanged in every case — reviewer-facing rationale stays intact, only the comment ORDER changed. The compliance_bridge.py addition uses the same allowlist-justified pattern as audit_adapters.py since both load internal modules from hardcoded for-loop tuples.

Refs: PR #68 (security/oss-sweep-2026-05-22 → main, 39 findings closed via dep bumps + SAST suppressions).