### PR TITLE
chore(release): complete v0.31.0 version lock (root pyproject slot)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shipwright"
-version = "0.30.0"
+version = "0.31.0"
 description = "AI-powered SDLC framework built on Claude Code"
 requires-python = ">=3.11"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ wheels = [
 
 [[package]]
 name = "shipwright"
-version = "0.30.0"
+version = "0.31.0"
 source = { virtual = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
Follow-up to #364. The v0.31.0 release bumped marketplace.json (top-level + 14
plugin entries) and all 14 `plugin.json`, but missed the **root project version
slot** — `pyproject.toml` and the `shipwright` root entry in `uv.lock` stayed at
`0.30.0`.

This completes the 30-slot version lock so all release-locked versions read
`0.31.0`. Without it, the next release's scoped `0.31.0 → next` bump would skip
the root slot and strand it.

- `pyproject.toml`: `version = "0.31.0"`
- `uv.lock`: shipwright root package `version = "0.31.0"` (via `uv lock`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
