### PR TITLE
fix(deps): bump pyasn1 0.6.3 -> 0.6.4 (CVE-2026-59885, CVE-2026-59886)

### DIFF
--- a/plugins/shipwright-plan/uv.lock
+++ b/plugins/shipwright-plan/uv.lock
@@ -484,11 +484,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the two open high-severity GitHub code-scanning alerts (#1276, #1277).

## Verdict: genuine finding, not a false positive

Trivy flagged `pyasn1 0.6.3` in `plugins/shipwright-plan/uv.lock`. Both CVEs are real and independently confirmed against OSV.dev:

| CVE | Advisory | Issue |
|---|---|---|
| CVE-2026-59885 | GHSA-8ppf-4f7h-5ppj | Quadratic complexity in OBJECT IDENTIFIER / RELATIVE-OID processing → DoS (CWE-400/770) |
| CVE-2026-59886 | GHSA-hm4w-wwcw-mr6r | Uncontrolled resource consumption converting decoded REAL values → DoS (CWE-400/770) |

Both affect `<0.6.4`, published 2026-07-21. OSV reports **zero** advisories for 0.6.4.

OSV additionally lists a third advisory against 0.6.3 that Trivy did not surface — CVE-2026-59884. This bump closes that one as well.

## Why bump rather than risk-accept

The dependency is transitive at depth 4:

```
shipwright-plan -> google-genai -> google-auth -> pyasn1-modules -> pyasn1
```

Real-world exposure is negligible: `google-auth` only reaches `pyasn1` when parsing service-account / X.509 ASN.1 credentials, and the external-review path authenticates with an API key, so that code path is never entered. Both CVEs are also DoS classes in a local dev CLI, not a network-facing service.

That said, the remediation is a lockfile-only change with no source impact, so a risk-accept entry would be more overhead than the fix itself.

## Change

`plugins/shipwright-plan/uv.lock` only — 3 lines, version + sdist/wheel hashes. No other package resolved differently.

## Verification

- `uv lock --upgrade-package pyasn1` — resolved 36 packages, only pyasn1 changed
- `uv sync` — clean
- `python -c "from google import genai"` — external-review import path OK, `pyasn1 0.6.4` active
- `uv run --extra dev pytest tests/ -q` — **57 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
