### PR TITLE
chore(docs): add shared/contracts/ to CLAUDE.md Structure listing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ plugins/                    # Claude Code plugins (one per SDLC phase)
   shipwright-adopt/         # Brownfield onboarding (analyze an existing repo)
 # Command Center WebUI lives at github.com/svenroth-ai/shipwright-webui since v0.4.0
 shared/                     # Shared across all plugins
+  contracts/                # Public cross-plugin API surface (compliance, iterate)
   profiles/                 # Stack profile definitions (JSON) + deploy profiles
   templates/                # CLAUDE.md, .shipwright/agent_docs, CI templates
   prompts/                  # Shared subagent prompts (code_reviewer, iterate_reviewer)


### PR DESCRIPTION
Post-Campaign-B-3 cleanup: drift detector flagged that `shared/contracts/` (B8, PR #96) wasn't documented in CLAUDE.md's Structure block. One-line fix.

Also dismisses the phantom `b3-functional-probe` Phase-Quality triage entry (B3's runner registered a synthetic run_id during its functional-probe audit invocation; no actual iterate run exists).