### PR TITLE
docs(constitution): never put sensitive detail in git-tracked triage/campaign artifacts

### DIFF
--- a/shared/constitution.md
+++ b/shared/constitution.md
@@ -85,6 +85,7 @@
 - Add features beyond what the spec requires (YAGNI)
 - Hardcode secrets, API keys, or tokens in source code
 - Commit `.env` files
+- Write sensitive detail — security/vulnerability descriptions, file:line, exploit steps, internal audit roadmaps, secrets — into **git-tracked** artifacts (`.shipwright/triage.jsonl`, which the outbox sweeps into the PR → tracked → public; `campaign.md` / `status.json`; specs; commit messages). Keep such detail in a gitignored store (the `Spec/` report, the gitignored campaign dir); the triage item / campaign card is a NEUTRAL, descriptive launch-pointer that references it — a title like "Audit bug-fixes — auto batch" is fine, "subsystem X is exploitable via …" or file:line is not
 - Retry blindly without root-cause analysis
 - Amend a commit that was blocked by a pre-commit hook
 - Loop more than 3 debugging attempts without escalating

--- a/shared/scripts/tools/triage_add.py
+++ b/shared/scripts/tools/triage_add.py
@@ -66,7 +66,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                         "escapes). Optional — defaults to empty string. "
                         "AC-1 lists --title / --severity / --kind / --source "
                         "/ --fr-id as the canonical surface; --detail rounds "
-                        "out the card when context is available.")
+                        "out the card when context is available. SENSITIVITY: "
+                        "triage is git-tracked (the outbox sweeps into the PR "
+                        "-> tracked -> public) - keep --title/--detail NEUTRAL: no "
+                        "security/vuln detail, file:line, exploit steps, or "
+                        "secrets (put those in a gitignored artifact). See "
+                        "shared/constitution.md (NEVER).")
     p.add_argument("--severity", required=True,
                    help="Severity: critical | high | medium | low | info "
                         "(validated by triage.append_triage_item).")
@@ -168,6 +173,16 @@ def main(argv: list[str] | None = None) -> int:
             "If the FR doesn't exist in spec.md, the RTM render will silently "
             "omit the deep-link until spec is updated."
         )
+    # Constant touchpoint reminder (stderr — keeps the stdout JSON contract clean).
+    # "is this content sensitive" is a semantic call code can't make, so the
+    # mechanism just surfaces the git-tracked nature on every add.
+    print(
+        "note: triage is git-tracked (the outbox sweeps into the iterate PR -> "
+        "tracked -> public). Keep items NEUTRAL - no security/vuln detail, "
+        "file:line, exploit steps, or secrets; put that in a gitignored artifact "
+        "(Spec/ report or the gitignored campaign dir). See shared/constitution.md (NEVER).",
+        file=sys.stderr,
+    )
     print(json.dumps(result, indent=2))
     return 0
 


### PR DESCRIPTION
Adds a NEVER rule to `shared/constitution.md`:

> Write sensitive detail — security/vulnerability descriptions, file:line, exploit steps, internal audit roadmaps, secrets — into **git-tracked** artifacts (`.shipwright/triage.jsonl`, which the outbox sweeps into the PR → tracked → public; `campaign.md`/`status.json`; specs; commit messages). Keep such detail in a gitignored store (the `Spec/` report, the gitignored campaign dir); the triage item / campaign card is a NEUTRAL, descriptive launch-pointer that references it.

**Why here:** the outbox→tracked routing is automatic *code*, but "is this content sensitive" is a *semantic* judgement code cannot make (a normal bug item legitimately carries file:line). So the boundary lives where agent behaviour is bound — the constitution — and ships/propagates with the plugin to every adopted repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)