### PR TITLE
fix(security): diff-mode prompt-injection scan honors self-reference/skip excludes

### DIFF
--- a/plugins/shipwright-security/scripts/tools/prompt_injection_scan.py
+++ b/plugins/shipwright-security/scripts/tools/prompt_injection_scan.py
@@ -489,23 +489,20 @@ SELF_REFERENCE_PATHS = {
 }
 
 
+def _is_excluded(path: Path, root: Path) -> bool:
+    """Under a SKIP_DIRS segment, or a SELF_REFERENCE_PATHS file (shared by the full walk + --diff path)."""
+    if any(part in SKIP_DIRS for part in path.parts):
+        return True
+    try:
+        rel = path.relative_to(root).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    return rel in SELF_REFERENCE_PATHS
+
+
 def iter_scannable_files(root: Path) -> list[Path]:
-    """Walk the tree and yield files we care about."""
-    result: list[Path] = []
-    for path in root.rglob("*"):
-        if not path.is_file():
-            continue
-        # Skip anything under a blocked directory
-        if any(part in SKIP_DIRS for part in path.parts):
-            continue
-        try:
-            rel = path.relative_to(root).as_posix()
-        except ValueError:
-            rel = path.as_posix()
-        if rel in SELF_REFERENCE_PATHS:
-            continue
-        result.append(path)
-    return result
+    """Walk the tree, excluding skip dirs + self-reference files (_is_excluded)."""
+    return [p for p in root.rglob("*") if p.is_file() and not _is_excluded(p, root)]
 
 
 def scan_file(
@@ -672,9 +669,11 @@ def main() -> int:
         )
         return 2
 
-    # Select files to scan
+    # Select files to scan. Both modes apply the same exclusion (_is_excluded);
+    # diff-mode must filter too, else a self-reference / skip-dir file in a PR
+    # diff is false-flagged (the bug seen on PR #125).
     if args.diff:
-        files = get_changed_files(args.diff, target)
+        files = [f for f in get_changed_files(args.diff, target) if not _is_excluded(f, target)]
     else:
         files = iter_scannable_files(target)
 

--- a/plugins/shipwright-security/tests/test_prompt_injection_scan_diff.py
+++ b/plugins/shipwright-security/tests/test_prompt_injection_scan_diff.py
@@ -1,0 +1,41 @@
+"""Regression for PR #125: the ``--diff`` scan path must apply the same
+``SKIP_DIRS`` / ``SELF_REFERENCE_PATHS`` exclusion as the full-tree walk.
+
+Without it, a PR whose diff touches the scanner's own source/tests — which
+carry dynamic-execution pattern literals by design — yields false-positive
+PY_EVAL / PY_EXEC findings (the noise seen on PR #125). Kept in its own file so
+the heavily-baselined ``test_prompt_injection_scan.py`` is not grown.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT / "scripts" / "tools"))
+
+import prompt_injection_scan as scanner  # noqa: E402
+
+REPO_ROOT = PLUGIN_ROOT.parents[1]
+
+
+class TestDiffModeExclusion:
+    def test_self_reference_files_are_excluded(self):
+        for rel in scanner.SELF_REFERENCE_PATHS:
+            assert scanner._is_excluded(REPO_ROOT / rel, REPO_ROOT), rel
+
+    def test_skip_dir_file_excluded(self):
+        p = REPO_ROOT / "plugins/shipwright-security/tests/fixtures/x.py"
+        assert scanner._is_excluded(p, REPO_ROOT)
+
+    def test_ordinary_file_not_excluded(self):
+        p = REPO_ROOT / "plugins/shipwright-security/scripts/tools/scan.py"
+        assert not scanner._is_excluded(p, REPO_ROOT)
+
+    def test_self_reference_test_file_would_flag_but_is_excluded(self):
+        # scan_file DOES flag this file's dynamic-exec fixtures; the exclusion
+        # is precisely what keeps diff-mode from reporting them.
+        target = REPO_ROOT / "plugins/shipwright-security/tests/test_prompt_injection_scan.py"
+        assert scanner.scan_file(target, REPO_ROOT), "raw scan_file should flag the fixtures"
+        assert scanner._is_excluded(target, REPO_ROOT)


### PR DESCRIPTION
## Why
On PR #125 the **Shipwright Security Scan** reported 4× HIGH `PY_EVAL`/`PY_EXEC` in `plugins/shipwright-security/tests/test_prompt_injection_scan.py` — the prompt-injection scanner flagging `eval(`/`exec(` **fixture literals in its own test file**. HIGH doesn't gate (the critical-gate blocks only on CRITICAL), so it was non-blocking noise, but it polluted every PR's security report.

## Root cause (proven)
The scanner already excludes those files via `SELF_REFERENCE_PATHS` / `SKIP_DIRS` — **but only in the full-tree walk (`iter_scannable_files`)**. `security.yml` scans PRs in **`--diff` mode**, which listed changed files via `get_changed_files()` and scanned them directly, bypassing the exclusion. So a PR whose diff touched the scanner's own source/tests got false positives.

```
in full-walk (iter_scannable_files)?  False   # correctly excluded
scan_file(test_prompt_injection_scan.py) -> [PY_EVAL, PY_EXEC, PY_EVAL, PY_EVAL]   # but per-file scan flags it
diff-mode filter applied -> 0 files kept -> 0 findings   # fix
```

## Fix
Extract a shared `_is_excluded(path, root)` predicate and apply it in **both** the full walk and the `--diff` file list. Regression test added in a new file (`test_prompt_injection_scan_diff.py`) so the heavily-baselined `test_prompt_injection_scan.py` isn't grown. Full-mode scan unaffected (0 findings, 1317 files).

Self-validating: this PR's own diff touches `prompt_injection_scan.py`, so its Security Scan should now come back **clean** (it would have flagged it before the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
