### PR TITLE
feat(triage): ingest prompt_risks.json as a gh-prompt producer source

### DIFF
--- a/.shipwright/planning/adr/094-bloat-github-triage-prompt-producer-tests.md
+++ b/.shipwright/planning/adr/094-bloat-github-triage-prompt-producer-tests.md
@@ -1,0 +1,73 @@
+# ADR-094: Bloat exception — `github_triage` test suites raised for the `gh-prompt:` producer
+
+- **Status:** accepted
+- **Date:** 2026-06-01
+- **Re-Review-Date:** 2026-09-01 _(check whether the github_triage test
+  suites should be split per-source, or the exception can be retired)_
+- **Incident Reference:** PR adding the `prompt_risks.json` triage producer
+  (`gh-prompt:` source) + a hermeticity fix for the existing `gh-security`
+  artifact path. First crossing surfaced when the new producer's tests +
+  `_patch_api` extensions pushed two already-grandfathered test files past
+  their baseline.
+
+## Context
+
+The `prompt_risks.json` triage producer adds a new artifact source mirroring
+the proven `findings.json` path. Two **test** files grew:
+
+- `shared/tests/test_github_triage.py` 413 → 421 (+8): `_patch_api` now mocks
+  the artifact functions (`latest_security_workflow_run`,
+  `download_security_findings`, `download_prompt_risks`) — a hermeticity fix for
+  a **pre-existing** flake (the `gh-security` artifact path hit real `gh` once
+  the repo had fresh successful `security.yml` runs; reproduced on `main`).
+- `shared/tests/test_github_triage_artifact_fallback.py` 713 → 718 (+5):
+  `_patch_api` gains a `download_prompt_risks` patch so the new consumer path is
+  hermetic.
+
+Source files were kept at/under baseline: `github_api.py` stayed at 392 (the
+new `download_prompt_risks` rode a shared helper + a docstring trim);
+`producer.py`/`consumer.py` are under 300 and unbaselined.
+
+## Ousterhout Argument
+
+These are cohesive **per-subsystem test suites** for `github_triage`, and
+`_patch_api` is a deep test fixture: a narrow interface (patch every
+`github_api` entry point) over substantial behaviour. The new source must be
+mocked there too or the suite is non-hermetic. Splitting the suites to dodge
++13 LOC would scatter related triage-producer tests and force the fixture to be
+duplicated — exposing the very wiring the fixture exists to hide.
+
+## YAGNI Check
+
+Every added line is needed **today**: the 3 `_patch_api` mocks close a live
+flake reproduced on `main`; the fallback patch is required for the new
+consumer path. No speculative scope — the regression tests for `gh-prompt:`
+live in a separate, unbaselined file.
+
+## Chesterton-Fence Check
+
+The test files are large because `github_triage` has many sources
+(security / secrets / CI / artifact), each needing coverage, with `_patch_api`
+centralising gh mocking (DRY). git history shows the suites grew source-by-
+source under that same structure. The fence stands for a reason; extending it
+by a few lines for the new source is consistent with it, not a violation.
+
+## Decision
+
+Raise `test_github_triage.py` to 421 and
+`test_github_triage_artifact_fallback.py` to 718 (`state: exception`,
+`adr: ADR-094`). Retire when the `github_triage` suites are split per-source
+(tracked at the Re-Review-Date).
+
+## Consequences
+
+The two suites now operate against the new limits; further additions must stay
+within them or bump again with justification. No source-file limit moved.
+
+## Rejected alternatives
+
+- **Split the suites now** — disproportionate: the files are coherent and the
+  trigger is +13 LOC, not a structural problem. Splitting churns a large,
+  well-tested module for cosmetic LOC.
+- **Skip the tests / skip the hermeticity fix** — unacceptable: leaves the new
+  producer without regression coverage and the `gh-security` flake live.

--- a/shared/scripts/github_api.py
+++ b/shared/scripts/github_api.py
@@ -325,26 +325,25 @@ def latest_security_workflow_run() -> dict | None:
 
 
 def download_security_findings(run_id: int) -> list[dict] | None:
