### PR TITLE
fix(iterate): F7b seals tracked event-log appends to prevent silent reset wipe

### DIFF
--- a/.shipwright/agent_docs/build_dashboard.md
+++ b/.shipwright/agent_docs/build_dashboard.md
@@ -1,10 +1,11 @@
 # Project Activity Dashboard
-> Updated: 2026-05-22 13:10 UTC | Session: 18bf1094-aa14-43b4-b60e-a1cf98127cbf | Run: iterate-2026-05-22-reconcile-d1-fr-coverage
+> Updated: 2026-05-22 13:11 UTC | Session: 18bf1094-aa14-43b4-b60e-a1cf98127cbf | Run: iterate-2026-05-23-iterate-f7-tracked-event-log-commit
 
-## Recent Changes (45 iterations)
+## Recent Changes (46 iterations)
 
 | Type | Description | Tests | Commit | FRs | Date |
 |------|-------------|-------|--------|-----|------|
+| change | compliance reconciliation: D1 spec-FR coverage — multi-FR event covering FR-01.03/04/05/06/07/08/09/12 (post-2026-05-04 watermark gap; no source/test/spec changes) | 0/0 | 1ca566a | FR-01.03, FR-01.04, FR-01.05 | 2026-05-22 |
 | Fix partial-run audit incorrectly dismissing out-of-scope compliance triage items | mirror_findings_to_triage now scoped to groups_run; --only E no longer dismisses A/B/C/D items | 0/0 | 09fedde | tooling | 2026-05-22 |
 | Re-aggregate triage inbox to surface SBOM bug cluster (trg-8bc99ae4) and commit regen artifacts | Re-aggregated triage_inbox.md; refreshed sbom.md, dashboard.md, test-evidence.md, traceability-matrix.md, change-history.md, session_handoff.md, build_dashboard.md | 0/0 | 69f1498 | compliance | 2026-05-22 |
 | Re-aggregate triage inbox to surface SBOM bug cluster (trg-8bc99ae4) and commit regen artifacts | Re-aggregated triage_inbox.md; refreshed sbom.md, dashboard.md, test-evidence.md, traceability-matrix.md, change-history.md, session_handoff.md, build_dashboard.md | 0/0 | 69f1498 | compliance | 2026-05-22 |
@@ -52,7 +53,7 @@
 | change | post-adoption framework cleanup (Sub-1A through 1D) | 225/225 | 3db485b | FR-01.01, FR-01.02, FR-01.03 | 2026-05-02 |
 
 ## Test Status
-Last run: 2026-05-22 | Smoke: not_run | (iterate)
+Last run: 2026-05-23 | Unit: 6/6 | Smoke: not_run | (iterate)
 
 ## Pipeline
 

--- a/.shipwright/agent_docs/iterates/iterate-2026-05-23-iterate-f7-tracked-event-log-commit.json
+++ b/.shipwright/agent_docs/iterates/iterate-2026-05-23-iterate-f7-tracked-event-log-commit.json
@@ -1,0 +1,10 @@
+{
+  "run_id": "iterate-2026-05-23-iterate-f7-tracked-event-log-commit",
+  "date": "2026-05-22T22:19:40.369431Z",
+  "type": "change",
+  "complexity": "small",
+  "branch": "iterate/iterate-f7-tracked-event-log-commit",
+  "spec": null,
+  "tests_passed": true,
+  "adr": "iterate-2026-05-23-iterate-f7-tracked-event-log-commit"
+}

--- a/.shipwright/agent_docs/session_handoff.md
+++ b/.shipwright/agent_docs/session_handoff.md
@@ -1,39 +1,35 @@
 ---
 canon_generated: true
-run_id: "iterate-2026-05-22-reconcile-d1-fr-coverage"
+run_id: "iterate-2026-05-23-iterate-f7-tracked-event-log-commit"
 phase: "iterate"
-reason: "iterate: reconcile D1 spec-FR coverage in events"
-timestamp: "2026-05-22T13:10:04.800918+00:00"
+reason: "iterate: F7-followup commit for tracked event log"
+timestamp: "2026-05-22T13:11:13.026162+00:00"
 ---
 
 # Session Handoff
 
-> Auto-generated 2026-05-22 13:10:04 UTC
+> Auto-generated 2026-05-22 13:11:13 UTC
 
 ## Session Info
 
 - **Session ID**: 18bf1094-aa14-43b4-b60e-a1cf98127cbf
-- **Timestamp**: 2026-05-22 13:10:04 UTC
-- **Reason**: iterate: reconcile D1 spec-FR coverage in events
+- **Timestamp**: 2026-05-22 13:11:13 UTC
+- **Reason**: iterate: F7-followup commit for tracked event log
 
 ## Last Iterate
 
-- **Run ID**: iterate-2026-05-22-reconcile-d1-fr-coverage
-- **Date**: 2026-05-22T13:09:50.649783Z
+- **Run ID**: iterate-2026-05-23-iterate-f7-tracked-event-log-commit
+- **Date**: 2026-05-22T22:19:40.369431Z
 - **Type**: change
 - **Complexity**: small
-- **Branch**: iterate/reconcile-d1-fr-coverage
-- **ADR**: iterate-2026-05-22-reconcile-d1-fr-coverage
+- **Branch**: iterate/iterate-f7-tracked-event-log-commit
+- **ADR**: iterate-2026-05-23-iterate-f7-tracked-event-log-commit
 - **Tests passed**: True
-- **Spec**: .shipwright/planning/iterate/2026-05-22-reconcile-d1-fr-coverage.md
 
 ## Current Iterate Progress
 
-- **Branch**: iterate/reconcile-d1-fr-coverage
-- **Run ID**: iterate-2026-05-22-reconcile-d1-fr-coverage
-- **Spec**: .shipwright/planning/iterate/2026-05-22-reconcile-d1-fr-coverage.md
-- **Complexity**: small
-- **External Review Marker**: stale (predates spec (2026-05-22T00:00:01))
+- **Branch**: iterate/iterate-f7-tracked-event-log-commit
+- **External Review Marker**: skipped_missing_keys (external_review_state.json @ 2026-05-22T00:00:01)
 
 ### Mandatory replay on Resume
 
@@ -51,8 +47,8 @@ Before dispatching to the handoff's Remaining phase, run these if missing:
 
 ## Git State
 
