### PR TITLE
fix(security): tolerate markdown-fenced JSON in pr_review parser

### DIFF
--- a/plugins/shipwright-security/scripts/lib/pr_review_lib.py
+++ b/plugins/shipwright-security/scripts/lib/pr_review_lib.py
@@ -63,14 +63,52 @@ def build_messages(system_prompt: str, user_prompt: str, diff: str, pr_meta: str
     ]
 
 
+def _strip_code_fence(raw: str) -> str:
+    """Drop a leading ```json / ``` fence line and the trailing ``` if present.
+
+    Even with `response_format: json_object`, OpenRouter -> Anthropic does not
+    strictly enforce raw-JSON output, so the model frequently wraps the object
+    in a markdown code fence. Verified live on a B4.5 Tier-3 smoke-test PR.
+    """
+    text = (raw or "").strip()
+    if not text.startswith("```"):
+        return text
+    nl = text.find("\n")
+    if nl != -1:
+        text = text[nl + 1:]  # drop the opening ``` / ```json line
+    fence = text.rfind("```")
+    if fence != -1:
+        text = text[:fence]   # drop the closing ``` fence
+    return text.strip()
+
+
 def parse_review_response(raw: str) -> dict:
-    """Parse the strict-JSON review object. Raises ValueError on any deviation."""
-    try:
-        data = json.loads(raw)
-    except (json.JSONDecodeError, TypeError) as e:
-        raise ValueError(f"response is not valid JSON: {e}") from e
-    if not isinstance(data, dict):
-        raise ValueError("response JSON is not an object")
+    """Parse the strict-JSON review object, tolerating a ```json fence or
+    surrounding prose around the object. Raises ValueError on any deviation.
+
+    Tries, in order: the raw text, the fence-stripped text, and the outermost
+    ``{ ... }`` slice (handles leading/trailing prose).
+    """
+    stripped = _strip_code_fence(raw)
+    candidates = [raw or "", stripped]
+    start, end = stripped.find("{"), stripped.rfind("}")
+    if start != -1 and end > start:
+        candidates.append(stripped[start:end + 1])
+
+    data = None
+    last_err: Exception = ValueError("empty response")
+    for cand in candidates:
+        try:
+            parsed = json.loads(cand)
+        except (json.JSONDecodeError, TypeError) as e:
+            last_err = e
+            continue
+        if isinstance(parsed, dict):
+            data = parsed
+            break
+        last_err = ValueError("response JSON is not an object")
+    if data is None:
+        raise ValueError(f"response is not valid JSON: {last_err}")
     if "decision" not in data:
         raise ValueError("response JSON missing required 'decision' field")
     return data

--- a/plugins/shipwright-security/tests/test_pr_review_lib.py
+++ b/plugins/shipwright-security/tests/test_pr_review_lib.py
@@ -73,6 +73,23 @@ class TestParseResponse:
         assert review["decision"] == "block"
         assert review["blocking"] == ["x"]
 
+    def test_json_object_in_markdown_fence(self):
+        # OpenRouter -> Anthropic ignores response_format and fences the JSON.
+        # Verified live on a B4.5 Tier-3 smoke test (exit 2 instead of the real decision).
+        obj = {"decision": "block", "summary": "s", "blocking": ["b"], "comments": []}
+        raw = "```json\n" + json.dumps(obj, indent=2) + "\n```"
+        review = L.parse_review_response(raw)
+        assert review["decision"] == "block"
+        assert review["blocking"] == ["b"]
+
+    def test_json_object_in_bare_fence(self):
+        raw = "```\n" + json.dumps({"decision": "approve", "summary": "ok"}) + "\n```"
+        assert L.parse_review_response(raw)["decision"] == "approve"
+
+    def test_json_object_with_surrounding_prose(self):
+        raw = 'Here is my review:\n{"decision": "comment", "summary": "nit"}\nThanks!'
+        assert L.parse_review_response(raw)["decision"] == "comment"
+
     def test_invalid_json_raises(self):
         with pytest.raises(ValueError):
             L.parse_review_response("this is not json")


### PR DESCRIPTION
**Found by the B4.5 Tier-3 smoke test.** OpenRouter→Anthropic doesn't strictly honor `response_format: json_object` — claude-sonnet-4.6 fenced its JSON in ```json … ```, so `parse_review_response` failed (`Expecting value: char 0`) and pr_review.py exited 2 instead of returning the real decision. This broke every Tier-3 review.

Fix: `parse_review_response` now tolerates a markdown fence / surrounding prose (raw → fence-stripped → outermost `{…}` slice). +3 tests. 52 pr_review tests pass, ruff clean.

The smoke test otherwise verified Tier routing, the OpenRouter call, and the prompt-injection inoculation all work.

Run-ID: iterate-2026-06-11-automerge-pr-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)