-    """Download the ``security-scan-results`` artifact from a workflow run
-    and return its ``findings`` array.
+    """SAST/SCA findings from the ``security-scan-results`` artifact's
+    ``findings.json``. Contract (subprocess hygiene, rglob discovery, semantic
+    list-validation, ADR-052 None-vs-``[]``) lives in ``_download_artifact_findings``.
+    """
+    return _download_artifact_findings(run_id, "findings.json")
 
-    Iterate C contract:
 
-    1. Subprocess via argv list, ``shell=False`` (review findings
-       openai-10, gemini-4 — command-injection hygiene).
-    2. Robust file discovery via ``rglob`` — works for both flat
-       (``findings.json``) and nested (``subdir/findings.json``)
-       artifact layouts (review finding openai-14).
-    3. Semantic validation — ``findings`` MUST be a list. Trusting the
-       aggregate ``by_severity`` / ``total_findings`` would be unsafe
-       if they disagreed with the actual array (review finding
-       openai-9). Returns ``None`` on a non-list ``findings`` value.
-    4. ``None`` on ANY failure: gh missing (FileNotFoundError), gh
-       non-zero exit, file not found, JSON parse error, semantic
-       validation failure. Empty list ``[]`` is a valid success state
-       (clean scan) — distinguished from failure per ADR-052.
-    5. Tempdir is created via ``tempfile.mkdtemp`` and removed in a
-       finally block — never leaked even on exception paths.
+def download_prompt_risks(run_id: int) -> list[dict] | None:
+    """Prompt-injection findings from the artifact's ``prompt_risks.json`` (same
+    contract as ``download_security_findings`` — see ``_download_artifact_findings``)."""
+    return _download_artifact_findings(run_id, "prompt_risks.json")
+
+
+def _download_artifact_findings(run_id: int, filename: str) -> list[dict] | None:
+    """Shared impl for the artifact-download helpers: download the
+    ``security-scan-results`` artifact and return the ``findings`` array out of
+    ``filename`` (``findings.json`` | ``prompt_risks.json``). Same hygiene as
+    the original ``download_security_findings`` (argv subprocess, robust rglob,
+    semantic list-validation, tempdir cleanup, ADR-052 None-vs-``[]``).
     """
     tmpdir = tempfile.mkdtemp(prefix="shipwright-artifact-")
     try:
@@ -365,7 +364,7 @@ def download_security_findings(run_id: int) -> list[dict] | None:
         if result.returncode != 0:
             return None
         # Robust discovery: gh usually flattens, but nested layouts are tolerated.
-        matches = list(Path(tmpdir).rglob("findings.json"))
+        matches = list(Path(tmpdir).rglob(filename))
         if not matches:
             return None
         try:

--- a/shared/scripts/github_triage/__init__.py
+++ b/shared/scripts/github_triage/__init__.py
@@ -56,8 +56,10 @@ from .consumer import import_findings
 from .mappers import ci_action_unit, latest_failed_ci_runs, secrets_action_unit
 from .producer import (
     PREFIX_CI,
+    PREFIX_PROMPT,
     PREFIX_SECRETS,
     PREFIX_SECURITY,
+    prompt_injection_action_unit_from_artifact,
     security_action_unit,
     security_action_unit_from_artifact,
 )
@@ -74,6 +76,7 @@ from .state import (
 __all__ = [
     "DEFAULT_THROTTLE_HOURS",
     "PREFIX_CI",
+    "PREFIX_PROMPT",
     "PREFIX_SECRETS",
     "PREFIX_SECURITY",
     "SOURCE",
@@ -81,6 +84,7 @@ __all__ = [
     "import_findings",
     "is_due",
     "latest_failed_ci_runs",
+    "prompt_injection_action_unit_from_artifact",
     "read_last_import",
     "secrets_action_unit",
     "security_action_unit",

--- a/shared/scripts/github_triage/consumer.py
+++ b/shared/scripts/github_triage/consumer.py
@@ -24,8 +24,10 @@ from triage import append_triage_item_idempotent
 from .mappers import ci_action_unit, latest_failed_ci_runs, secrets_action_unit
 from .producer import (
     PREFIX_CI,
+    PREFIX_PROMPT,
     PREFIX_SECRETS,
     PREFIX_SECURITY,
+    prompt_injection_action_unit_from_artifact,
     security_action_unit,
     security_action_unit_from_artifact,
 )
@@ -82,13 +84,15 @@ def import_findings(project_root) -> dict:
     # review HIGH #1 — gemini-1).
     artifact_run: dict | None = None
     artifact_findings: list[dict] | None = None
+    prompt_findings: list[dict] | None = None
     if cs_alerts is None:
         try:
             artifact_run = github_api.latest_security_workflow_run()
             if artifact_run is not None:
-                artifact_findings = github_api.download_security_findings(
-                    artifact_run.get("id") or 0,
-                )
+                run_id = artifact_run.get("id") or 0
+                artifact_findings = github_api.download_security_findings(run_id)
+                # prompt_risks.json ships in the SAME artifact (gh-prompt source).
+                prompt_findings = github_api.download_prompt_risks(run_id)
         except Exception as exc:  # noqa: BLE001 — fail-soft, never block
             sys.stderr.write(
                 f"[github-triage] artifact fetch failed: "
@@ -96,6 +100,7 @@ def import_findings(project_root) -> dict:
             )
             artifact_run = None
             artifact_findings = None
+            prompt_findings = None
 
     fetch_succeeded = {
         "code_scanning": cs_alerts is not None,
@@ -106,6 +111,7 @@ def import_findings(project_root) -> dict:
         # ``download failed / never tried``. Auto-resolve depends on
         # this per ADR-052.
         "artifact": artifact_findings is not None,
+        "prompt": prompt_findings is not None,
     }
 
     # Run the legacy-migration sweep FIRST so it never races against the
@@ -147,6 +153,16 @@ def import_findings(project_root) -> dict:
             dependabot=db_alerts,
         )
         if (cs_alerts is None and artifact_findings is not None)
+        else None
+    )
+    # Prompt-injection artifact path: parallel to artifact_unit, separate source.
+    prompt_unit = (
+        prompt_injection_action_unit_from_artifact(
+            findings=prompt_findings,
+            owner_repo=owner_repo,
+            workflow_run_url=(artifact_run or {}).get("html_url"),
+        )
+        if (cs_alerts is None and prompt_findings is not None)
         else None
     )
     secrets_unit = (
@@ -221,6 +237,19 @@ def import_findings(project_root) -> dict:
             appended += 1
     else:
         by_source[PREFIX_SECRETS] = None
+
+    # Prompt-injection (artifact path; parallel to + independent of gh-security).
+    # Gated on cs_alerts is None like the artifact security unit; auto-resolve
+    # opens for PREFIX_PROMPT so a clean scan ([] findings) dismisses an open item.
+    if cs_alerts is None and fetch_succeeded["prompt"]:
+        if owner_repo is not None:
+            resolvable_prefixes.add(PREFIX_PROMPT)
+        prompt_id = _maybe_append(prompt_unit)
+        by_source[PREFIX_PROMPT] = 1 if prompt_id else 0
+        if prompt_id:
+            appended += 1
+    else:
+        by_source[PREFIX_PROMPT] = None
 
     # CI
     if fetch_succeeded["runs"]:

--- a/shared/scripts/github_triage/producer.py
+++ b/shared/scripts/github_triage/producer.py
@@ -39,11 +39,64 @@ from .severity import (
 PREFIX_SECURITY = "gh-security:"
 PREFIX_SECRETS = "gh-secrets:"
 PREFIX_CI = "gh-ci:"
-_OWNED_PREFIXES = (PREFIX_SECURITY, PREFIX_SECRETS, PREFIX_CI)
+PREFIX_PROMPT = "gh-prompt:"
+_OWNED_PREFIXES = (PREFIX_SECURITY, PREFIX_SECRETS, PREFIX_CI, PREFIX_PROMPT)
 
 # Length cap for the artifact-source detail line — protects against
 # pathological finding-array sizes (review finding openai-11).
 _ARTIFACT_DETAIL_MAX_LEN = 1024
+
+
+def prompt_injection_action_unit_from_artifact(
+    *,
+    findings: list[dict],
+    owner_repo: str | None,
+    workflow_run_url: str | None = None,
+) -> dict | None:
+    """Collapse shipwright-security prompt-injection findings (``prompt_risks.json``
+    artifact) into a ``gh-prompt:{owner}/{repo}`` action-unit — a SEPARATE source
+    from the SAST/SCA ``gh-security`` unit (different finding class, independently
+    dismissable). Same ADR-052 + hygiene contract as
+    ``security_action_unit_from_artifact``: severity derived by iterating
+    ``findings`` (never the aggregate); no raw finding strings in ``detail`` /
+    ``launch_payload``; ``detail`` capped. Returns ``None`` when ``owner_repo`` is
+    ``None`` OR ``findings`` is empty — an empty (clean) scan is handled by the
+    orchestrator's auto-resolve gate.
+    """
+    if owner_repo is None or not findings:
+        return None
+    breakdown = severity_breakdown(findings, artifact_extract_severity)
+    severity = max_severity(
+        [triage_severity(artifact_extract_severity(f)) for f in findings]
+    )
+    total = len(findings)
+    run_url = workflow_run_url or security_url(owner_repo)
+    title = f"GitHub prompt-injection: {total} finding(s) ({severity})"
+    detail = (
+        f"Repo {owner_repo} | "
+        f"prompt-injection (prompt_risks.json): {format_breakdown(breakdown)} | "
+        f"run: {run_url}"
+    )
+    if len(detail) > _ARTIFACT_DETAIL_MAX_LEN:
+        detail = detail[: _ARTIFACT_DETAIL_MAX_LEN - 1] + "…"
+    payload = (
+        f"/shipwright-security\n"
+        f"\n"
+        f"Context: the shipwright-security prompt-injection scan reports "
+        f"{total} open finding(s) for {owner_repo}.\n"
+        f"Severity breakdown — prompt-injection: {format_breakdown(breakdown)}.\n"
+        f"Workflow run: {run_url}\n"
+        f"Re-scan locally: see docs/security-ci-setup.md\n"
+        f"Source: triage item {PREFIX_PROMPT}{owner_repo}"
+    )
+    return {
+        "severity": severity,
+        "kind": kind_for(severity),
+        "title": title[:160],
+        "detail": detail,
+        "dedup_key": f"{PREFIX_PROMPT}{owner_repo}",
+        "launch_payload": payload,
+    }
 
 
 def security_action_unit(

--- a/shared/tests/test_github_triage.py
+++ b/shared/tests/test_github_triage.py
@@ -121,6 +121,13 @@ def _patch_api(
     )
     monkeypatch.setattr(github_api, "fetch_workflow_runs", lambda branch: runs)
     monkeypatch.setattr(github_api, "owner_repo", lambda _: owner_repo)
+    # Artifact path dormant by default — these tests exercise the GHAS/secret/CI
+    # feeds, not the security-scan-results artifact. Without this the cs_alerts=
+    # None cases hit the REAL gh artifact download (non-hermetic: flakes once the
+    # repo has fresh successful security.yml runs).
+    monkeypatch.setattr(github_api, "latest_security_workflow_run", lambda: None)
+    monkeypatch.setattr(github_api, "download_security_findings", lambda rid: None)
+    monkeypatch.setattr(github_api, "download_prompt_risks", lambda rid: None)
 
 
 def _append_events(project_root: Path) -> list[dict]:

--- a/shared/tests/test_github_triage_artifact_fallback.py
+++ b/shared/tests/test_github_triage_artifact_fallback.py
@@ -106,6 +106,7 @@ def _patch_api(
     ci_runs: Any = None,
     artifact_run: Any = None,
     artifact_findings: Any = None,
+    prompt_findings: Any = None,
     branch: str = "main",
     owner_repo_value: str | None = OWNER_REPO,
     available: bool = True,
@@ -126,6 +127,9 @@ def _patch_api(
     )
     monkeypatch.setattr(
         github_api, "download_security_findings", lambda run_id: artifact_findings,
+    )
+    monkeypatch.setattr(
+        github_api, "download_prompt_risks", lambda run_id: prompt_findings,
     )
 
 

--- a/shared/tests/test_github_triage_prompt_artifact.py
+++ b/shared/tests/test_github_triage_prompt_artifact.py
@@ -1,0 +1,107 @@
+"""Tests for the prompt_risks.json triage producer (``gh-prompt:`` source).
+
+Prompt-injection findings ship in the SAME ``security-scan-results`` artifact as
+``findings.json``; this source emits a SEPARATE, independently-dismissable
+``gh-prompt:{owner}/{repo}`` action-unit (parallel to the ``gh-security``
+artifact path). Same ADR-052 None-vs-``[]`` + hygiene contract.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+_SHARED_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SHARED_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SHARED_SCRIPTS))
+
+import github_api  # noqa: E402
+import github_triage  # noqa: E402
+
+OWNER_REPO = "acme/foo"
+_mapper = github_triage.prompt_injection_action_unit_from_artifact
+
+
+# --------------------------------------------------------------------------- #
+# Mapper (pure function)
+# --------------------------------------------------------------------------- #
+def test_returns_none_when_owner_repo_none() -> None:
+    assert _mapper(findings=[{"severity": "high"}], owner_repo=None) is None
+
+
+def test_returns_none_when_findings_empty() -> None:
+    # Empty (clean) scan -> None; the orchestrator's auto-resolve gate handles it.
+    assert _mapper(findings=[], owner_repo=OWNER_REPO) is None
+
+
+def test_builds_gh_prompt_unit() -> None:
+    unit = _mapper(
+        findings=[{"severity": "high"}, {"severity": "critical"}],
+        owner_repo=OWNER_REPO,
+        workflow_run_url="https://github.com/acme/foo/actions/runs/900",
+    )
+    assert unit is not None
+    assert unit["dedup_key"] == "gh-prompt:acme/foo"
+    assert unit["severity"] == "critical"  # max of the two findings
+    assert "prompt-injection" in unit["title"]
+    assert "2 finding" in unit["title"]
+    assert unit["launch_payload"].startswith("/shipwright-security")
+    assert "gh-prompt:acme/foo" in unit["launch_payload"]
+
+
+def test_no_raw_finding_strings_leak() -> None:
+    # Hygiene: only aggregated counts + run URL — never raw rule/desc/file text.
+    unit = _mapper(
+        findings=[{
+            "severity": "high",
+            "rule": "PY_EVAL_SECRET_RULE",
+            "description": "do-not-leak-this-text",
+            "file": "secret/path/leak.py",
+        }],
+        owner_repo=OWNER_REPO,
+    )
+    assert unit is not None
+    blob = unit["detail"] + unit["launch_payload"]
+    assert "PY_EVAL_SECRET_RULE" not in blob
+    assert "do-not-leak-this-text" not in blob
+    assert "secret/path/leak.py" not in blob
+
+
+# --------------------------------------------------------------------------- #
+# Consumer integration (artifact path)
+# --------------------------------------------------------------------------- #
+def _patch(monkeypatch, *, prompt_findings: Any, findings: Any = None) -> None:
+    monkeypatch.setattr(github_api, "gh_available", lambda: True)
+    monkeypatch.setattr(github_api, "default_branch", lambda: "main")
+    monkeypatch.setattr(github_api, "owner_repo", lambda _: OWNER_REPO)
+    monkeypatch.setattr(github_api, "fetch_code_scanning_alerts", lambda: None)
+    monkeypatch.setattr(github_api, "fetch_dependabot_alerts", lambda: None)
+    monkeypatch.setattr(github_api, "fetch_secret_scanning_alerts", lambda: None)
+    monkeypatch.setattr(github_api, "fetch_workflow_runs", lambda b: None)
+    monkeypatch.setattr(
+        github_api, "latest_security_workflow_run",
+        lambda: {"id": 900, "html_url": "https://github.com/acme/foo/actions/runs/900"},
+    )
+    monkeypatch.setattr(github_api, "download_security_findings", lambda rid: findings)
+    monkeypatch.setattr(github_api, "download_prompt_risks", lambda rid: prompt_findings)
+
+
+def test_prompt_findings_emit_gh_prompt_item(tmp_path, monkeypatch) -> None:
+    _patch(monkeypatch, prompt_findings=[{"severity": "high"}])
+    result = github_triage.import_findings(tmp_path)
+    assert result["by_source"][github_triage.PREFIX_PROMPT] == 1
+
+
+def test_clean_prompt_scan_emits_nothing(tmp_path, monkeypatch) -> None:
+    # [] = clean scan: fetch succeeded, but no item emitted (auto-resolve opens).
+    _patch(monkeypatch, prompt_findings=[])
+    result = github_triage.import_findings(tmp_path)
+    assert result["by_source"][github_triage.PREFIX_PROMPT] == 0
+
+
+def test_prompt_fetch_failed_is_none(tmp_path, monkeypatch) -> None:
+    # None = fetch failed: by_source marks None (auto-resolve stays gated, ADR-052).
+    _patch(monkeypatch, prompt_findings=None)
+    result = github_triage.import_findings(tmp_path)
+    assert result["by_source"][github_triage.PREFIX_PROMPT] is None