-- **Branch**: iterate/reconcile-d1-fr-coverage
-- **Last Commit**: 8382ff9 fix(meta): deterministic render timestamps from max(event.ts) (#66)
+- **Branch**: iterate/iterate-f7-tracked-event-log-commit
+- **Last Commit**: c5b3208 chore(events): restore 9 lost event-log entries after `git reset --hard` (#70)
 - **Uncommitted Changes**: Yes
 
 ## Config Files to Read
@@ -61,24 +57,24 @@ Before dispatching to the handoff's Remaining phase, run these if missing:
 - `shipwright_project_config.json` — exists
 - `shipwright_plan_config.json` — exists
 - `shipwright_build_config.json` — exists
-- `shipwright_security_config.json` — missing
+- `shipwright_security_config.json` — exists
 - `shipwright_compliance_config.json` — exists
 
 ## Last Events
 
 | Event | Type | Source | Date |
 |-------|------|--------|------|
+| evt-ddb23fe7 | work_completed | iterate (compliance reconciliation: D1 spec-FR coverage — multi-FR event covering FR-01.03/04/05/06/07/08/09/12 (post-2026-05-04 watermark gap; no source/test/spec changes)) | 2026-05-22 |
 | evt-1bd33db1 | work_completed | iterate (mirror_findings_to_triage now scoped to groups_run; --only E no longer dismisses A/B/C/D items) | 2026-05-22 |
 | evt-c817e0b9 | work_completed | iterate (Re-aggregated triage_inbox.md; refreshed sbom.md, dashboard.md, test-evidence.md, traceability-matrix.md, change-history.md, session_handoff.md, build_dashboard.md) | 2026-05-22 |
 | evt-da3e7e51 | work_completed | iterate (Re-aggregated triage_inbox.md; refreshed sbom.md, dashboard.md, test-evidence.md, traceability-matrix.md, change-history.md, session_handoff.md, build_dashboard.md) | 2026-05-22 |
 | evt-3277175b | work_completed | iterate (Extended g2_stoplist with 13 cross-cutting monorepo scopes; backfilled ADR-054..061 stubs in decision_log.md; regenerated RTM/test-evidence/dashboard) | 2026-05-22 |
-| evt-af75507f | work_completed | iterate (deterministic render timestamps from max(event.ts)) | 2026-05-21 |
 
 ## Recovery
 
 - **Pipeline**: 1 phases completed
-- **Total work events**: 45
-- **Last iterate**: Fix partial-run audit incorrectly dismissing out-of-scope compliance triage items — mirror_findings_to_triage now scoped to groups_run; --only E no longer dismisses A/B/C/D items (2026-05-22)
+- **Total work events**: 46
+- **Last iterate**: change — compliance reconciliation: D1 spec-FR coverage — multi-FR event covering FR-01.03/04/05/06/07/08/09/12 (post-2026-05-04 watermark gap; no source/test/spec changes) (2026-05-22)
 - **Resume**: `/shipwright-iterate` for next change, or `/shipwright-run` for new pipeline
 
 ## Recent Decisions

--- a/.shipwright/compliance/change-history.md
+++ b/.shipwright/compliance/change-history.md
@@ -1,17 +1,17 @@
 # Commit Change Log
 
-Generated: 2026-05-22T13:10:04Z
-Total commits: 695
+Generated: 2026-05-22T13:11:13.026162+00:00
+Total commits: 705
 
 ## Commit Distribution
 
 ```mermaid
 pie title Commit Types
     "feat" : 236
-    "fix" : 181
-    "chore" : 117
+    "fix" : 184
+    "chore" : 123
     "docs" : 104
-    "refactor" : 34
+    "refactor" : 35
     "test" : 15
     "other" : 7
     "build" : 1
@@ -260,10 +260,13 @@ pie title Commit Types
 | 2026-03-20 | — | Task 02 — project templates (CLAUDE.md, agent_docs, CI) | c3a6d2f53bd3 |
 | 2026-03-20 | — | Task 01 — monorepo scaffolding + supabase-nextjs stack profile | 990a138a4690 |
 
-### Fixes (fix) — 181 commits
+### Fixes (fix) — 184 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-22 | security | inline nosemgrep on shell=True line (semgrep flags kwarg, not call) | 69319684056a |
+| 2026-05-22 | security | place nosemgrep directly adjacent to flagged line | eeab07c9d2e5 |
+| 2026-05-22 | security | hoist github context to env in security workflow (semgrep run-shell-injection) | 81fdc7c0c687 |
 | 2026-05-21 | meta | deterministic render timestamps from max(event.ts) (#66) | 8382ff90bbb2 |
 | 2026-05-21 | triage | gate gh-security action-unit emit on artifact stub in test fixture (#54) | f4a1ff11636e |
 | 2026-05-21 | build | section-builder.md JSON examples conform to result schema (#51) | 823225e0942c |
@@ -446,10 +449,16 @@ pie title Commit Types
 | 2026-03-21 | — | rename skill folders for clean slash commands | 5a8d77658fab |
 | 2026-03-20 | — | update README attribution to svenroth.ai | dd5de7f7d6ab |
 
-### Chores (chore) — 117 commits
+### Chores (chore) — 123 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-23 | events | restore 9 lost event-log entries after `git reset --hard` (#70) | c5b3208b205d |
+| 2026-05-22 | security | persist remediation results from PR #68 | 6b8e3e8042d7 |
+| 2026-05-22 | compliance | reconcile D1 spec-FR coverage in events (#67) | b379a3063a90 |
+| 2026-05-22 | security | suppress 9 by-design SAST findings with justifications | d3d30eaee778 |
+| 2026-05-22 | security | suppress 4 false-positive Popen Py3.6 compat warnings | 6ecc71fa080a |
+| 2026-05-22 | security | bump deps to patch 21 SCA findings (CI run 26195036492) | 2bdf61482c52 |
 | 2026-05-21 | canon | allowlist .shipwright/planning/adr/**.md in compliance migration (#55) | 5c067485c5d7 |
 | 2026-05-20 | phase-0a | backfill FRs + add change_type schema field (#42) | fd212b23ab58 |
 | 2026-05-19 | — | remove gitignore entry for deleted triage handoff doc | 90af09980d93 |
@@ -677,10 +686,11 @@ pie title Commit Types
 | 2026-03-21 | — | expand README with pipeline diagram, architecture, and quality gates | 377dc2141b3d |
 | 2026-03-20 | — | add README.md for GitHub repo | 853c8f930132 |
 
-### Refactoring (refactor) — 34 commits
+### Refactoring (refactor) — 35 commits
 
 | Date | Scope | Description | Commit |
 |------|-------|-------------|--------|
+| 2026-05-22 | security | replace 4 dynamic __import__ calls with normal imports | d67b6f02d3bf |
 | 2026-05-11 | tests | centralize CI-discipline helpers + Self-Review § 8 probe | 16618252250b |
 | 2026-05-11 | tests | hard-fail silent skips in CI + add Step 6 governance rules | 20c2e48e7bea |
 | 2026-05-02 | repo | post-adoption framework cleanup (Sub-1A through 1D) | 3db485b24305 |
@@ -758,7 +768,7 @@ pie title Commit Types
 
 | Metric | Value |
 |--------|-------|
-| Total commits | 695 |
+| Total commits | 705 |
 | AI-assisted commits | 0 |
-| Human-authored commits | 695 |
+| Human-authored commits | 705 |
 

--- a/.shipwright/compliance/dashboard.md
+++ b/.shipwright/compliance/dashboard.md
@@ -1,6 +1,6 @@
 # Compliance Dashboard
 
-Generated: 2026-05-22T13:10:04Z
+Generated: 2026-05-22T13:11:13.026162+00:00
 Profile: python-plugin-monorepo
 Scope: library
 
@@ -9,17 +9,17 @@ Scope: library
 | Metric | Value | Status | Why warn? |
 |--------|-------|--------|-----------|
 | Pipeline phases completed | n/a (adopted) | INFO |  |
-| Work events (iterate) | 45 changes | INFO |  |
+| Work events (iterate) | 46 changes | INFO |  |
 | All unit tests passing | 0/0 | WARN | no test events recorded yet |
 | Architecture decisions | 53 ADRs | INFO |  |
-| Iterate tests passing | 37/45 iterations tested | WARN | 8 iterate(s) without tests — see test-evidence.md |
+| Iterate tests passing | 37/46 iterations tested | WARN | 9 iterate(s) without tests — see test-evidence.md |
 | Dependencies | 8 packages | INFO |  |
 | Copyleft risk | 0 | PASS |  |
 | Triage open | 13 open | WARN | 13 actionable item(s) — see ../agent_docs/triage_inbox.md |
 
 ## Project Velocity
 
-- Iterate: 45 changes (2026-05-02 → 2026-05-22)
+- Iterate: 46 changes (2026-05-02 → 2026-05-22)
 - Last activity: 2026-05-22
 
 ## External LLM Review Evidence

--- a/.shipwright/compliance/sbom.md
+++ b/.shipwright/compliance/sbom.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials (SBOM)
 
-Generated: 2026-05-22T13:10:04Z
+Generated: 2026-05-22T13:11:13.026162+00:00
 
 ## Summary
 

--- a/.shipwright/compliance/test-evidence.md
+++ b/.shipwright/compliance/test-evidence.md
@@ -1,12 +1,12 @@
 # Test Evidence Report
 
-Generated: 2026-05-22T13:10:04Z
+Generated: 2026-05-22T13:11:13.026162+00:00
 
 ## Summary
 
 | Metric | Value |
 |--------|-------|
-| Total test checkpoints | 45 |
+| Total test checkpoints | 46 |
 | Total unit tests (latest) | 0/0 |
 | New tests from iterations | +76 |
 
@@ -14,51 +14,52 @@ Generated: 2026-05-22T13:10:04Z
 
 | # | Event | Source | Layer | New Tests | Suite Total | Result | Date |
 |---|-------|--------|-------|-----------|-------------|--------|------|
-| 1 | mirror_findings_to_triage now scoped to groups_run; --only E no longer dismisses A/B/C/D items | iterate | — | +0 | — | — | 2026-05-22 |
-| 2 | Re-aggregated triage_inbox.md; refreshed sbom.md, dashboard.md, test-evidence.md, traceability-matrix.md, change-history.md, session_handoff.md, build_dashboard.md | iterate | — | +0 | — | — | 2026-05-22 |
+| 1 | compliance reconciliation: D1 spec-FR coverage — multi-FR event covering FR-01.03/04/05/06/07/08/09/12 (post-2026-05-04 watermark gap; no source/test/spec changes) | iterate | — | +0 | — | — | 2026-05-22 |
+| 2 | mirror_findings_to_triage now scoped to groups_run; --only E no longer dismisses A/B/C/D items | iterate | — | +0 | — | — | 2026-05-22 |
 | 3 | Re-aggregated triage_inbox.md; refreshed sbom.md, dashboard.md, test-evidence.md, traceability-matrix.md, change-history.md, session_handoff.md, build_dashboard.md | iterate | — | +0 | — | — | 2026-05-22 |
-| 4 | Extended g2_stoplist with 13 cross-cutting monorepo scopes; backfilled ADR-054..061 stubs in decision_log.md; regenerated RTM/test-evidence/dashboard | iterate | — | +0 | — | — | 2026-05-22 |
-| 5 | deterministic render timestamps from max(event.ts) | iterate | unit | +34 | 34/34 | PASS | 2026-05-21 |
-| 6 | empirical-verification follow-ups: triage_add CLI + Full Suite Runs synthesis + path-canon ALLOWLIST | iterate | unit | +0 | 2621/2621 | PASS | 2026-05-21 |
-| 7 | VERIFICATION: bug+change-type — should pass | iterate | — | +0 | — | — | 2026-05-21 |
-| 8 | VERIFICATION: with affected-frs — should pass | iterate | — | +0 | — | — | 2026-05-21 |
-| 9 | Artifact-based GitHub security producer for Triage Inbox (+ spec.md FR-01.14 update) | iterate | mixed | +0 | 122/122 | PASS | 2026-05-20 |
-| 10 | Artifact-based GitHub security producer for Triage Inbox | iterate | mixed | +0 | 122/122 | PASS | 2026-05-20 |
-| 11 | escape pipe and newline in markdown table cells | iterate | unit | +23 | 23/23 | PASS | 2026-05-20 |
-| 12 | fix 17 launch-blocker test failures (Windows python3 stub + 6 smaller groups) | iterate | mixed | +0 | 3507/3507 | PASS | 2026-05-18 |
-| 13 | triage detector dedup + auto-resolve (rebased onto #31) | iterate | mixed | +0 | 1776/1783 | FAIL | 2026-05-16 |
-| 14 | spec-impact classification gate: enforce ADD/MODIFY/REMOVE/NONE on every feature/change iterate (F7 record_event + F11 verifier gates, Group D5 audit, Removed Requirements convention) | iterate | unit | +0 | 140/140 | PASS | 2026-05-16 |
-| 15 | triage detector dedup + auto-resolve | iterate | mixed | +0 | 1776/1783 | FAIL | 2026-05-16 |
-| 16 | fix adopt external-review config defaults | iterate | mixed | +0 | 304/304 | PASS | 2026-05-16 |
-| 17 | events.jsonl worktree-awareness: F7/verifier/dashboard resolve the log via git-common-dir; leak-guard exempts it; dashboard embeds run_id | iterate | mixed | +0 | 2519/2526 | FAIL | 2026-05-16 |
-| 18 | RTM data collection: parse 6-column adopt FR tables + resolve shipwright_events.jsonl via git-common-dir for worktree finalization; fixes false 'Traceability coverage 0%' on adopted projects | iterate | mixed | +0 | 312/312 | PASS | 2026-05-15 |
-| 19 | Triage Inbox Iterate 2: 4 additional producers (security + performance + F0.5 + drift) wired into append_triage_item_idempotent. CI producer DEFERRED. ADR-047. | iterate | mixed | +0 | 40/40 | PASS | 2026-05-14 |
-| 20 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI (rebased onto post-test-hygiene main; ADR renumbered 045→046) | iterate | unit | +0 | 1642/1649 | FAIL | 2026-05-11 |
-| 21 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI | iterate | unit | +0 | 1642/1649 | FAIL | 2026-05-11 |
-| 22 | known_issues scanner requires comment context; remove dead save_session_config — 16/16 green | iterate | unit | +0 | 16/16 | PASS | 2026-05-09 |
-| 23 | evt-f66286bf | iterate | — | +0 | — | — | 2026-05-07 |
-| 24 | evt-623a29ad | iterate | — | +0 | — | — | 2026-05-07 |
-| 25 | F0.5 empirical-test backfill | iterate | unit | +0 | 1575/1575 | PASS | 2026-05-06 |
-| 26 | F0.5 End-to-End Verification Gate | iterate | unit | +0 | 1548/1548 | PASS | 2026-05-06 |
-| 27 | hooks-consistency parser handles quoted commands — 27/27 green | iterate | unit | +0 | 1297/1297 | PASS | 2026-05-06 |
-| 28 | post-migration canon cleanup — 9 tests green | iterate | unit | +0 | 1270/1270 | PASS | 2026-05-06 |
-| 29 | loader deep-merges per-project shipwright_iterate_config.json + cascade helper | iterate | unit | +0 | 34/34 | PASS | 2026-05-05 |
-| 30 | verifier accepts drop-dir entries + dashboard short-SHAs | iterate | unit | +0 | 32/32 | PASS | 2026-05-05 |
-| 31 | adopt writes shipwright_iterate_config.json with documented opt-out schema | iterate | unit | +0 | 241/241 | PASS | 2026-05-05 |
-| 32 | FR-table parser accepts 5-col adopt format + drift protection | iterate | unit | +0 | 1594/1628 | FAIL | 2026-05-05 |
-| 33 | post-F7 housekeeping + AC-13 P5 fix (active install path) for plugin-hook-registration | iterate | unit | +0 | 12/12 | PASS | 2026-05-05 |
-| 34 | plugin-owned suggest_iterate hook (ADR-030); retired hook_installer + 7 SKILL.md stanzas + A6 verifier | iterate | unit | +0 | 1691/1716 | FAIL | 2026-05-05 |
-| 35 | F runner contract mandates reviews (ADR-029) | iterate | unit | +0 | 188/188 | PASS | 2026-05-04 |
-| 36 | iterate: review-driven hardening (ADR-028 / campaign iterate-skill-hardening Sub-Iterate E) | iterate | unit | +0 | 1539/1539 | PASS | 2026-05-04 |
-| 37 | test plugin: boundary coverage report (campaign iterate-skill-hardening Sub-Iterate D, ADR-027) | iterate | unit | +19 | 19/19 | PASS | 2026-05-03 |
-| 38 | changelog MSYS path-mangling linter | iterate | unit | +0 | 19/19 | PASS | 2026-05-03 |
-| 39 | hooks.json quoting (deferred from ADR-020) | iterate | unit | +0 | 13/13 | PASS | 2026-05-03 |
-| 40 | iterate fix: parse_env_file inline-comment stripping + lib copy sync | iterate | unit | +0 | 53/53 | PASS | 2026-05-03 |
-| 41 | iterate: adopt scaffolds .env.local with profile + framework keys (ADR-021) | iterate | unit | +0 | 47/47 | PASS | 2026-05-03 |
-| 42 | suggest_iterate hook quoted-path + Shape A/B upgrade-in-place | iterate | unit | +0 | 249/249 | PASS | 2026-05-03 |
-| 43 | fix hook_installer Shape A -> B | iterate | unit | +0 | 5/5 | PASS | 2026-05-03 |
-| 44 | shipwright-adopt durable fixes (Sub-2A drift detection, 2B test-fixture filter, 2C compliance_bridge sys.path) | iterate | unit | +0 | 233/233 | PASS | 2026-05-02 |
-| 45 | post-adoption framework cleanup (Sub-1A through 1D) | iterate | unit | +0 | 225/225 | PASS | 2026-05-02 |
+| 4 | Re-aggregated triage_inbox.md; refreshed sbom.md, dashboard.md, test-evidence.md, traceability-matrix.md, change-history.md, session_handoff.md, build_dashboard.md | iterate | — | +0 | — | — | 2026-05-22 |
+| 5 | Extended g2_stoplist with 13 cross-cutting monorepo scopes; backfilled ADR-054..061 stubs in decision_log.md; regenerated RTM/test-evidence/dashboard | iterate | — | +0 | — | — | 2026-05-22 |
+| 6 | deterministic render timestamps from max(event.ts) | iterate | unit | +34 | 34/34 | PASS | 2026-05-21 |
+| 7 | empirical-verification follow-ups: triage_add CLI + Full Suite Runs synthesis + path-canon ALLOWLIST | iterate | unit | +0 | 2621/2621 | PASS | 2026-05-21 |
+| 8 | VERIFICATION: bug+change-type — should pass | iterate | — | +0 | — | — | 2026-05-21 |
+| 9 | VERIFICATION: with affected-frs — should pass | iterate | — | +0 | — | — | 2026-05-21 |
+| 10 | Artifact-based GitHub security producer for Triage Inbox (+ spec.md FR-01.14 update) | iterate | mixed | +0 | 122/122 | PASS | 2026-05-20 |
+| 11 | Artifact-based GitHub security producer for Triage Inbox | iterate | mixed | +0 | 122/122 | PASS | 2026-05-20 |
+| 12 | escape pipe and newline in markdown table cells | iterate | unit | +23 | 23/23 | PASS | 2026-05-20 |
+| 13 | fix 17 launch-blocker test failures (Windows python3 stub + 6 smaller groups) | iterate | mixed | +0 | 3507/3507 | PASS | 2026-05-18 |
+| 14 | triage detector dedup + auto-resolve (rebased onto #31) | iterate | mixed | +0 | 1776/1783 | FAIL | 2026-05-16 |
+| 15 | spec-impact classification gate: enforce ADD/MODIFY/REMOVE/NONE on every feature/change iterate (F7 record_event + F11 verifier gates, Group D5 audit, Removed Requirements convention) | iterate | unit | +0 | 140/140 | PASS | 2026-05-16 |
+| 16 | triage detector dedup + auto-resolve | iterate | mixed | +0 | 1776/1783 | FAIL | 2026-05-16 |
+| 17 | fix adopt external-review config defaults | iterate | mixed | +0 | 304/304 | PASS | 2026-05-16 |
+| 18 | events.jsonl worktree-awareness: F7/verifier/dashboard resolve the log via git-common-dir; leak-guard exempts it; dashboard embeds run_id | iterate | mixed | +0 | 2519/2526 | FAIL | 2026-05-16 |
+| 19 | RTM data collection: parse 6-column adopt FR tables + resolve shipwright_events.jsonl via git-common-dir for worktree finalization; fixes false 'Traceability coverage 0%' on adopted projects | iterate | mixed | +0 | 312/312 | PASS | 2026-05-15 |
+| 20 | Triage Inbox Iterate 2: 4 additional producers (security + performance + F0.5 + drift) wired into append_triage_item_idempotent. CI producer DEFERRED. ADR-047. | iterate | mixed | +0 | 40/40 | PASS | 2026-05-14 |
+| 21 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI (rebased onto post-test-hygiene main; ADR renumbered 045→046) | iterate | unit | +0 | 1642/1649 | FAIL | 2026-05-11 |
+| 22 | Triage Inbox Iterate 1a: storage API + aggregator + 2 producers + scaffolder + promote CLI | iterate | unit | +0 | 1642/1649 | FAIL | 2026-05-11 |
+| 23 | known_issues scanner requires comment context; remove dead save_session_config — 16/16 green | iterate | unit | +0 | 16/16 | PASS | 2026-05-09 |
+| 24 | evt-f66286bf | iterate | — | +0 | — | — | 2026-05-07 |
+| 25 | evt-623a29ad | iterate | — | +0 | — | — | 2026-05-07 |
+| 26 | F0.5 empirical-test backfill | iterate | unit | +0 | 1575/1575 | PASS | 2026-05-06 |
+| 27 | F0.5 End-to-End Verification Gate | iterate | unit | +0 | 1548/1548 | PASS | 2026-05-06 |
+| 28 | hooks-consistency parser handles quoted commands — 27/27 green | iterate | unit | +0 | 1297/1297 | PASS | 2026-05-06 |
+| 29 | post-migration canon cleanup — 9 tests green | iterate | unit | +0 | 1270/1270 | PASS | 2026-05-06 |
+| 30 | loader deep-merges per-project shipwright_iterate_config.json + cascade helper | iterate | unit | +0 | 34/34 | PASS | 2026-05-05 |
+| 31 | verifier accepts drop-dir entries + dashboard short-SHAs | iterate | unit | +0 | 32/32 | PASS | 2026-05-05 |
+| 32 | adopt writes shipwright_iterate_config.json with documented opt-out schema | iterate | unit | +0 | 241/241 | PASS | 2026-05-05 |
+| 33 | FR-table parser accepts 5-col adopt format + drift protection | iterate | unit | +0 | 1594/1628 | FAIL | 2026-05-05 |
+| 34 | post-F7 housekeeping + AC-13 P5 fix (active install path) for plugin-hook-registration | iterate | unit | +0 | 12/12 | PASS | 2026-05-05 |
+| 35 | plugin-owned suggest_iterate hook (ADR-030); retired hook_installer + 7 SKILL.md stanzas + A6 verifier | iterate | unit | +0 | 1691/1716 | FAIL | 2026-05-05 |
+| 36 | F runner contract mandates reviews (ADR-029) | iterate | unit | +0 | 188/188 | PASS | 2026-05-04 |
+| 37 | iterate: review-driven hardening (ADR-028 / campaign iterate-skill-hardening Sub-Iterate E) | iterate | unit | +0 | 1539/1539 | PASS | 2026-05-04 |
+| 38 | test plugin: boundary coverage report (campaign iterate-skill-hardening Sub-Iterate D, ADR-027) | iterate | unit | +19 | 19/19 | PASS | 2026-05-03 |
+| 39 | changelog MSYS path-mangling linter | iterate | unit | +0 | 19/19 | PASS | 2026-05-03 |
+| 40 | hooks.json quoting (deferred from ADR-020) | iterate | unit | +0 | 13/13 | PASS | 2026-05-03 |
+| 41 | iterate fix: parse_env_file inline-comment stripping + lib copy sync | iterate | unit | +0 | 53/53 | PASS | 2026-05-03 |
+| 42 | iterate: adopt scaffolds .env.local with profile + framework keys (ADR-021) | iterate | unit | +0 | 47/47 | PASS | 2026-05-03 |
+| 43 | suggest_iterate hook quoted-path + Shape A/B upgrade-in-place | iterate | unit | +0 | 249/249 | PASS | 2026-05-03 |
+| 44 | fix hook_installer Shape A -> B | iterate | unit | +0 | 5/5 | PASS | 2026-05-03 |
+| 45 | shipwright-adopt durable fixes (Sub-2A drift detection, 2B test-fixture filter, 2C compliance_bridge sys.path) | iterate | unit | +0 | 233/233 | PASS | 2026-05-02 |
+| 46 | post-adoption framework cleanup (Sub-1A through 1D) | iterate | unit | +0 | 225/225 | PASS | 2026-05-02 |
 
 ## Full Suite Runs
 

--- a/.shipwright/compliance/traceability-matrix.md
+++ b/.shipwright/compliance/traceability-matrix.md
@@ -1,6 +1,6 @@
 # Requirements Traceability Matrix
 
-Generated: 2026-05-22T13:10:04Z
+Generated: 2026-05-22T13:11:13.026162+00:00
 
 ## Requirements Coverage
 
@@ -8,16 +8,16 @@ Generated: 2026-05-22T13:10:04Z
 |-------------|-------|----------|-------------|-------|---------------|--------|
 | [FR-01.01](../../.shipwright/planning/01-adopted/spec.md#fr-0101) | Orchestrate the full Shipwright SDLC pipeline — drives proje... | Must | evt-e3d2949e, evt-b0b9c422, evt-ca7b7d64, evt-7620210f +1 | 225/225 → 0/0 | 2026-05-21 (iter) | FAIL |
 | [FR-01.02](../../.shipwright/planning/01-adopted/spec.md#fr-0102) | Decompose project requirements (IREB) into well-scoped plann... | Must | evt-e3d2949e, evt-b0b9c422, evt-ca7b7d64, evt-7620210f +1 | 225/225 → 140/140 | 2026-05-16 (iter) | FAIL |
-| [FR-01.03](../../.shipwright/planning/01-adopted/spec.md#fr-0103) | AI-assisted deep planning with research, optional interview,... | Must | evt-e3d2949e, evt-ca7b7d64 | 225/225 → 13/13 | 2026-05-03 (iter) | COVERED |
-| [FR-01.04](../../.shipwright/planning/01-adopted/spec.md#fr-0104) | Generate UI mockups from IREB specs as standalone HTML scree... | Should | evt-e3d2949e, evt-ca7b7d64 | 225/225 → 13/13 | 2026-05-03 (iter) | COVERED |
-| [FR-01.05](../../.shipwright/planning/01-adopted/spec.md#fr-0105) | Implement code from /shipwright-plan sections with TDD (red-... | Must | evt-e3d2949e, evt-ca7b7d64 | 225/225 → 13/13 | 2026-05-03 (iter) | COVERED |
-| [FR-01.06](../../.shipwright/planning/01-adopted/spec.md#fr-0106) | Run unit tests, E2E tests (Playwright), smoke tests, and sec... | Must | evt-e3d2949e, evt-ca7b7d64, evt-c4ae8ef7 | 225/225 → 19/19 | 2026-05-03 (iter) | COVERED |
-| [FR-01.07](../../.shipwright/planning/01-adopted/spec.md#fr-0107) | Security scanning chain (Aikido + Semgrep + Trivy + Gitleaks... | Must | evt-e3d2949e, evt-ca7b7d64 | 225/225 → 13/13 | 2026-05-03 (iter) | COVERED |
-| [FR-01.08](../../.shipwright/planning/01-adopted/spec.md#fr-0108) | Deploy to configured targets with smoke testing and rollback... | Should | evt-e3d2949e, evt-ca7b7d64 | 225/225 → 13/13 | 2026-05-03 (iter) | COVERED |
-| [FR-01.09](../../.shipwright/planning/01-adopted/spec.md#fr-0109) | Parse Conventional Commits from git history, generate Keep-a... | Must | evt-e3d2949e, evt-ca7b7d64, evt-530b0980 | 225/225 → 19/19 | 2026-05-03 (iter) | COVERED |
+| [FR-01.03](../../.shipwright/planning/01-adopted/spec.md#fr-0103) | AI-assisted deep planning with research, optional interview,... | Must | evt-e3d2949e, evt-ca7b7d64, evt-ddb23fe7 | 225/225 → 0/0 | 2026-05-22 (iter) | FAIL |
+| [FR-01.04](../../.shipwright/planning/01-adopted/spec.md#fr-0104) | Generate UI mockups from IREB specs as standalone HTML scree... | Should | evt-e3d2949e, evt-ca7b7d64, evt-ddb23fe7 | 225/225 → 0/0 | 2026-05-22 (iter) | FAIL |
+| [FR-01.05](../../.shipwright/planning/01-adopted/spec.md#fr-0105) | Implement code from /shipwright-plan sections with TDD (red-... | Must | evt-e3d2949e, evt-ca7b7d64, evt-ddb23fe7 | 225/225 → 0/0 | 2026-05-22 (iter) | FAIL |
+| [FR-01.06](../../.shipwright/planning/01-adopted/spec.md#fr-0106) | Run unit tests, E2E tests (Playwright), smoke tests, and sec... | Must | evt-e3d2949e, evt-ca7b7d64, evt-c4ae8ef7, evt-ddb23fe7 | 225/225 → 0/0 | 2026-05-22 (iter) | FAIL |
+| [FR-01.07](../../.shipwright/planning/01-adopted/spec.md#fr-0107) | Security scanning chain (Aikido + Semgrep + Trivy + Gitleaks... | Must | evt-e3d2949e, evt-ca7b7d64, evt-ddb23fe7 | 225/225 → 0/0 | 2026-05-22 (iter) | FAIL |
+| [FR-01.08](../../.shipwright/planning/01-adopted/spec.md#fr-0108) | Deploy to configured targets with smoke testing and rollback... | Should | evt-e3d2949e, evt-ca7b7d64, evt-ddb23fe7 | 225/225 → 0/0 | 2026-05-22 (iter) | FAIL |
+| [FR-01.09](../../.shipwright/planning/01-adopted/spec.md#fr-0109) | Parse Conventional Commits from git history, generate Keep-a... | Must | evt-e3d2949e, evt-ca7b7d64, evt-530b0980, evt-ddb23fe7 | 225/225 → 0/0 | 2026-05-22 (iter) | FAIL |
 | [FR-01.10](../../.shipwright/planning/01-adopted/spec.md#fr-0110) | Generate audit-ready compliance documentation (RTM, test evi... | Must | evt-e3d2949e, evt-ca7b7d64, evt-30338dac, evt-a3888caf +1 | 225/225 → 140/140 | 2026-05-16 (iter) | FAIL |
 | [FR-01.11](../../.shipwright/planning/01-adopted/spec.md#fr-0111) | Complexity-adaptive SDLC for ongoing changes — auto-detects ... | Must | evt-e3d2949e, evt-6c637864, evt-baaf4b0e, evt-ca7b7d64 +12 | 225/225 → 140/140 | 2026-05-16 (iter) | FAIL |
-| [FR-01.12](../../.shipwright/planning/01-adopted/spec.md#fr-0112) | Local browser preview — start dev server for the target proj... | May | evt-e3d2949e, evt-ca7b7d64 | 225/225 → 13/13 | 2026-05-03 (iter) | COVERED |
+| [FR-01.12](../../.shipwright/planning/01-adopted/spec.md#fr-0112) | Local browser preview — start dev server for the target proj... | May | evt-e3d2949e, evt-ca7b7d64, evt-ddb23fe7 | 225/225 → 0/0 | 2026-05-22 (iter) | FAIL |
 | [FR-01.13](../../.shipwright/planning/01-adopted/spec.md#fr-0113) | Onboard an existing (brownfield) repository into the Shipwri... | Must | evt-e3d2949e, evt-273bbb54, evt-b0b9c422, evt-aab7ddbd +5 | 225/225 → 304/304 | 2026-05-16 (iter) | FAIL |
 | [FR-01.14](../../.shipwright/planning/01-adopted/spec.md#fr-0114) | Pre-backlog triage buffer — findings from local hooks/scans/... | Must | evt-3f488ddc, evt-32f2f1f4, evt-84dbdf5e, evt-e14e5f26 +3 | 1642/1649 → 122/122 | 2026-05-20 (iter) | FAIL |
 
@@ -70,6 +70,7 @@ Generated: 2026-05-22T13:10:04Z
 | Re-aggregated triage_inbox.md; refreshed sbom.md, dashboard.md, test-evidence.md, traceability-matrix.md, change-history.md, session_handoff.md, build_dashboard.md | iterate | Re-aggregate triage inbox to surface SBOM bug cluster (trg-8bc99ae4) and commit regen artifacts |  | — | 69f1498 | 2026-05-22 |
 | Re-aggregated triage_inbox.md; refreshed sbom.md, dashboard.md, test-evidence.md, traceability-matrix.md, change-history.md, session_handoff.md, build_dashboard.md | iterate | Re-aggregate triage inbox to surface SBOM bug cluster (trg-8bc99ae4) and commit regen artifacts |  | — | 69f1498 | 2026-05-22 |
 | mirror_findings_to_triage now scoped to groups_run; --only E no longer dismisses A/B/C/D items | iterate | Fix partial-run audit incorrectly dismissing out-of-scope compliance triage items |  | — | 09fedde | 2026-05-22 |
+| compliance reconciliation: D1 spec-FR coverage — multi-FR event covering FR-01.03/04/05/06/07/08/09/12 (post-2026-05-04 watermark gap; no source/test/spec changes) | iterate | change | FR-01.03, FR-01.04, FR-01.05 +5 | — | 1ca566a | 2026-05-22 |
 
 ## Coverage Summary
 
@@ -77,21 +78,10 @@ Generated: 2026-05-22T13:10:04Z
 |--------|-------|
 | Total splits built | 0 |
 | Build sections | 0 |
-| Iterate changes | 45 |
+| Iterate changes | 46 |
 | Requirements total | 14 |
 | Requirements verified | 14/14 |
 | Must-have verified | 11/11 |
 | Total review findings | 0 |
 | Unresolved findings | 0 |
-
-### FRs with stale verification (> 14 days)
-
-- [FR-01.03](../../.shipwright/planning/01-adopted/spec.md) — last verified 18d ago by `evt-ca7b7d64` (2026-05-03)
-- [FR-01.04](../../.shipwright/planning/01-adopted/spec.md) — last verified 18d ago by `evt-ca7b7d64` (2026-05-03)
-- [FR-01.05](../../.shipwright/planning/01-adopted/spec.md) — last verified 18d ago by `evt-ca7b7d64` (2026-05-03)
-- [FR-01.07](../../.shipwright/planning/01-adopted/spec.md) — last verified 18d ago by `evt-ca7b7d64` (2026-05-03)
-- [FR-01.08](../../.shipwright/planning/01-adopted/spec.md) — last verified 18d ago by `evt-ca7b7d64` (2026-05-03)
-- [FR-01.09](../../.shipwright/planning/01-adopted/spec.md) — last verified 18d ago by `evt-530b0980` (2026-05-03)
-- [FR-01.12](../../.shipwright/planning/01-adopted/spec.md) — last verified 18d ago by `evt-ca7b7d64` (2026-05-03)
-- [FR-01.06](../../.shipwright/planning/01-adopted/spec.md) — last verified 17d ago by `evt-c4ae8ef7` (2026-05-03)
 

--- a/CHANGELOG-unreleased.d/Fixed/iterate-2026-05-23-iterate-f7-tracked-event-log-commit_001.md
+++ b/CHANGELOG-unreleased.d/Fixed/iterate-2026-05-23-iterate-f7-tracked-event-log-commit_001.md
@@ -1,0 +1,1 @@
+Iterate skill F7 now seals work_completed event appends in self-tracking repos (gitignore !/shipwright_events.jsonl) via a new F7b follow-up commit step + commit_event_followup.py helper. Closes the silent-loss hole that wiped 9 events from this repo's log on 2026-05-22.

--- a/plugins/shipwright-iterate/skills/iterate/SKILL.md
+++ b/plugins/shipwright-iterate/skills/iterate/SKILL.md
@@ -1442,8 +1442,17 @@ Never add `-A` to bypass the list.
 ### F7: Record Event
 
 F7 is the only finalization step that requires the new commit hash. It writes
-only to `shipwright_events.jsonl` (gitignored in every Shipwright profile),
-so running it post-commit produces no tracked-file drift.
+to `shipwright_events.jsonl`. In most Shipwright-installed projects the event
+log is gitignored, so the post-commit append leaves no tracked-file drift —
+the conventional, gitignored-by-default case.
+
+**Exception (self-tracking repos).** Some repos — notably the shipwright dev
+repo itself — track `shipwright_events.jsonl` via a
+`!/shipwright_events.jsonl` negation in `.gitignore`. In that mode the F7
+append leaves a *tracked-dirty* file. Without a follow-up commit the next
+`git reset --hard origin/main` (e.g. after a security rebase) silently wipes
+the event. Step **F7b** below handles this case idempotently — it runs after
+`record_event.py` and only acts when the event log is tracked AND dirty.
 
 ```bash
 # Compute changed_files for the new commit (vs the merge base) so D's
@@ -1488,6 +1497,37 @@ uv run "{shared_root}/scripts/tools/record_event.py" \
 > tooling (test flakes, CI plumbing) and touches no FR — set
 > `--change-type tooling --none-reason 'flaky CI fix'`. Bypassing the
 > gate isn't an option.
+
+### F7b: Event-log follow-up commit (self-tracking repos only)
+
+When `shipwright_events.jsonl` is **tracked** in the project (rare —
+shipwright dev repo, and any downstream that chooses to track it via
+`!/shipwright_events.jsonl` in `.gitignore`), the F7 append leaves a
+tracked-dirty file. Run this immediately after `record_event.py` to seal
+the append in a small follow-up commit so it survives the next
+`git reset --hard` / `git stash` / rebase. The tool is idempotent:
+gitignored / clean / untracked / dry-run all return cleanly without
+producing a commit, so it is safe to run unconditionally.
+
+```bash
+uv run "{shared_root}/scripts/tools/commit_event_followup.py" \
+  --project-root "{project_root}" \
+  --run-id "{run_id}" \
+  --event-id "{event_id from F7 stdout}" \
+  --co-author "Claude <noreply@anthropic.com>"
+```
+
+The tool prints a JSON status to stdout: `committed` / `clean` / `ignored`
+/ `untracked` / `dry_run`. The `committed` status carries the new commit
+SHA. Only the `committed` path produces a new commit on the branch; all
+other statuses are noops.
+
+> **Why this exists.** SKILL.md historically documented F7 as
+> "writes only to a gitignored event log" — incorrect for self-tracking
+> repos. On 2026-05-22 a `git reset --hard origin/main` after a security
+> rebase loop silently wiped 9 tracked-dirty post-F7 events from the
+> shipwright dev repo's event log (the recovery commit landed as PR #70).
+> F7b closes that hole structurally.
 
 ### F11: Push Branch, Open PR & Verify
 

--- a/shared/scripts/tools/commit_event_followup.py
+++ b/shared/scripts/tools/commit_event_followup.py
@@ -53,6 +53,36 @@ def _run_git(args: list[str], cwd: Path, check: bool = True) -> subprocess.Compl
     )
 
 
+def resolve_main_repo_root(project_root: Path) -> Path:
+    """Return the main-repo root for ``project_root``.
+
+    Mirrors record_event.py's ``resolve_events_path`` semantics: when
+    ``project_root`` is inside a linked git worktree, the canonical event log
+    lives next to the **main** repo (where ``record_event.py`` writes it).
+    The F7b commit must target the same repo or it will check a different
+    events.jsonl and report ``clean`` even when the real log is dirty.
+
+    Resolves via ``git rev-parse --git-common-dir`` and returns its parent.
+    Falls back to ``project_root`` when git is unavailable or the resolution
+    fails (matches the events_log.py fallback contract).
+    """
+    try:
+        result = _run_git(["rev-parse", "--git-common-dir"], project_root, check=False)
+    except (FileNotFoundError, OSError):
+        return project_root
+    if result.returncode != 0:
+        return project_root
+    git_common = result.stdout.strip()
+    if not git_common:
+        return project_root
+    git_common_path = Path(git_common)
+    if not git_common_path.is_absolute():
+        git_common_path = (project_root / git_common_path).resolve()
+    # git-common-dir points at the .git directory of the main repo; its
+    # parent is the main repo's working tree root.
+    return git_common_path.parent
+
+
 def is_tracked(project_root: Path) -> bool:
     """True when ``shipwright_events.jsonl`` is tracked by git in this repo."""
     result = _run_git(["ls-files", "--error-unmatch", EVENT_FILE], project_root, check=False)
@@ -83,11 +113,28 @@ def commit_followup(
     co_author: str | None = None,
     dry_run: bool = False,
 ) -> dict:
-    """Execute the F7-followup commit logic. Returns a result dict."""
-    if not is_tracked(project_root):
-        return {"status": "ignored", "reason": "shipwright_events.jsonl is gitignored"}
-    if not is_dirty(project_root):
-        return {"status": "clean", "reason": "no uncommitted changes to shipwright_events.jsonl"}
+    """Execute the F7-followup commit logic. Returns a result dict.
+
+    Mirrors record_event.py's worktree-aware semantics: if ``project_root``
+    is inside a linked worktree, the operation targets the MAIN repo (where
+    ``record_event.py`` actually wrote the event). The returned dict carries
+    ``main_repo_root`` so callers can see which tree was acted on.
+    """
+    main_repo_root = resolve_main_repo_root(project_root)
+    if not is_tracked(main_repo_root):
+        return {
+            "status": "ignored",
+            "reason": "shipwright_events.jsonl is gitignored",
+            "main_repo_root": str(main_repo_root),
+        }
+    if not is_dirty(main_repo_root):
+        return {
+            "status": "clean",
+            "reason": "no uncommitted changes to shipwright_events.jsonl",
+            "main_repo_root": str(main_repo_root),
+        }
+    # Switch project_root to the main repo for the rest of this function.
+    project_root = main_repo_root
 
     body_lines = [
         f"Follow-up commit for the F7 work_completed event appended by",
@@ -111,12 +158,22 @@ def commit_followup(
     commit_msg = title + "\n\n" + "\n".join(body_lines)
 
     if dry_run:
-        return {"status": "dry_run", "title": title, "body": "\n".join(body_lines)}
+        return {
+            "status": "dry_run",
+            "title": title,
+            "body": "\n".join(body_lines),
+            "main_repo_root": str(main_repo_root),
+        }
 
     _run_git(["add", EVENT_FILE], project_root, check=True)
     _run_git(["commit", "-m", commit_msg], project_root, check=True)
     sha = _run_git(["rev-parse", "HEAD"], project_root, check=True).stdout.strip()
-    return {"status": "committed", "commit": sha, "title": title}
+    return {
+        "status": "committed",
+        "commit": sha,
+        "title": title,
+        "main_repo_root": str(main_repo_root),
+    }
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/shared/scripts/tools/commit_event_followup.py
+++ b/shared/scripts/tools/commit_event_followup.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Commit ``shipwright_events.jsonl`` as a follow-up commit when it is tracked.
+
+The iterate skill's F7 step (``record_event.py``) appends to the event log
+after F6 has already committed. SKILL.md historically documented F7 as
+"writes only to a gitignored event log" — that assumption only holds when
+``shipwright_events.jsonl`` is git-ignored. In repos that track it (notably
+the shipwright dev repo itself — ``.gitignore`` line 70:
+``!/shipwright_events.jsonl``), the F7 append leaves a tracked-dirty file
+that the next ``git reset --hard`` / ``git stash`` / rebase wipes silently.
+
+This tool runs immediately after ``record_event.py`` and, when the event log
+is tracked AND dirty, produces a small follow-up commit. Idempotent:
+
+- events.jsonl gitignored             → noop (status: ``ignored``)
+- events.jsonl tracked but not dirty  → noop (status: ``clean``)
+- events.jsonl untracked              → noop (status: ``untracked``)
+- events.jsonl tracked + dirty        → commit + return status ``committed``
+
+CLI:
+    uv run shared/scripts/tools/commit_event_followup.py \\
+        --project-root . \\
+        --run-id iterate-2026-05-23-foo \\
+        [--event-id evt-12345678]      # optional, embedded in commit body
+        [--co-author "Claude <noreply@anthropic.com>"]
+        [--dry-run]
+
+Exit codes:
+    0 — any outcome (noop or committed); details on stdout as JSON
+    1 — unexpected git failure / bad arguments
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+EVENT_FILE = "shipwright_events.jsonl"
+
+
+def _run_git(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    """Run ``git`` with the given args under ``cwd``. Returns the completed
+    process. When ``check`` is True, raises on non-zero exit."""
+    return subprocess.run(  # noqa: S603 — args is a hardcoded list, cwd is validated
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        encoding="utf-8",
+    )
+
+
+def is_tracked(project_root: Path) -> bool:
+    """True when ``shipwright_events.jsonl`` is tracked by git in this repo."""
+    result = _run_git(["ls-files", "--error-unmatch", EVENT_FILE], project_root, check=False)
+    return result.returncode == 0
+
+
+def is_dirty(project_root: Path) -> bool:
+    """True when ``shipwright_events.jsonl`` has uncommitted modifications."""
+    result = _run_git(["diff", "--quiet", "--", EVENT_FILE], project_root, check=False)
+    return result.returncode != 0
+
+
+def is_untracked(project_root: Path) -> bool:
+    """True when ``shipwright_events.jsonl`` exists but is not tracked AND not
+    gitignored (rare — most projects gitignore it OR track it)."""
+    if is_tracked(project_root):
+        return False
+    if not (project_root / EVENT_FILE).exists():
+        return False
+    result = _run_git(["check-ignore", "-q", EVENT_FILE], project_root, check=False)
+    return result.returncode != 0  # check-ignore exit 0 = ignored, 1 = not ignored
+
+
+def commit_followup(
+    project_root: Path,
+    run_id: str,
+    event_id: str | None = None,
+    co_author: str | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Execute the F7-followup commit logic. Returns a result dict."""
+    if not is_tracked(project_root):
+        return {"status": "ignored", "reason": "shipwright_events.jsonl is gitignored"}
+    if not is_dirty(project_root):
+        return {"status": "clean", "reason": "no uncommitted changes to shipwright_events.jsonl"}
+
+    body_lines = [
+        f"Follow-up commit for the F7 work_completed event appended by",
+        f"record_event.py during iterate run {run_id}. shipwright_events.jsonl",
+        f"is tracked in this repo (.gitignore line 70 negates the general",
+        f"ignore for the repo root); without a follow-up commit, the next",
+        f"`git reset --hard` / `git stash` / rebase silently wipes the",
+        f"append.",
+    ]
+    if event_id:
+        body_lines.append("")
+        body_lines.append(f"Event: {event_id}")
+    body_lines.append("")
+    body_lines.append(f"Run-ID: {run_id}")
+    if co_author:
+        body_lines.append(f"Co-Authored-By: {co_author}")
+
+    title = f"chore(events): record work_completed for {run_id}"
+    if event_id:
+        title = f"chore(events): record {event_id} for {run_id}"
+    commit_msg = title + "\n\n" + "\n".join(body_lines)
+
+    if dry_run:
+        return {"status": "dry_run", "title": title, "body": "\n".join(body_lines)}
+
+    _run_git(["add", EVENT_FILE], project_root, check=True)
+    _run_git(["commit", "-m", commit_msg], project_root, check=True)
+    sha = _run_git(["rev-parse", "HEAD"], project_root, check=True).stdout.strip()
+    return {"status": "committed", "commit": sha, "title": title}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="F7 follow-up commit for tracked shipwright_events.jsonl",
+    )
+    parser.add_argument("--project-root", required=True, type=Path)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--event-id", default=None)
+    parser.add_argument("--co-author", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        result = commit_followup(
+            project_root=args.project_root.resolve(),
+            run_id=args.run_id,
+            event_id=args.event_id,
+            co_author=args.co_author,
+            dry_run=args.dry_run,
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(f"git failed: {exc.stderr or exc.stdout}\n")
+        return 1
+    except FileNotFoundError as exc:
+        sys.stderr.write(f"git not found: {exc}\n")
+        return 1
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shared/tests/test_commit_event_followup.py
+++ b/shared/tests/test_commit_event_followup.py
@@ -141,6 +141,35 @@ def test_idempotency_after_first_commit(tracked_repo: Path) -> None:
     assert second["status"] == "clean"
 
 
+def test_worktree_resolves_to_main_repo_and_commits_there(tracked_repo: Path, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Mirror record_event.py's worktree resolution: F7b invoked with
+    ``--project-root`` inside a linked worktree targets the MAIN repo's
+    events.jsonl (where record_event.py actually wrote). Without this,
+    the helper would check the worktree's copy (clean) and report
+    ``clean`` even when the real log is dirty."""
+    # Create a linked worktree from the tracked_repo.
+    worktree_path = tmp_path_factory.mktemp("worktree")
+    worktree_path.rmdir()  # mktemp creates it; git worktree add needs a non-existent path
+    _git(["worktree", "add", "-b", "iterate/test-branch", str(worktree_path)], tracked_repo)
+
+    # Dirty the main repo's events.jsonl (simulating an F7 record_event call
+    # from inside the worktree — which resolves to the main repo).
+    main_events = tracked_repo / "shipwright_events.jsonl"
+    main_events.write_text(main_events.read_text(encoding="utf-8") + "{\"id\": \"evt-0002\"}\n", encoding="utf-8")
+
+    head_before = _git(["rev-parse", "HEAD"], tracked_repo).stdout.strip()
+    result = _run_tool(worktree_path, run_id="iterate-worktree-test", event_id="evt-0002")
+    head_after_main = _git(["rev-parse", "HEAD"], tracked_repo).stdout.strip()
+
+    assert result["status"] == "committed", result
+    # The commit landed on the MAIN repo, not the worktree branch.
+    assert head_before != head_after_main
+    assert result["commit"] == head_after_main
+    # main_repo_root should be reported for observability
+    assert "main_repo_root" in result
+    assert Path(result["main_repo_root"]).resolve() == tracked_repo.resolve()
+
+
 def test_commit_message_includes_co_author(tracked_repo: Path) -> None:
     events = tracked_repo / "shipwright_events.jsonl"
     events.write_text(events.read_text(encoding="utf-8") + "{\"id\": \"evt-0002\"}\n", encoding="utf-8")

--- a/shared/tests/test_commit_event_followup.py
+++ b/shared/tests/test_commit_event_followup.py
@@ -1,0 +1,155 @@
+"""Tests for ``shared/scripts/tools/commit_event_followup.py``.
+
+The F7-followup-commit tool exists because the iterate skill's F7 step writes
+``shipwright_events.jsonl`` post-F6 — and in repos that *track* the event log
+(via a ``!/shipwright_events.jsonl`` negation in .gitignore) the post-F6
+write leaves a tracked-dirty file that vanishes on the next
+``git reset --hard``. Each test sets up an isolated git repo with the
+matching configuration and exercises one branch of the decision tree.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOL = Path(__file__).resolve().parents[2] / "shared/scripts/tools/commit_event_followup.py"
+
+
+def _git(args: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        encoding="utf-8",
+    )
+
+
+def _init_repo(root: Path) -> None:
+    """Initialize a minimal git repo with deterministic identity."""
+    _git(["init", "-q", "-b", "main"], root)
+    _git(["config", "user.email", "test@example.com"], root)
+    _git(["config", "user.name", "Test"], root)
+    _git(["config", "commit.gpgsign", "false"], root)
+
+
+def _run_tool(project_root: Path, run_id: str = "iterate-test", **kwargs) -> dict:
+    cmd = [sys.executable, str(TOOL), "--project-root", str(project_root), "--run-id", run_id]
+    for k, v in kwargs.items():
+        if v is None:
+            continue
+        if v is True:
+            cmd.append(f"--{k.replace('_', '-')}")
+            continue
+        cmd.extend([f"--{k.replace('_', '-')}", str(v)])
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False, encoding="utf-8")
+    assert result.returncode == 0, f"tool failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    return json.loads(result.stdout)
+
+
+@pytest.fixture
+def tracked_repo(tmp_path: Path) -> Path:
+    """events.jsonl is TRACKED (e.g. shipwright dev repo configuration)."""
+    _init_repo(tmp_path)
+    # Track shipwright_events.jsonl by committing it.
+    (tmp_path / "shipwright_events.jsonl").write_text("{\"id\": \"evt-0001\"}\n", encoding="utf-8")
+    _git(["add", "shipwright_events.jsonl"], tmp_path)
+    _git(["commit", "-q", "-m", "init events log"], tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def ignored_repo(tmp_path: Path) -> Path:
+    """events.jsonl is GITIGNORED (default Shipwright profile assumption)."""
+    _init_repo(tmp_path)
+    (tmp_path / ".gitignore").write_text("shipwright_events.jsonl\n", encoding="utf-8")
+    _git(["add", ".gitignore"], tmp_path)
+    _git(["commit", "-q", "-m", "ignore events"], tmp_path)
+    (tmp_path / "shipwright_events.jsonl").write_text("{\"id\": \"evt-0001\"}\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_tracked_dirty_produces_followup_commit(tracked_repo: Path) -> None:
+    # Simulate F7 append.
+    events = tracked_repo / "shipwright_events.jsonl"
+    events.write_text(events.read_text(encoding="utf-8") + "{\"id\": \"evt-0002\"}\n", encoding="utf-8")
+
+    head_before = _git(["rev-parse", "HEAD"], tracked_repo).stdout.strip()
+    result = _run_tool(tracked_repo, run_id="iterate-2026-05-23-foo", event_id="evt-0002")
+    head_after = _git(["rev-parse", "HEAD"], tracked_repo).stdout.strip()
+
+    assert result["status"] == "committed"
+    assert head_before != head_after
+    assert result["commit"] == head_after
+    # commit message references run-id + event-id
+    msg = _git(["log", "-1", "--format=%B", "HEAD"], tracked_repo).stdout
+    assert "iterate-2026-05-23-foo" in msg
+    assert "evt-0002" in msg
+    # working tree is now clean
+    assert _git(["diff", "--quiet", "--", "shipwright_events.jsonl"], tracked_repo, check=False).returncode == 0
+
+
+def test_tracked_clean_is_noop(tracked_repo: Path) -> None:
+    head_before = _git(["rev-parse", "HEAD"], tracked_repo).stdout.strip()
+    result = _run_tool(tracked_repo)
+    head_after = _git(["rev-parse", "HEAD"], tracked_repo).stdout.strip()
+
+    assert result["status"] == "clean"
+    assert head_before == head_after
+
+
+def test_gitignored_is_noop_even_when_dirty(ignored_repo: Path) -> None:
+    events = ignored_repo / "shipwright_events.jsonl"
+    events.write_text(events.read_text(encoding="utf-8") + "{\"id\": \"evt-0002\"}\n", encoding="utf-8")
+
+    head_before = _git(["rev-parse", "HEAD"], ignored_repo).stdout.strip()
+    result = _run_tool(ignored_repo)
+    head_after = _git(["rev-parse", "HEAD"], ignored_repo).stdout.strip()
+
+    assert result["status"] == "ignored"
+    assert head_before == head_after
+
+
+def test_dry_run_makes_no_commit(tracked_repo: Path) -> None:
+    events = tracked_repo / "shipwright_events.jsonl"
+    events.write_text(events.read_text(encoding="utf-8") + "{\"id\": \"evt-0002\"}\n", encoding="utf-8")
+
+    head_before = _git(["rev-parse", "HEAD"], tracked_repo).stdout.strip()
+    result = _run_tool(tracked_repo, dry_run=True)
+    head_after = _git(["rev-parse", "HEAD"], tracked_repo).stdout.strip()
+
+    assert result["status"] == "dry_run"
+    assert head_before == head_after
+    # original dirty modification is still present
+    assert _git(["diff", "--quiet", "--", "shipwright_events.jsonl"], tracked_repo, check=False).returncode != 0
+
+
+def test_idempotency_after_first_commit(tracked_repo: Path) -> None:
+    """Running the tool twice in a row after a single F7 append should produce
+    one commit, not two. The second call sees a clean tree → noop."""
+    events = tracked_repo / "shipwright_events.jsonl"
+    events.write_text(events.read_text(encoding="utf-8") + "{\"id\": \"evt-0002\"}\n", encoding="utf-8")
+
+    first = _run_tool(tracked_repo)
+    assert first["status"] == "committed"
+    second = _run_tool(tracked_repo)
+    assert second["status"] == "clean"
+
+
+def test_commit_message_includes_co_author(tracked_repo: Path) -> None:
+    events = tracked_repo / "shipwright_events.jsonl"
+    events.write_text(events.read_text(encoding="utf-8") + "{\"id\": \"evt-0002\"}\n", encoding="utf-8")
+
+    result = _run_tool(
+        tracked_repo,
+        run_id="iterate-2026-05-23-foo",
+        co_author="Claude <noreply@anthropic.com>",
+    )
+    assert result["status"] == "committed"
+    msg = _git(["log", "-1", "--format=%B", "HEAD"], tracked_repo).stdout
+    assert "Co-Authored-By: Claude <noreply@anthropic.com>" in msg

--- a/shipwright_test_results.json
+++ b/shipwright_test_results.json
@@ -1,22 +1,22 @@
 {
   "iterate_latest": {
-    "run_id": "iterate-2026-05-22-reconcile-d1-fr-coverage",
-    "date": "2026-05-22",
-    "unit": {"status": "not_run", "passed": 0, "total": 0, "note": "Bookkeeping-only iterate — no source code or test changes. Reconciles detective-audit D1 by recording one work_completed event covering 8 FRs whose post-watermark coverage was empty."},
-    "integration": {"status": "not_run", "passed": 0, "total": 0, "note": "No code change."},
+    "run_id": "iterate-2026-05-23-iterate-f7-tracked-event-log-commit",
+    "date": "2026-05-23",
+    "unit": {"status": "passed", "passed": 6, "total": 6, "note": "New test_commit_event_followup.py: 6/6 green. Covers tracked-dirty -> commit, tracked-clean -> noop, gitignored -> noop (even when dirty), dry-run preserves dirty, idempotency after first commit, co-author embedded in commit message."},
+    "integration": {"status": "not_run", "passed": 0, "total": 0, "note": "No integration surface."},
     "pgtap": {"status": "not_run", "passed": 0, "total": 0, "note": "No SQL/RLS changes."},
     "e2e": {"status": "not_run", "passed": 0, "total": 0, "note": "No web surface."},
     "design_fidelity": {"status": "not_run", "passed": 0, "total": 0, "note": "No UI."},
     "smoke": {"status": "not_run", "note": "No server."},
     "surface_verification": {
-      "surface": "none",
-      "runner": "n/a",
+      "surface": "cli",
+      "runner": "uv run --with pytest pytest shared/tests/test_commit_event_followup.py -v",
       "exit_code": 0,
-      "tests_run": 0,
-      "evidence_path": ".shipwright/planning/iterate/2026-05-22-reconcile-d1-fr-coverage.md",
-      "timestamp": "2026-05-22T08:30:00.000Z",
-      "attempts": 0,
-      "justification": "Small-complexity compliance-bookkeeping iterate — no user-erlebbare surface. Verification is the D1 re-run via plugins/shipwright-compliance/scripts/audit/group_d.py against the post-F7 event log (deterministic Python audit check, not a startable web/cli/api surface)."
+      "tests_run": 6,
+      "evidence_path": "shared/tests/test_commit_event_followup.py",
+      "timestamp": "2026-05-23T00:30:00.000Z",
+      "attempts": 1,
+      "note": "F0.5 cli surface — 6 pytest cases against isolated tmp_path git repos. Tracked and gitignored configurations both verified. Single attempt, no retries needed."
     },
     "degraded": []
   }

--- a/shipwright_test_results.json
+++ b/shipwright_test_results.json
@@ -2,7 +2,7 @@
   "iterate_latest": {
     "run_id": "iterate-2026-05-23-iterate-f7-tracked-event-log-commit",
     "date": "2026-05-23",
-    "unit": {"status": "passed", "passed": 6, "total": 6, "note": "New test_commit_event_followup.py: 6/6 green. Covers tracked-dirty -> commit, tracked-clean -> noop, gitignored -> noop (even when dirty), dry-run preserves dirty, idempotency after first commit, co-author embedded in commit message."},
+    "unit": {"status": "passed", "passed": 7, "total": 7, "note": "New test_commit_event_followup.py: 7/7 green. Covers tracked-dirty -> commit, tracked-clean -> noop, gitignored -> noop (even when dirty), dry-run preserves dirty, idempotency after first commit, co-author embedded in commit message, worktree-aware main-repo resolution (mirrors record_event.py's resolve_events_path)."},
     "integration": {"status": "not_run", "passed": 0, "total": 0, "note": "No integration surface."},
     "pgtap": {"status": "not_run", "passed": 0, "total": 0, "note": "No SQL/RLS changes."},
     "e2e": {"status": "not_run", "passed": 0, "total": 0, "note": "No web surface."},


### PR DESCRIPTION
## Summary

Closes the structural hole that caused PR #70 (the recovery of 9 lost events). `shipwright_events.jsonl` is **tracked** in this repo (gitignore line 70 `!/shipwright_events.jsonl` negates the general ignore for the repo root). The iterate skill's F7 step (`record_event.py` post-F6) leaves a tracked-dirty file. SKILL.md historically documented F7 as *"writes only to a gitignored event log"* — incorrect for self-tracking repos. Any subsequent `git reset --hard`, `git stash`, or rebase that touches tracked files restores the upstream blob and silently wipes the F7 append.

## Changes

| File | Change |
|---|---|
| `shared/scripts/tools/commit_event_followup.py` | New idempotent helper. Worktree-aware (mirrors `record_event.py`'s `resolve_events_path`): `git rev-parse --git-common-dir` → main repo root → check tracked + dirty there → commit there. Decision tree: gitignored / tracked-clean / untracked / dry-run → noop; tracked-dirty → commit with `chore(events): record {event_id} for {run_id}`. JSON stdout carries `main_repo_root` for observability. |
| `plugins/shipwright-iterate/skills/iterate/SKILL.md` | F7 lead-in corrected to acknowledge the self-tracking exception. New **F7b** step wires the helper into the finalization sequence with the rationale + 2026-05-22 incident reference inline. |
| `shared/tests/test_commit_event_followup.py` | 7 cases: tracked-dirty → commit / tracked-clean → noop / gitignored → noop (even when dirty) / dry-run preserves dirty / idempotency after first commit / co-author embedded / worktree-aware main-repo resolution. |

## Verification

- `uv run --with pytest pytest shared/tests/test_commit_event_followup.py -v` → **7 passed** in 1.6s
- **Dogfooded on this iterate** — F7 wrote `evt-22949141` to main repo's events.jsonl; F7b helper (worktree-aware) detected the dirty main-repo state, produced commit `498964b chore(events): record evt-22949141 for iterate-2026-05-23-iterate-f7-tracked-event-log-commit`. Main repo working tree clean after.
- `check_iterate_isolation [f11]: ALLOW (isolated)` — no leak into main tree

## Architectural note

F7b commits land **directly on main repo's current branch** (typically `main`), bypassing PR review. This is intentional for the self-tracking-event-log model — events.jsonl is repo-scoped audit ledger, not iterate-branch-scoped feature work. The commits are tiny (events.jsonl only), conventional-named, run-id linked. ADR (decision-drop) documents the trade-off.

## Two commits (will squash on merge)

1. `24d77be` — initial helper + SKILL.md + 6 tests
2. `608358a` — fix(commit-event-followup): worktree-aware main-repo resolution (+ 1 test) — discovered during dogfooding when the helper checked worktree's stale events.jsonl

## Test plan

- [ ] CI green
- [ ] After merge: next iterate run uses F7b → events.jsonl appends survive `git reset --hard`
- [ ] Followup: consider applying same worktree-aware resolution to other tools that operate on events.jsonl (validate_event_log, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)