### PR TITLE
Release v0.29.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "shipwright",
   "description": "Shipwright SDLC — AI-powered software delivery lifecycle framework",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "owner": {
     "name": "svenroth.ai",
     "url": "https://github.com/svenroth-ai"
@@ -11,7 +11,7 @@
     {
       "name": "shipwright-run",
       "description": "Orchestrate the full Shipwright SDLC pipeline — from user description to deployed application",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-run",
       "category": "development",
       "tags": ["orchestration", "sdlc", "pipeline", "deployment"]
@@ -19,7 +19,7 @@
     {
       "name": "shipwright-project",
       "description": "Decompose project requirements into well-scoped planning units with IREB-aligned specs",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-project",
       "category": "development",
       "tags": ["planning", "decomposition", "requirements", "ireb"]
@@ -27,7 +27,7 @@
     {
       "name": "shipwright-design",
       "description": "Generate UI mockups from IREB specs — standalone HTML screens and user flows",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-design",
       "category": "development",
       "tags": ["ui-design", "mockups", "html", "prototyping", "untitled-ui"]
@@ -35,7 +35,7 @@
     {
       "name": "shipwright-plan",
       "description": "Deep planning with research, interview, external LLM review, and TDD approach",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-plan",
       "category": "development",
       "tags": ["planning", "tdd", "architecture", "llm-review"]
@@ -43,7 +43,7 @@
     {
       "name": "shipwright-build",
       "description": "TDD implementation with code review, Conventional Commits, and feature branch workflow",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-build",
       "category": "development",
       "tags": ["implementation", "tdd", "code-review", "conventional-commits"]
@@ -51,7 +51,7 @@
     {
       "name": "shipwright-test",
       "description": "Profile-aware test runner: unit tests, smoke tests, Playwright E2E, and security scans",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-test",
       "category": "development",
       "tags": ["testing", "vitest", "playwright", "smoke-test"]
@@ -59,7 +59,7 @@
     {
       "name": "shipwright-deploy",
       "description": "Deploy to Jelastic (Infomaniak) with smoke test verification and rollback support",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-deploy",
       "category": "development",
       "tags": ["deployment", "jelastic", "infomaniak", "rollback"]
@@ -67,7 +67,7 @@
     {
       "name": "shipwright-changelog",
       "description": "Parse Conventional Commits, generate Keep-a-Changelog entries, create version tags and PRs",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-changelog",
       "category": "development",
       "tags": ["changelog", "conventional-commits", "semver", "pr"]
@@ -75,7 +75,7 @@
     {
       "name": "shipwright-security",
       "description": "Security scanning — Semgrep + Trivy + Gitleaks + Shipwright prompt-injection scan (OSS default), with an automated remediation loop and an optional Aikido backend",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-security",
       "category": "development",
       "tags": ["security", "sast", "sca", "secrets", "semgrep", "trivy", "gitleaks", "remediation", "aikido"]
@@ -83,7 +83,7 @@
     {
       "name": "shipwright-compliance",
       "description": "IREB traceability, Requirements Traceability Matrix, SBOM, test evidence, and change history reports",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-compliance",
       "category": "development",
       "tags": ["compliance", "ireb", "traceability", "sbom", "rtm"]
@@ -91,7 +91,7 @@
     {
       "name": "shipwright-iterate",
       "description": "Lightweight SDLC for ongoing changes. Auto-detects intent (feature/change/bug) and runs specs → build → test → commit.",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-iterate",
       "category": "development",
       "tags": ["iterate", "change", "bug-fix", "continuous"]
@@ -99,7 +99,7 @@
     {
       "name": "shipwright-preview",
       "description": "Local browser preview — start dev server and show URL for in-browser testing",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-preview",
       "category": "development",
       "tags": ["preview", "dev-server", "browser", "local"]
@@ -107,7 +107,7 @@
     {
       "name": "shipwright-adopt",
       "description": "Onboard an existing (brownfield) repository into the Shipwright SDLC — analyze stack + routes + conventions, generate CLAUDE.md + agent_docs + configs + E2E baseline",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "source": "./plugins/shipwright-adopt",
       "category": "development",
       "tags": ["adoption", "onboarding", "brownfield", "legacy", "documentation"]

--- a/.shipwright/agent_docs/conventions.md
+++ b/.shipwright/agent_docs/conventions.md
@@ -263,3 +263,5 @@ Contribution rules, dev setup, the graduated trust model, and high-sensitivity a
 - **ADR-222** (2026-06-14): Hook fan-out deduped via once-per-event guard + session-state phase resolver
 - **ADR-227** (2026-06-16): Skip-aware compliance rendering + centralized intent normalization
 - **ADR-230** (2026-06-17): Unify all plugin/marketplace versions to 0.29.0; relabel Early Access Beta to Beta
+- **ADR-234** (2026-06-20): Dedup the aggregate_triage Stop regen across the plugin fan-out
+- **ADR-235** (2026-06-20): Dedup the bloat-gate Stop block across the plugin fan-out

--- a/.shipwright/agent_docs/decision_log.md
+++ b/.shipwright/agent_docs/decision_log.md
@@ -3095,3 +3095,68 @@ shipwright/
 - **Rationale:** One number everywhere ends the namespace drift and matches the curated-release-playbook (tag after merge); honest+inviting beta wording beats hard deterrence; gitignored Spec/ is never public so its links must go.
 - **Consequences:** sync_check version parity stays green; next release tags v0.29.0; public docs carry no dead links and one consistent Beta label.
 - **Rejected:** Per-plugin independent SemVer (drift is exactly what we fix); keep 'Early Access' (launch decision is plain Beta); scrub Leadwright/author provenance (companion project also going public).
+
+---
+
+### ADR-231: Corrupt bloat baseline fails the gate closed
+- **Date:** 2026-06-17
+- **Section:** Iterate — bug: anti-ratchet corrupt-baseline fail-closed
+- **Run-ID:** iterate-2026-06-17-anti-ratchet-corrupt-failclosed
+- **Context:** anti_ratchet_check.py returned exit 0 (fail-open) for a present-but-malformed shipwright_bloat_baseline.json, silently disabling the CI/pre-commit anti-ratchet gate so a real ratchet could pass.
+- **Decision:** Distinguish absent from corrupt at the CLI via is_file(): an absent baseline stays fail-open (fresh repo); a present-but-unreadable/malformed baseline fails closed (exit 1).
+- **Commit:** (assigned post-merge)
+- **Rationale:** A gate that silently disables itself on corruption is a false-green; a corrupt baseline signals tampering or a merge accident, not a fresh repo.
+- **Consequences:** A corrupted baseline now blocks instead of silently disabling the gate; absent stays fail-open. The separate Stop-hook bloat gate is intentionally left fail-open (advisory).
+- **Rejected:** Distinguish in the loader lib (larger vendored surface); fail-closed on absent too (breaks legitimate fresh-repo first run).
+
+---
+
+### ADR-232: Root pyproject.toml to 0.29.0; generalize OneDrive folder example in a source comment
+- **Date:** 2026-06-17
+- **Section:** Iterate — change: align root pyproject version + de-PII a source comment
+- **Run-ID:** iterate-2026-06-17-launch-polish
+- **Context:** Post-v0.29.0 launch polish: root pyproject.toml still read 0.5.0 while marketplace + all 13 plugin.json are 0.29.0 (ADR-230 lockstep); and one source comment (master_stop_check.py) used the maintainer's real OneDrive folder name as the spaces-in-path example.
+- **Decision:** Set root pyproject.toml version to 0.29.0 (extends ADR-230 one-number-everywhere to the root package metadata); replace the personal folder name in the master_stop_check.py comment with a neutral example ('Program Files' / 'a OneDrive-synced folder'), keeping the OneDrive compat guidance intact.
+- **Commit:** (assigned post-merge)
+- **Rationale:** Public-repo consistency + tidiness; pyproject is dev metadata (no PyPI consumer) so no re-tag needed. OneDrive guidance stays; only the identifying folder name is generalized.
+- **Consequences:** pyproject version matches everywhere; no personal folder name in active source; v0.29.0 tag unchanged (post-release dev-metadata polish, not a release artifact).
+- **Rejected:** Re-tag v0.29.0 to include the bump (never move a pushed tag); scrub the OneDrive example from historical CHANGELOG/ADRs (non-sensitive example + no-monorepo-history-rewrite policy).
+
+---
+
+### ADR-233: Truncated Tier-3 review fails closed
+- **Date:** 2026-06-17
+- **Section:** Iterate — bug: pr-review truncation fail-closed
+- **Run-ID:** iterate-2026-06-17-pr-review-truncation-failclosed
+- **Context:** pr_review.py returned EXIT_OK on a truncated (>200k char) diff, so a required PR-review gate passed green even on a block verdict — an untrusted PR could bypass review by size.
+- **Decision:** On truncation, force a request-changes state + EXIT_BLOCK (needs human); a maintainer overrides via the skip-pr-review label.
+- **Commit:** (assigned post-merge)
+- **Rationale:** For a required gate on untrusted PRs, auto-passing on partial info is a silent bypass; neither auto-block-on-partial nor auto-pass is right — require human.
+- **Consequences:** An oversized external/sensitive diff can no longer bypass the gate; the red required check surfaces the PR via the gh-pr-ci triage producer.
+- **Rejected:** Raise MAX_DIFF_CHARS only (still bypassable); honor-block-else-neutral (more complex, still trusts a partial verdict).
+
+---
+
+### ADR-234: Dedup the aggregate_triage Stop regen across the plugin fan-out
+- **Date:** 2026-06-20
+- **Section:** shared/scripts/hooks/aggregate_triage_on_stop.py
+- **Run-ID:** iterate-2026-06-20-aggregate-triage-stop-fanout-dedup
+- **Context:** aggregate_triage_on_stop regenerates the triage_inbox.md derived cache and is registered in all 12 plugins, so one Stop event fired it ~12×, each doing a redundant non-atomic write_text (a latent parallel-corruption window). Found auditing the other un-guarded Stop hooks after the bloat-gate fix.
+- **Decision:** Add event_once.claim_once_for_event(project_root, 'stop-triage-inbox', sid) after the is_shipwright_project no-op guard so one invocation regenerates per (Stop, session); serializing to one writer also closes the corruption window. A failed winner (exception or non-zero rc) releases the claim (event_claim_path.unlink) so a sibling/later stop retries.
+- **Commit:** (assigned post-merge)
+- **Rationale:** Reuses the bloat-gate dedup primitive + key shape. First-wins still observes settled triage: aggregate_triage runs after the producer audit_compliance_on_stop in every plugin Stop array. Release-on-failure is safe to retry because aggregate_triage's only non-zero rc path is pre-write.
+- **Consequences:** One Stop regenerates triage_inbox.md once, not 12×. 30s-TTL staleness is benign (derived cache; RTM + WebUI read triage.jsonl directly). audit_compliance_on_stop left as-is (its (sha,session) marker dedups under serial Stop execution; only a theoretical parallel race). docs/hooks-and-pipeline.md guarded-table updated; stale 'LAST Stop hook' docstring corrected.
+- **Rejected:** Make the write atomic instead (fixes corruption, keeps 11x redundant work). Per-stop-event discriminator key (unbounded .cache leak). Also guarding audit_compliance now (its marker already dedups under serial execution; kept single-concern).
+
+---
+
+### ADR-235: Dedup the bloat-gate Stop block across the plugin fan-out
+- **Date:** 2026-06-20
+- **Section:** shared/scripts/hooks/bloat_gate_on_stop.py
+- **Run-ID:** iterate-2026-06-20-bloat-gate-stop-fanout-dedup
+- **Context:** The bloat gate is registered in all 12 plugins, so one Stop event fires it 12x. PR #250 (hook-fanout-dedup) guarded audit/handoff/drift but listed bloat_gate_on_stop as 'already convergent' — wrong: its empty pass path is invisible, masking that the BLOCK path re-emits the full Iron-Law reason once per plugin (12 identical Stop blocks in webui session bfd244ca).
+- **Decision:** Add event_once.claim_once_for_event(root, 'stop-bloat', sid) on the block path ONLY, after every no-op/pass guard, so the first invocation to reach a real block wins and the other 11 emit the empty pass. The 30s-TTL (event,session) key re-arms a genuinely-later stop.
+- **Commit:** (assigned post-merge)
+- **Rationale:** Reuses the established PR #250 dedup primitive and key shape for consistency; placing the claim on the block edge (not the top) keeps the PR #250 ordering rule so no-op invocations never starve a real block.
+- **Consequences:** One Stop event now shows ONE bloat block, not 12. A re-stop within 30s on a still-oversize file is not re-blocked locally (a cleared file re-measures to pass before the claim; CI anti-ratchet is the authoritative gate; the TTL also damps the tight block-loop). docs/hooks-and-pipeline.md corrected.
+- **Rejected:** Per-stop-event discriminator (transcript UUID in the key) would avoid the 30s window but leaks one unbounded .cache claim per stop and diverges from the three sibling hooks; the local gate is an advisory nudge so the window is benign.

--- a/CHANGELOG-unreleased.d/Changed/iterate-2026-06-17-launch-polish_001.md
+++ b/CHANGELOG-unreleased.d/Changed/iterate-2026-06-17-launch-polish_001.md
@@ -1,1 +1,0 @@
-Aligned the root pyproject.toml version to 0.29.0 (completing the one-version-everywhere convention) and generalized a personal folder name in one source comment to a neutral example

--- a/CHANGELOG-unreleased.d/Changed/iterate-2026-06-20-aggregate-triage-stop-fanout-dedup_001.md
+++ b/CHANGELOG-unreleased.d/Changed/iterate-2026-06-20-aggregate-triage-stop-fanout-dedup_001.md
@@ -1,1 +1,0 @@
-The triage-inbox Stop hook now regenerates its derived cache once per stop instead of once per installed plugin (~12×), via a once-per-(stop,session) dedup guard; a failed regeneration releases the guard so another invocation retries.

--- a/CHANGELOG-unreleased.d/Fixed/iterate-2026-06-20-bloat-gate-stop-fanout-dedup_001.md
+++ b/CHANGELOG-unreleased.d/Fixed/iterate-2026-06-20-bloat-gate-stop-fanout-dedup_001.md
@@ -1,1 +1,0 @@
-Bloat-gate Stop hook no longer fires its block once per installed plugin — a single stop now shows ONE bloat-gate block instead of 12 identical ones, via a once-per-(stop,session) dedup guard on the block path.

--- a/CHANGELOG-unreleased.d/Security/iterate-2026-06-17-anti-ratchet-corrupt-failclosed_001.md
+++ b/CHANGELOG-unreleased.d/Security/iterate-2026-06-17-anti-ratchet-corrupt-failclosed_001.md
@@ -1,1 +1,0 @@
-Anti-ratchet gate now fails closed on a present-but-corrupt bloat baseline (was: fail-open), so a corrupted baseline can no longer silently disable the gate; an absent baseline still fails open

--- a/CHANGELOG-unreleased.d/Security/iterate-2026-06-17-pr-review-truncation-failclosed_001.md
+++ b/CHANGELOG-unreleased.d/Security/iterate-2026-06-17-pr-review-truncation-failclosed_001.md
@@ -1,1 +1,0 @@
-Tier-3 PR review now fails closed on a truncated diff (was: passed green), so an oversized diff can no longer bypass the required review gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.1] - 2026-06-22
+
+### Changed
+
+- Aligned the root pyproject.toml version to 0.29.0 (completing the one-version-everywhere convention) and generalized a personal folder name in one source comment to a neutral example
+- The triage-inbox Stop hook now regenerates its derived cache once per stop instead of once per installed plugin (~12×), via a once-per-(stop,session) dedup guard; a failed regeneration releases the guard so another invocation retries.
+
+### Fixed
+
+- Bloat-gate Stop hook no longer fires its block once per installed plugin — a single stop now shows ONE bloat-gate block instead of 12 identical ones, via a once-per-(stop,session) dedup guard on the block path.
+
+### Security
+
+- Anti-ratchet gate now fails closed on a present-but-corrupt bloat baseline (was: fail-open), so a corrupted baseline can no longer silently disable the gate; an absent baseline still fails open
+- Tier-3 PR review now fails closed on a truncated diff (was: passed green), so an oversized diff can no longer bypass the required review gate
+
 ## [0.29.0] - 2026-06-17
 
 ### Added

--- a/plugins/shipwright-adopt/.claude-plugin/plugin.json
+++ b/plugins/shipwright-adopt/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-adopt",
   "description": "Onboard an existing repository (brownfield) into the Shipwright SDLC — analyze codebase, generate docs, configs, compliance artifacts, and an E2E baseline",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-build/.claude-plugin/plugin.json
+++ b/plugins/shipwright-build/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-build",
   "description": "Implement code from /shipwright-plan sections with TDD, code review, Conventional Commits, and git workflow",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-changelog/.claude-plugin/plugin.json
+++ b/plugins/shipwright-changelog/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-changelog",
   "description": "Generate changelogs from Conventional Commits, create tags, and manage PRs",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-compliance/.claude-plugin/plugin.json
+++ b/plugins/shipwright-compliance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-compliance",
   "description": "Generate audit-ready compliance documentation from Shipwright pipeline data (RTM, test evidence, change history, SBOM)",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-deploy/.claude-plugin/plugin.json
+++ b/plugins/shipwright-deploy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-deploy",
   "description": "Deploy to configured targets with smoke testing and rollback — Jelastic as first flavor",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-design/.claude-plugin/plugin.json
+++ b/plugins/shipwright-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-design",
   "description": "Generate UI mockups from IREB specs — standalone HTML screens and user flows",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-iterate/.claude-plugin/plugin.json
+++ b/plugins/shipwright-iterate/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-iterate",
   "description": "Complexity-adaptive SDLC for ongoing changes. Auto-detects intent + complexity, scales from quick fix to structured feature with specs, plans, reviews, and testing.",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": { "name": "Sven Roth", "url": "https://github.com/svenroth-ai" },
   "repository": "https://github.com/svenroth-ai/shipwright",
   "license": "MIT",

--- a/plugins/shipwright-plan/.claude-plugin/plugin.json
+++ b/plugins/shipwright-plan/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-plan",
   "description": "AI-assisted deep planning with research, interview, external LLM review, and TDD approach",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-preview/.claude-plugin/plugin.json
+++ b/plugins/shipwright-preview/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-preview",
   "description": "Local browser preview for Shipwright projects — starts dev server and shows URL",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-project/.claude-plugin/plugin.json
+++ b/plugins/shipwright-project/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-project",
   "description": "Decompose project requirements into well-scoped planning units for /shipwright-plan",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-run/.claude-plugin/plugin.json
+++ b/plugins/shipwright-run/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-run",
   "description": "Orchestrate the full Shipwright SDLC pipeline — from user description to deployed application",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-security/.claude-plugin/plugin.json
+++ b/plugins/shipwright-security/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-security",
   "description": "Security scanning via Aikido API with automated remediation loop",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/plugins/shipwright-test/.claude-plugin/plugin.json
+++ b/plugins/shipwright-test/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "shipwright-test",
   "description": "Run unit tests, E2E tests, smoke tests, and security scans for Shipwright projects",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Sven Roth",
     "url": "https://github.com/svenroth-ai"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shipwright"
-version = "0.29.0"
+version = "0.29.1"
 description = "AI-powered SDLC framework built on Claude Code"
 requires-python = ">=3.11"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "shipwright"
-version = "0.29.0"
+version = "0.29.1"
 source = { virtual = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Release v0.29.1

Pre-public-launch release. Patch bump (Conventional Commits): only
fix / security-hardening / refactor / docs since `v0.29.0` — no new features.

### Changelog (`[0.29.1] - 2026-06-22`)

**Changed**
- Triage-inbox Stop hook regenerates its derived cache once per stop instead of once per installed plugin (~12×), with a once-per-(stop,session) dedup guard that releases on failed regeneration.
- Aligned the root `pyproject.toml` version to the one-version-everywhere convention.

**Fixed**
- Bloat-gate Stop hook no longer fires its block once per installed plugin — one stop now shows ONE block instead of 12.

**Security**
- Anti-ratchet gate fails closed on a present-but-corrupt bloat baseline (was: fail-open).
- Tier-3 PR review fails closed on a truncated diff (was: passed green).

### Version bump (ADR-230 one-version-everywhere, lockstep)
- `marketplace.json` top-level + all 13 plugin entries → `0.29.1`
- all 13 `plugins/*/.claude-plugin/plugin.json` → `0.29.1`
- root `pyproject.toml` + `uv.lock` → `0.29.1`

`sync_check` version parity green; per-plugin `pyproject.toml`, `package-lock.json`, and historical docs intentionally untouched.

### Decisions
- ADR-231…ADR-235 aggregated into `decision_log.md` with Run-ID traceability.

### Release flow
Curated-release-playbook: release branch → PR → **merge → tag `v0.29.1` after merge** (matches `check_changelog_version_matches_tag`). The tag is applied to the merged commit on the default branch once Required Checks are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
