### PR TITLE
docs: drop GPG/SSH commit-signing guidance (keyless workflow)

### DIFF
--- a/.shipwright/agent_docs/conventions.md
+++ b/.shipwright/agent_docs/conventions.md
@@ -350,10 +350,6 @@ git commit -s -m "feat(scope): your message"
 
 This adds a `Signed-off-by:` line confirming you have the right to contribute the code.
 
-### Signed Commits (GPG/SSH)
-
-Signing commits with GPG or SSH keys is **strongly encouraged**. For the main branch, signed commits will eventually become required.
-
 ## Graduated Trust Model
 
 Shipwright uses a graduated trust model to balance openness with security. Different levels of access unlock different types of contributions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,10 +184,6 @@ git commit -s -m "feat(scope): your message"
 
 This adds a `Signed-off-by:` line confirming you have the right to contribute the code.
 
-### Signed Commits (GPG/SSH)
-
-Signing commits with GPG or SSH keys is **strongly encouraged**. For the main branch, signed commits will eventually become required.
-
 ## Graduated Trust Model
 
 Shipwright uses a graduated trust model to balance openness with security. Different levels of access unlock different types of contributions:


### PR DESCRIPTION
## What
Removes the **"Signed Commits (GPG/SSH)"** section from `CONTRIBUTING.md` and `.shipwright/agent_docs/conventions.md`.

## Why
Shipwright's workflow is **keyless**: `/shipwright-iterate` PRs are bot-committed without a signing key, and the SME/solopreneur target audience won't set up GPG/SSH commit signing. The `main` ruleset's `required_signatures` was removed for the same reason (it would permanently block every bot-authored iterate PR → automerge never fires).

Provenance is still intact:
- **`main` history stays `verified`** — GitHub signs the squash-merge commits it creates.
- The real hardening is the **5 CI gates** (security scan, 2x CodeQL, anti-ratchet, lint+test).

**DCO sign-off is retained** (`git commit -s` -> a keyless `Signed-off-by:` trailer, not a cryptographic signature).

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