--- a/shipwright_bloat_baseline.json
+++ b/shipwright_bloat_baseline.json
@@ -872,9 +872,9 @@
     {
       "path": "shared/tests/test_github_triage.py",
       "limit": 300,
-      "current": 413,
-      "state": "grandfathered",
-      "adr": null
+      "current": 421,
+      "state": "exception",
+      "adr": "ADR-094"
     },
     {
       "path": "shared/tests/test_github_triage_action_units.py",
@@ -886,9 +886,9 @@
     {
       "path": "shared/tests/test_github_triage_artifact_fallback.py",
       "limit": 300,
-      "current": 713,
-      "state": "grandfathered",
-      "adr": null
+      "current": 718,
+      "state": "exception",
+      "adr": "ADR-094"
     },
     {
       "path": "shared/tests/test_hook_output_schema_compliance.py",


### PR DESCRIPTION
## Why
The GitHub triage producer ingests code-scanning + Dependabot + the shipwright-security **`findings.json`** artifact (the active security source on this private repo, since GHAS Code Scanning is off). But it ignored **`prompt_risks.json`** — the prompt-injection scan output that ships in the *same* `security-scan-results` artifact. So prompt-injection findings on `main` were never auto-triaged.

## What
A **separate** `gh-prompt:{owner}/{repo}` source mirroring the proven `findings.json` artifact path (prompt-injection is a distinct finding class, independently dismissable):
- `github_api.download_prompt_risks()` via a shared `_download_artifact_findings` helper (`download_security_findings` delegates to it).
- `producer.prompt_injection_action_unit_from_artifact()` + `PREFIX_PROMPT` — same **ADR-052** `None`-vs-`[]` contract + hygiene (severity from iterating findings, **no raw finding strings** in detail/payload, detail capped).
- `consumer` wiring: fetch + build + append + **auto-resolve** (a clean `[]` scan dismisses an open item).
- 7 new tests (`test_github_triage_prompt_artifact.py`): mapper (None/empty/build/no-leak) + consumer (emit / clean / failed-fetch).

## Also (pre-existing flake, fixed)
`test_github_triage.py::test_failed_fetch_does_not_resolve_items` **fails on `main`** — `_patch_api` there didn't mock the `gh-security` artifact path, so with fresh successful `security.yml` runs the real `gh` path fired and resolved the seeded item. Fixed by mocking the artifact functions in `_patch_api` (hermetic).

## Bloat
`github_api.py` held at its 392 baseline (docstring trim absorbed the new function). The two `github_triage` test suites grew (+8/+5) for the new tests + hermeticity patches → raised via **ADR-094** (`state: exception`). No source-file limit moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
