### PR TITLE
chore(bloat): clear 3 Group H findings (post Campaign B+C hygiene)

### DIFF
--- a/plugins/shipwright-compliance/tests/test_collectors_dashboard.py
+++ b/plugins/shipwright-compliance/tests/test_collectors_dashboard.py
@@ -1,11 +1,11 @@
-"""Tests for the Compliance Dashboard's bloat-findings column (B3).
+"""Tests for the Compliance Dashboard bloat-findings column (B3).
 
-Iterate Campaign B (B3) wired three new Quality-Indicators rows into
+Campaign B B3 wired three Quality-Indicators rows into
 ``compliance_report.py`` fed from
-``shared.scripts.lib.phase_quality.collect_bloat_summary``. Covers:
+``shared.scripts.lib.phase_quality.collect_bloat_summary``. Covers
 producer behaviour (over_limit / in_allowlist / ratchet_delta math +
-fail-open) + the spec-mandated round-trip probe (regenerate the
-dashboard MD against a fixture; confirm the three rows appear).
+fail-open) plus the spec-mandated round-trip probe (regenerate the
+dashboard MD against a fixture; confirm all three rows appear).
 """
 
 from __future__ import annotations
@@ -18,8 +18,7 @@ import pytest
 
 # Load shared phase_quality as a top-level package (not `lib.phase_quality`).
 # test_enforcement_hooks.py defensively clears its own `lib.*` cache before
-# resolving `lib.thresholds`, so it tolerates the `lib.*` entries this import
-# transitively populates.
+# resolving `lib.thresholds`, tolerating the `lib.*` entries this import populates.
 _SHARED_LIB = str(Path(__file__).resolve().parents[3] / "shared" / "scripts" / "lib")
 if _SHARED_LIB not in sys.path:
     sys.path.insert(0, _SHARED_LIB)

--- a/shared/scripts/lib/bloat_baseline.py
+++ b/shared/scripts/lib/bloat_baseline.py
@@ -46,12 +46,17 @@ _SOURCE_EXTS = {".py", ".ts", ".tsx", ".js", ".jsx"}
 
 # Skip globs / substrings — generated, vendored, lock files, migrations,
 # test fixtures (spec §3.2: long-by-nature, exempt from size check).
+# ``.shipwright/runs/`` is the gitignored runtime-artifact tree (campaign
+# setup scripts, surface_verification logs, evidence files); scanning it
+# produces false-positive Group H1 findings because the content can never
+# be committed.
 _SKIP_PATH_RE = re.compile(
     r"(\.lock$|package-lock|node_modules[/\\]|vendor[/\\]|dist[/\\]"
     r"|build[/\\]|\.min\.|__pycache__|\.pyc$|\.generated\."
     r"|migrations?[/\\].*\.sql"
     r"|(?:^|[/\\])fixtures[/\\]"
-    r"|(?:^|[/\\])__fixtures__[/\\])",
+    r"|(?:^|[/\\])__fixtures__[/\\]"
+    r"|(?:^|[/\\])\.shipwright[/\\]runs[/\\])",
     re.IGNORECASE,
 )
 # Non-source extensions that are never weighed.

--- a/shipwright_bloat_baseline.json
+++ b/shipwright_bloat_baseline.json
@@ -501,7 +501,7 @@
     {
       "path": "plugins/shipwright-test/scripts/tools/boundary_coverage_report.py",
       "limit": 300,
-      "current": 661,
+      "current": 640,
       "state": "grandfathered",
       "adr": null
     },


### PR DESCRIPTION
## Summary

Phase-D smoke after Campaign B + C finished surfaced 3 non-blocking Group-H findings. This PR clears all three. Result: Group H reports **7/7 pass** on shipwright; anti-ratchet check is fully clean (0 ratchets / 0 stale / 0 new_crossings).

| # | Finding | Cause | Fix |
|---|---|---|---|
| H1 | `.shipwright/runs/_campaign_B_setup/write_detailed_specs.py` (614) | Path is gitignored — uncommittable — but `bloat_baseline.scan()` walked it | Added `\.shipwright[/\]runs[/\]` to `_SKIP_PATH_RE` in `shared/scripts/lib/bloat_baseline.py` with explanatory comment |
| H1 | `plugins/shipwright-compliance/tests/test_collectors_dashboard.py` (301 LOC, 1 over) | Trailing comment block was 1 line over the 300 source limit | Trimmed one comment line; behaviour unchanged, 19/19 tests still green |
| H2 | `plugins/shipwright-test/scripts/tools/boundary_coverage_report.py` baseline current=661 vs actual=640 | File shrank during Campaign B but baseline entry wasn't tightened | Updated baseline `current` 661 → 640 |

## Verification (worktree mode, pre-PR)

- `anti_ratchet_check`: `status=ok ratchets=0 stale=0 new_crossings=0`
- Group H detective audit: 7/7 pass (H0..H6 all green)
- `shared/tests/test_anti_ratchet_check*.py`: 16/16 green
- `plugins/shipwright-compliance/tests/test_collectors_dashboard.py`: 19/19 green

## Test plan
- [x] Worktree-mode anti-ratchet clean
- [x] Group H 7/7 pass post-fix
- [x] Anti-ratchet tests unaffected by new skip-regex term
- [ ] CI bloat-check workflow green on this PR

Run-ID: iterate-2026-05-26-bloat-hygiene

🤖 Generated with [Claude Code](https://claude.com/claude-code)