### PR TITLE
fix(canon): resolve compliance + planning artifact-path-canon failures on main

### DIFF
--- a/.shipwright/agent_docs/iterates/iterate-2026-05-30-rtm-covered-ignore-untested-events.json
+++ b/.shipwright/agent_docs/iterates/iterate-2026-05-30-rtm-covered-ignore-untested-events.json
@@ -5,5 +5,5 @@
   "complexity": "small",
   "branch": "iterate/rtm-covered-ignore-untested-events",
   "tests_passed": true,
-  "adr": "compliance/rtm-status-logic"
+  "adr": "iterate-2026-05-30-rtm-covered-ignore-untested-events"
 }

--- a/.shipwright/agent_docs/session_handoff.md
+++ b/.shipwright/agent_docs/session_handoff.md
@@ -23,7 +23,7 @@ timestamp: "2026-05-30T20:59:20.601989+00:00"
 - **Type**: bug
 - **Complexity**: small
 - **Branch**: iterate/rtm-covered-ignore-untested-events
-- **ADR**: compliance/rtm-status-logic
+- **ADR**: iterate-2026-05-30-rtm-covered-ignore-untested-events
 - **Tests passed**: True
 
 ## Current Iterate Progress

--- a/plugins/shipwright-build/tests/test_reviewer_orchestration.py
+++ b/plugins/shipwright-build/tests/test_reviewer_orchestration.py
@@ -95,7 +95,7 @@ def test_spec_reviewer_cites_spec_line_on_reject() -> None:
 
 def test_spec_reviewer_is_adversarial_compliance() -> None:
     low = _lower(SPEC_REVIEWER)
-    assert "spec" in low and "compliance" in low, (
+    assert "spec" in low and "compliance" in low, (  # artifact-path-canon: legacy
         "spec-reviewer must frame itself as a spec-compliance review"
     )
 

--- a/shared/tests/test_gitignore_propagation_wiring.py
+++ b/shared/tests/test_gitignore_propagation_wiring.py
@@ -77,14 +77,14 @@ def test_project_write_config_merges_canonical_block(tmp_path: Path) -> None:
     """`write-project-config.py --status complete` propagates the block."""
     _require_git()
     _git("init", cwd=tmp_path)
-    (tmp_path / "planning").mkdir()
+    (tmp_path / "planning").mkdir()  # artifact-path-canon: legacy
 
     proc = subprocess.run(
         [
             sys.executable,
             str(_WRITE_PROJECT_CONFIG),
             "--planning-dir",
-            str(tmp_path / "planning"),
+            str(tmp_path / "planning"),  # artifact-path-canon: legacy
             "--profile",
             "generic",
             "--scope",


### PR DESCRIPTION
Rebuilt cleanly on current `main` (post-#117). Supersedes #121, which was based on a stale `main` (`1088b82`) and conflicted on generated-artifact churn.

## What
`test_artifact_path_canon` is red on current `main` for two migrations. This is a **minimal, source-only** 4-file change (no churn artifacts → conflict-free).

**compliance:**
- The rtm iterate record `.shipwright/agent_docs/iterates/iterate-2026-05-30-rtm-covered-ignore-untested-events.json` + its `session_handoff.md` line carry `adr: "compliance/rtm-status-logic"` — malformed (neither `ADR-NNN` nor run_id, so F11's ADR check can't resolve it, and it trips the `compliance/` matcher). → set to the run_id (no real ADR file by that slug exists; the run's decision-drop resolves).
- `plugins/shipwright-build/tests/test_reviewer_orchestration.py` asserts `"compliance" in low` (a legit reviewer-output string check, not a path). → inline `# artifact-path-canon: legacy` marker.

**planning:**
- `shared/tests/test_gitignore_propagation_wiring.py` builds `tmp_path / "planning"` fixtures (explicit `--planning-dir`) the AST matcher flags. → inline markers on the two lines.

## Verification
- `test_artifact_path_canon`: **4/4 migrations pass** (were 2 red).
- Touched test files still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)