### PR TITLE
feat(shared): one reader for the accepted-baseline failures list (FR-01.06)

### DIFF
--- a/CHANGELOG-unreleased.d/Changed/iterate-2026-07-27-test-phase-record-honesty_001.md
+++ b/CHANGELOG-unreleased.d/Changed/iterate-2026-07-27-test-phase-record-honesty_001.md
@@ -1,0 +1,1 @@
+`/shipwright-test` reads the same accepted-baseline list (`shipwright_known_failures.json`) the audit phase reads, through one shared reader, and reports known-and-accepted failures separately from genuine ones. An onboarded project no longer reports a permanently red run while the audit calls the same run fine.

--- a/plugins/shipwright-compliance/scripts/lib/collectors/test_evidence.py
+++ b/plugins/shipwright-compliance/scripts/lib/collectors/test_evidence.py
@@ -12,9 +12,19 @@ Iterate Campaign B (B2): split out of ``data_collector.py``.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 from ._types import KnownFailure, TestResults
+
+# The accepted-baseline parser is shared with the test phase. It lives at
+# ``shared/scripts/`` top level (NOT under a ``lib/`` package) so importing it
+# cannot shadow a plugin's own ``scripts/lib`` namespace — ADR-045.
+_SHARED_SCRIPTS = Path(__file__).resolve().parents[5] / "shared" / "scripts"
+if str(_SHARED_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SHARED_SCRIPTS))
+
+from known_failures import load_accepted_baseline as _load_accepted_baseline  # noqa: E402
 
 
 def _parse_test_results_file(path: Path) -> TestResults | None:
@@ -159,24 +169,24 @@ def collect_known_failures(project_root: Path) -> tuple[list[KnownFailure], int]
     """Load known failures from shipwright_known_failures.json.
 
     Returns (failures_list, baseline_failure_count).
-    """
-    path = project_root / "shipwright_known_failures.json"
-    if not path.exists():
-        return [], 0
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return [], 0
 
+    **Delegates** to ``shared/scripts/known_failures.py``. The audit used to own
+    the only parse of this file, which is how the test phase ended up not
+    knowing it existed — one component excusing an onboarded project's inherited
+    failures while the other reported them as fresh. Both now read through one
+    parser (iterate-2026-07-27-test-phase-record-honesty, FR-01.06). Signature,
+    return types and every observable answer are unchanged; only the ownership
+    of the parse moved.
+    """
+    baseline = _load_accepted_baseline(project_root)
     failures = [
         KnownFailure(
-            test=f.get("test", ""),
-            description=f.get("description", ""),
-            ticket=f.get("ticket", ""),
-            added=f.get("added", ""),
-            count=f.get("count", 1),
+            test=e.test,
+            description=e.description,
+            ticket=e.ticket,
+            added=e.added,
+            count=e.count,
         )
-        for f in data.get("known_failures", [])
+        for e in baseline.entries
     ]
-    baseline = data.get("baseline_failure_count", sum(f.count for f in failures))
-    return failures, baseline
+    return failures, baseline.baseline_failure_count

--- a/plugins/shipwright-compliance/scripts/lib/compliance_report.py
+++ b/plugins/shipwright-compliance/scripts/lib/compliance_report.py
@@ -39,14 +39,13 @@ _COPYLEFT_LICENSES = {"GPL", "LGPL", "AGPL", "MPL-2.0", "GPL-2.0", "GPL-3.0", "A
 def _is_adopted(run_config: dict) -> bool:
     """True when the project was onboarded via /shipwright-adopt.
 
-    The empirically correct signal is the presence of the `adoption`
-    object (carrying `adopted_at`, `commit_at_adoption`, ...). The
-    artifact-polish plan originally suggested checking `scope`, but
-    `scope` carries values like `"library"` / `"full_app"` — orthogonal
-    to adoption status (Iterate B.1, 2026-05-21).
+    Delegates to `project_facts`, which owns the signal and its rationale —
+    the test phase routes journey-coverage gaps on the same fact, and one fact
+    answered two ways is how components end up disagreeing about a project.
     """
-    adoption = run_config.get("adoption")
-    return isinstance(adoption, dict) and bool(adoption)
+    from project_facts import is_adopted_run_config  # noqa: PLC0415
+
+    return is_adopted_run_config(run_config)
 
 
 _SIGNAL_SEVERITIES = frozenset({"critical", "high", "medium", "low"})

--- a/plugins/shipwright-compliance/tests/test_known_failures_delegation.py
+++ b/plugins/shipwright-compliance/tests/test_known_failures_delegation.py
@@ -1,0 +1,108 @@
+"""The audit collector delegates the accepted-baseline read; behaviour is unchanged.
+
+``collect_known_failures`` used to own the only parse of
+``shipwright_known_failures.json``. The test phase now reads the same list, so
+the parse moved to ``shared/scripts/known_failures.py`` and this collector
+became a thin adapter over it.
+
+The point of the move is that the two components cannot hold different truths
+about one run — which only holds if the audit's observable behaviour did not
+shift when it started delegating. These tests pin exactly that: signature,
+return types, and the answer for present / absent / malformed / partial input.
+
+iterate-2026-07-27-test-phase-record-honesty, FR-01.06.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.lib.collectors import collect_known_failures
+from scripts.lib.collectors._types import KnownFailure
+
+
+def _write(project: Path, payload: object) -> None:
+    (project / "shipwright_known_failures.json").write_text(
+        json.dumps(payload), encoding="utf-8")
+
+
+@pytest.mark.covers("FR-01.06")
+def test_absent_file_still_yields_empty_list_and_zero_baseline(tmp_path: Path):
+    assert collect_known_failures(tmp_path) == ([], 0)
+
+
+@pytest.mark.covers("FR-01.06")
+def test_malformed_file_still_yields_empty_list_and_zero_baseline(tmp_path: Path):
+    (tmp_path / "shipwright_known_failures.json").write_text("{nope", encoding="utf-8")
+    assert collect_known_failures(tmp_path) == ([], 0)
+
+
+@pytest.mark.covers("FR-01.06")
+def test_entries_are_returned_as_KnownFailure_with_the_same_fields(tmp_path: Path):
+    _write(tmp_path, {"known_failures": [
+        {
+            "test": "tests/test_legacy.py::test_old",
+            "description": "predates adoption",
+            "ticket": "LEG-1",
+            "added": "2026-01-01",
+            "count": 2,
+        },
+    ]})
+    failures, baseline = collect_known_failures(tmp_path)
+
+    assert baseline == 2
+    assert len(failures) == 1
+    entry = failures[0]
+    # The dataclass identity matters — the RTM and dashboard render these.
+    assert isinstance(entry, KnownFailure)
+    assert entry.test == "tests/test_legacy.py::test_old"
+    assert entry.description == "predates adoption"
+    assert entry.ticket == "LEG-1"
+    assert entry.added == "2026-01-01"
+    assert entry.count == 2
+
+
+@pytest.mark.covers("FR-01.06")
+def test_missing_optional_fields_default_exactly_as_before(tmp_path: Path):
+    _write(tmp_path, {"known_failures": [{"test": "a"}]})
+    failures, baseline = collect_known_failures(tmp_path)
+
+    assert baseline == 1
+    assert (failures[0].description, failures[0].ticket, failures[0].added) == ("", "", "")
+    assert failures[0].count == 1
+
+
+@pytest.mark.covers("FR-01.06")
+def test_explicit_baseline_count_still_wins(tmp_path: Path):
+    _write(tmp_path, {"known_failures": [{"test": "a"}], "baseline_failure_count": 5})
+    assert collect_known_failures(tmp_path)[1] == 5
+
+
+@pytest.mark.covers("FR-01.06")
+def test_empty_known_failures_list_is_a_present_but_empty_baseline(tmp_path: Path):
+    _write(tmp_path, {"known_failures": []})
+    assert collect_known_failures(tmp_path) == ([], 0)
+
+
+@pytest.mark.covers("FR-01.06")
+def test_the_audit_and_the_test_phase_read_one_parser(tmp_path: Path):
+    """AC5 — the same file, read once, giving both sides the same answer."""
+    import sys
+
+    shared_scripts = Path(__file__).resolve().parents[3] / "shared" / "scripts"
+    if str(shared_scripts) not in sys.path:
+        sys.path.insert(0, str(shared_scripts))
+    from known_failures import load_accepted_baseline
+
+    _write(tmp_path, {"known_failures": [
+        {"test": "test_a", "count": 2}, {"test": "test_b"},
+    ]})
+
+    audit_failures, audit_baseline = collect_known_failures(tmp_path)
+    shared_view = load_accepted_baseline(tmp_path)
+
+    assert audit_baseline == shared_view.baseline_failure_count == 3
+    assert [f.test for f in audit_failures] == [e.test for e in shared_view.entries]

--- a/shared/scripts/known_failures.py
+++ b/shared/scripts/known_failures.py
@@ -1,0 +1,236 @@
+"""The one reader for ``shipwright_known_failures.json``.
+
+The file is a hand-maintained declaration: *these failures predate onboarding
+and are accepted, do not count them as new regressions.*
+
+It used to be read by exactly one component — the compliance audit — so an
+onboarded project got its inherited failures excused by the audit and reported
+as fresh failures by the test phase. Two components, two truths about one run,
+and a permanently red test phase that teaches the operator to ignore red.
+
+This module is that single reader. Both the audit collector
+(``collectors/test_evidence.collect_known_failures``) and the test phase read
+through it, so the two cannot drift.
+
+Lives at ``shared/scripts/`` top level, stdlib-only, per ADR-045 — see
+``project_facts`` for the same reasoning.
+
+Two distinct questions, deliberately kept apart:
+
+* **Which of these named failures are accepted?** — :func:`split_accepted`,
+  matching by identity. This is the one that can honestly say "this failure is
+  known".
+* **Is this run's failure count within the declared allowance?** —
+  :func:`within_baseline`, pure arithmetic mirroring the audit's rule. It is an
+  *aggregate allowance* and says nothing about which failures those were.
+
+A caller that only has counts must report the second as an allowance, never
+dress it up as the first.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+KNOWN_FAILURES_NAME = "shipwright_known_failures.json"
+
+# A declared id shorter than this is not used for substring matching — a
+# one- or two-character entry would swallow unrelated failures. Such an entry
+# still counts toward the aggregate baseline; it just cannot claim an identity.
+_MIN_SUBSTRING_MATCH = 4
+
+
+@dataclass(frozen=True)
+class AcceptedFailure:
+    """One declared entry of ``known_failures``."""
+
+    test: str
+    description: str = ""
+    ticket: str = ""
+    added: str = ""
+    count: int = 1
+
+
+@dataclass(frozen=True)
+class AcceptedBaseline:
+    """The declared list, plus how it was read.
+
+    ``present`` / ``malformed`` exist so a caller can say *"the accepted list
+    could not be read"* instead of silently reporting "nothing is accepted" —
+    the same failure mode this module exists to remove.
+    """
+
+    entries: tuple[AcceptedFailure, ...] = ()
+    baseline_failure_count: int = 0
+    present: bool = False
+    malformed: bool = False
+
+
+def _coerce_entry(raw: object) -> AcceptedFailure | None:
+    if not isinstance(raw, dict):
+        return None
+    test = raw.get("test")
+    if not isinstance(test, str) or not test.strip():
+        return None
+    count = raw.get("count", 1)
+    if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        count = 1
+    return AcceptedFailure(
+        test=test,
+        description=raw.get("description", "") if isinstance(raw.get("description"), str) else "",
+        ticket=raw.get("ticket", "") if isinstance(raw.get("ticket"), str) else "",
+        added=raw.get("added", "") if isinstance(raw.get("added"), str) else "",
+        count=count,
+    )
+
+
+def load_accepted_baseline(project_root: Path | str) -> AcceptedBaseline:
+    """Read the declared accepted-failure list.
+
+    Absent file → an empty baseline (``present=False``). Present but
+    unreadable → ``malformed=True`` with the same zero-baseline result, so a
+    corrupt file can never *widen* what is excused.
+    """
+    path = Path(project_root) / KNOWN_FAILURES_NAME
+    if not path.exists():
+        return AcceptedBaseline()
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return AcceptedBaseline(present=True, malformed=True)
+
+    if not isinstance(data, dict):
+        return AcceptedBaseline(present=True, malformed=True)
+
+    raw_entries = data.get("known_failures", [])
+    if not isinstance(raw_entries, list):
+        return AcceptedBaseline(present=True, malformed=True)
+
+    entries = tuple(e for e in (_coerce_entry(r) for r in raw_entries) if e is not None)
+
+    declared = data.get("baseline_failure_count")
+    if isinstance(declared, int) and not isinstance(declared, bool) and declared >= 0:
+        count = declared
+    else:
+        count = sum(e.count for e in entries)
+
+    return AcceptedBaseline(
+        entries=entries, baseline_failure_count=count, present=True, malformed=False,
+    )
+
+
+def split_accepted(
+    failure_names: list[str] | tuple[str, ...],
+    baseline: AcceptedBaseline,
+) -> tuple[list[str], list[str]]:
+    """Split reported failures into ``(known_and_accepted, genuine)`` by identity.
+
+    A reported failure is accepted when a declared entry's ``test`` is equal to
+    it, or is contained in it (reported names usually carry a suite/file prefix
+    the declaration omits). Short declared ids do not substring-match — see
+    ``_MIN_SUBSTRING_MATCH``.
+
+    A declared failure that did **not** fire this run excuses nothing: matching
+    runs from the reported side, so an unrelated new failure stays genuine even
+    when the declared count would have covered it.
+    """
+    declared = [e.test for e in baseline.entries]
+    accepted: list[str] = []
+    genuine: list[str] = []
+
+    for name in failure_names:
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if any(
+            d == name or (len(d) >= _MIN_SUBSTRING_MATCH and d in name)
+            for d in declared
+        ):
+            accepted.append(name)
+        else:
+            genuine.append(name)
+
+    return accepted, genuine
+
+
+def within_baseline(passed: int, total: int, baseline_count: int) -> bool:
+    """True when the passed/total gap is covered by the declared allowance.
+
+    Verbatim mirror of the audit's rule (``rtm_generator``: ``gap <= 0`` →
+    covered; ``baseline > 0 and gap <= baseline`` → ``COVERED (baseline)``). A
+    different rule here would re-open the divergence this module closes.
+
+    This is an **aggregate allowance**. It does not identify which failures
+    were accepted — use :func:`split_accepted` when identities are available.
+    """
+    gap = total - passed
+    if gap <= 0:
+        return True
+    return baseline_count > 0 and gap <= baseline_count
+
+
+def has_exact_failure_count(failed: object = None, skipped: object = None) -> bool:
+    """True when the layer reported enough to know the failure count exactly.
+
+    Either an explicit ``failed``, or an explicit ``skipped`` (which makes the
+    residual ``total - passed - skipped`` exact). Without either, all we have is
+    a gap that may be failures or skips.
+
+    This is the switch on the aggregate baseline allowance, and it mirrors the
+    audit's deliberate rule (``tests_block.progression_result`` + its pinning
+    test ``test_explicit_residual_ignores_baseline_charity``): *an explicit
+    residual is exact, so the baseline exemption must NOT apply to it.* The
+    exemption is charity for an unbroken-down gap, not a licence to wave away
+    failures somebody actually counted. Where the count is exact, acceptance is
+    decided per failure by :func:`split_accepted`, not by arithmetic.
+    """
+    exact_failed = isinstance(failed, int) and not isinstance(failed, bool) and failed >= 0
+    exact_skipped = isinstance(skipped, int) and not isinstance(skipped, bool) and skipped >= 0
+    return exact_failed or exact_skipped
+
+
+def genuine_failure_count(
+    *,
+    passed: int,
+    total: int,
+    failed: int | None = None,
+    skipped: int | None = None,
+) -> int:
+    """How many tests genuinely failed, using the best signal available.
+
+    Prefers an explicit ``failed`` count; falls back to ``total - passed -
+    skipped``; falls back again to the bare gap. The fallbacks matter because
+    ``total - passed`` counts *skipped* tests as failures — which would make a
+    fully green run with host-gated skips consume accepted-failure allowance.
+    Never negative.
+
+    **Deliberately the same arithmetic as the audit's**
+    ``tests_block.progression_result`` (the skip-vs-fail SSoT introduced when
+    skipped tests became a first-class field): explicit skip count → genuine
+    failures are ``total - passed - skipped``; no explicit count → the gap is
+    read charitably. That module renders a *cell*, this one returns a *number*,
+    so neither can call the other — the agreement is pinned by
+    ``shared/tests/test_known_failures_audit_parity.py`` instead. Changing one
+    without the other re-opens exactly the divergence this module exists to
+    close.
+    """
+    if isinstance(failed, int) and not isinstance(failed, bool) and failed >= 0:
+        return failed
+    gap = total - passed
+    if isinstance(skipped, int) and not isinstance(skipped, bool) and skipped >= 0:
+        gap -= skipped
+    return max(0, gap)
+
+
+__all__ = [
+    "KNOWN_FAILURES_NAME",
+    "AcceptedBaseline",
+    "AcceptedFailure",
+    "genuine_failure_count",
+    "has_exact_failure_count",
+    "load_accepted_baseline",
+    "split_accepted",
+    "within_baseline",
+]

--- a/shared/scripts/project_facts.py
+++ b/shared/scripts/project_facts.py
@@ -1,0 +1,60 @@
+"""Facts derived from ``shipwright_run_config.json``, read by more than one plugin.
+
+Kept deliberately small and stdlib-only. Lives at ``shared/scripts/`` top level
+(the ``triage.py`` precedent) rather than ``shared/scripts/lib/`` — ADR-045:
+a shared module inside a ``lib/`` namespace shadows a plugin's own
+``scripts/lib/`` when the plugin puts ``shared/scripts`` on ``sys.path``, which
+turns into a green local run and a red CI one.
+
+Currently one fact: **was this project onboarded from an existing codebase?**
+That answer routes decisions in two places already (the compliance dashboard's
+adopted-project rendering, and the test phase's greenfield-blocks /
+brownfield-files-a-follow-up split), so it gets one definition rather than two.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+RUN_CONFIG_NAME = "shipwright_run_config.json"
+
+
+def read_run_config(project_root: Path | str) -> dict:
+    """Return the parsed run config, or ``{}`` when absent / unreadable.
+
+    Tolerant by design: every caller here is answering "which flavour of
+    project is this?", and a missing or corrupt config must degrade to the
+    conservative answer, never raise into a phase.
+    """
+    path = Path(project_root) / RUN_CONFIG_NAME
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def is_adopted_run_config(run_config: dict) -> bool:
+    """True when this run config describes a project onboarded via /shipwright-adopt.
+
+    The signal is the presence of a non-empty ``adoption`` object (carrying
+    ``adopted_at``, ``commit_at_adoption``, ...). Chosen empirically in
+    Iterate B.1 (2026-05-21) over ``scope``, which carries ``"library"`` /
+    ``"full_app"`` — orthogonal to adoption status.
+    """
+    adoption = run_config.get("adoption")
+    return isinstance(adoption, dict) and bool(adoption)
+
+
+def is_adopted_project(project_root: Path | str) -> bool:
+    """``is_adopted_run_config`` over the project's config on disk."""
+    return is_adopted_run_config(read_run_config(project_root))
+
+
+__all__ = [
+    "RUN_CONFIG_NAME",
+    "is_adopted_project",
+    "is_adopted_run_config",
+    "read_run_config",
+]

--- a/shared/scripts/shared_lib_loader.py
+++ b/shared/scripts/shared_lib_loader.py
@@ -1,0 +1,58 @@
+"""Importing ``shared/scripts/lib/*`` from a module that lives outside ``lib/``.
+
+ADR-045 keeps cross-plugin helpers (``triage.py``, ``known_failures.py``, …) at
+``shared/scripts/`` top level, because every plugin carries its own
+``scripts/lib`` package and an eager ``from lib.X import …`` would bind
+``sys.modules['lib']`` to whichever one got there first.
+
+Importing them **lazily** was the accepted mitigation, and it is not enough: if
+a plugin's test session has ALREADY imported its own ``lib.*``, the lazy import
+still resolves against that package and raises ``ModuleNotFoundError`` on a
+sibling that only exists under ``shared``. Latent for a long time because every
+triage producer emitted from a subprocess; surfaced by the first in-process one
+(iterate-2026-07-27-test-phase-record-honesty).
+
+:func:`load_shared_lib` tries the normal package import first — unchanged in the
+common case — and falls back to loading the file directly under a private module
+name that touches no ``lib`` namespace at all.
+
+**Only safe for lib modules with no intra-package imports.** A module that does
+``from lib.sibling import …`` would still resolve that sibling against the
+shadowing package, so the fallback must not be used for it.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent  # shared/scripts
+
+
+def load_shared_lib(module_name: str):
+    """Return ``shared/scripts/lib/<module_name>``, shadowing-proof."""
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    try:
+        return importlib.import_module(f"lib.{module_name}")
+    except ImportError:
+        pass
+
+    private_name = f"_shipwright_shared_lib_{module_name}"
+    cached = sys.modules.get(private_name)
+    if cached is not None:
+        return cached
+
+    path = _SCRIPTS_DIR / "lib" / f"{module_name}.py"
+    spec = importlib.util.spec_from_file_location(private_name, path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError(f"cannot load shared lib module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[private_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+__all__ = ["load_shared_lib"]

--- a/shared/scripts/tools/verifiers/test_checks.py
+++ b/shared/scripts/tools/verifiers/test_checks.py
@@ -22,7 +22,22 @@ from ``common.py``.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+
+# The accepted-baseline reader is shared with the compliance audit. It lives at
+# ``shared/scripts/`` top level (not under a ``lib/`` package) so importing it
+# can never shadow a plugin's own ``scripts/lib`` namespace — ADR-045.
+_SHARED_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SHARED_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SHARED_SCRIPTS))
+
+from known_failures import (  # noqa: E402
+    KNOWN_FAILURES_NAME,
+    genuine_failure_count,
+    has_exact_failure_count,
+    load_accepted_baseline,
+)
 
 from .common import (
     CheckResult,
@@ -45,6 +60,16 @@ def check_test_results_file_fresh(project_root: Path) -> CheckResult:
     """``shipwright_test_results.json`` must exist and have a populated
     ``unit`` layer. The other layers (integration / e2e / smoke) are
     optional per profile, but unit is always expected.
+
+    Reads the same accepted-baseline list the audit phase reads
+    (``shipwright_known_failures.json``), so an onboarded project's inherited
+    failures are not reported here as a failing run while the audit reports the
+    same run as within baseline
+    (iterate-2026-07-27-test-phase-record-honesty, FR-01.06).
+
+    The baseline is an **aggregate allowance** — it says how many failures were
+    declared, not which. The detail line says so rather than claiming these
+    particular failures are the accepted ones.
     """
     name = "test_results unit layer populated"
     path = project_root / "shipwright_test_results.json"
@@ -62,13 +87,56 @@ def check_test_results_file_fresh(project_root: Path) -> CheckResult:
             f"unit.total={total}, expected >0 (were unit tests executed?)",
         )
     passed = unit.get("passed", 0)
-    if not isinstance(passed, int) or passed < total:
+    if not isinstance(passed, int):
+        passed = 0
+
+    # A skipped test is not a failure. Prefer the layer's own `failed` count;
+    # fall back to the gap minus skips; fall back again to the bare gap.
+    exact = has_exact_failure_count(unit.get("failed"), unit.get("skipped"))
+    failures = genuine_failure_count(
+        passed=passed,
+        total=total,
+        failed=unit.get("failed"),
+        skipped=unit.get("skipped"),
+    )
+    if failures <= 0:
+        return CheckResult(name, True, f"unit {passed}/{total} passed")
+
+    baseline = load_accepted_baseline(project_root)
+    declared = baseline.baseline_failure_count
+    unreadable = " — accepted-failure list unreadable" if baseline.malformed else ""
+
+    # The aggregate allowance is charity for an un-broken-down gap only. Where
+    # the layer counted its failures exactly, the allowance does not apply —
+    # the audit made that call deliberately (`tests_block.progression_result`,
+    # pinned by `test_explicit_residual_ignores_baseline_charity`), and the two
+    # must agree. Acceptance of an exactly-counted failure is decided per
+    # failure by identity in the phase report, not by arithmetic here.
+    if not exact and declared > 0 and failures <= declared:
         return CheckResult(
-            name, False,
-            f"unit.passed={passed}/{total} (tests failing)",
-            severity=Severity.WARNING.value,
+            name, True,
+            f"unit {passed}/{total} passed; gap of {failures} within the "
+            f"declared baseline of {declared} ({KNOWN_FAILURES_NAME}) — an "
+            f"aggregate allowance over an un-broken-down gap, not a per-failure "
+            f"acceptance",
         )
-    return CheckResult(name, True, f"unit {passed}/{total} passed")
+
+    if declared > 0:
+        detail = (
+            f"unit.passed={passed}/{total}: {failures} failing, "
+            f"{declared} declared in the baseline"
+        )
+        if exact:
+            detail += (
+                " — an exactly-counted failure is not waived by a count; "
+                "report which of them are known-and-accepted by name"
+            )
+        else:
+            detail += f", {failures - declared} beyond it"
+    else:
+        detail = f"unit.passed={passed}/{total} ({failures} tests failing){unreadable}"
+
+    return CheckResult(name, False, detail, severity=Severity.WARNING.value)
 
 
 # ---------------------------------------------------------------------------

--- a/shared/scripts/triage.py
+++ b/shared/scripts/triage.py
@@ -40,39 +40,27 @@ from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
-# Cross-platform append-log mutex, extracted to lib/file_lock.py
-# (iterate-2026-06-13-shc-file-lock). Imported LAZILY (never at module top): an
-# eager `from lib.file_lock import ...` would bind sys.modules['lib'] to
-# shared/scripts/lib, and triage.py deliberately lives OUTSIDE lib/ per ADR-045
-# so it stays importable from plugins/*/{tests,scripts} (which each carry their
-# own `lib` package) without that collision. `_load_file_lock_cls()` mirrors the
-# lazy worktree_isolation import below; the PEP 562 `__getattr__` keeps
-# `triage._FileLock` and `from triage import _FileLock` resolving for external
+from shared_lib_loader import load_shared_lib
+
+# Cross-platform append-log mutex + the record-boundary / header leaves live under
+# lib/, but triage.py deliberately lives OUTSIDE lib/ per ADR-045 so it stays
+# importable from plugins/*/{tests,scripts} (which each carry their own `lib`
+# package). `shared_lib_loader.load_shared_lib` owns that import — including the
+# path-based fallback for the case where a plugin's `lib` is already cached. The
+# PEP 562 `__getattr__` below keeps `triage._FileLock` resolving for external
 # consumers (sweep_outbox, triage_gc, reconcile_triage).
 def _load_file_lock_cls():
-    scripts_dir = str(Path(__file__).resolve().parent)  # shared/scripts
-    if scripts_dir not in sys.path:
-        sys.path.insert(0, scripts_dir)
-    from lib.file_lock import FileLock  # noqa: PLC0415
-    return FileLock
+    return load_shared_lib("file_lock").FileLock
 
 
 def _load_jsonl_records():
     """Lazy `lib.jsonl_records` (record-boundary SSoT) — ADR-045 constraint above."""
-    scripts_dir = str(Path(__file__).resolve().parent)  # shared/scripts
-    if scripts_dir not in sys.path:
-        sys.path.insert(0, scripts_dir)
-    from lib import jsonl_records  # noqa: PLC0415
-    return jsonl_records
+    return load_shared_lib("jsonl_records")
 
 
 def _load_triage_header():
     """Lazy `lib.triage_header` — same ADR-045 constraint as above."""
-    scripts_dir = str(Path(__file__).resolve().parent)  # shared/scripts
-    if scripts_dir not in sys.path:
-        sys.path.insert(0, scripts_dir)
-    from lib import triage_header  # noqa: PLC0415
-    return triage_header
+    return load_shared_lib("triage_header")
 
 
 def __getattr__(name):  # PEP 562 — lazy `triage._FileLock`, no eager lib import
@@ -112,6 +100,10 @@ KNOWN_SOURCES = (
     "f0.5",
     "drift",
     "github",
+    # Test-phase producers — the non-blocking layers that used to leave nothing
+    # behind once the session ended (iterate-2026-07-27-test-phase-record-honesty).
+    "test-warning",
+    "journey-coverage",
 )
 
 SEVERITY_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}

--- a/shared/tests/test_known_failures.py
+++ b/shared/tests/test_known_failures.py
@@ -1,0 +1,269 @@
+"""Tests for the shared accepted-baseline-failures reader.
+
+``shipwright_known_failures.json`` used to be read by exactly one component
+(the compliance audit). The test phase read nothing, so an onboarded project's
+inherited failures were excused by one component and reported as fresh failures
+by the other — two truths about one run.
+
+These pin the ONE reader both now use
+(iterate-2026-07-27-test-phase-record-honesty, FR-01.06).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from known_failures import (  # noqa: E402
+    AcceptedBaseline,
+    genuine_failure_count,
+    load_accepted_baseline,
+    split_accepted,
+    within_baseline,
+)
+from project_facts import is_adopted_project  # noqa: E402
+
+
+def _write(project: Path, payload) -> Path:
+    path = project / "shipwright_known_failures.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# load_accepted_baseline — the tolerant read
+# ---------------------------------------------------------------------------
+
+@pytest.mark.covers("FR-01.06")
+def test_absent_file_is_an_empty_baseline_not_an_error(tmp_path):
+    baseline = load_accepted_baseline(tmp_path)
+    assert baseline.present is False
+    assert baseline.malformed is False
+    assert baseline.entries == ()
+    assert baseline.baseline_failure_count == 0
+
+
+@pytest.mark.covers("FR-01.06")
+def test_declared_entries_are_read_with_their_metadata(tmp_path):
+    _write(tmp_path, {
+        "known_failures": [
+            {
+                "test": "tests/test_legacy.py::test_old",
+                "description": "predates onboarding",
+                "ticket": "LEG-1",
+                "added": "2026-01-01",
+                "count": 2,
+            },
+            {"test": "tests/test_other.py::test_x"},
+        ],
+    })
+    baseline = load_accepted_baseline(tmp_path)
+
+    assert baseline.present is True
+    assert [e.test for e in baseline.entries] == [
+        "tests/test_legacy.py::test_old", "tests/test_other.py::test_x",
+    ]
+    assert baseline.entries[0].ticket == "LEG-1"
+    # count defaults to 1 when the entry omits it
+    assert baseline.entries[1].count == 1
+    # derived from the entries when not stated explicitly
+    assert baseline.baseline_failure_count == 3
+
+
+@pytest.mark.covers("FR-01.06")
+def test_explicit_baseline_count_wins_over_the_derived_sum(tmp_path):
+    _write(tmp_path, {
+        "known_failures": [{"test": "a", "count": 1}],
+        "baseline_failure_count": 7,
+    })
+    assert load_accepted_baseline(tmp_path).baseline_failure_count == 7
+
+
+@pytest.mark.covers("FR-01.06")
+def test_malformed_file_is_flagged_but_yields_a_zero_baseline(tmp_path):
+    (tmp_path / "shipwright_known_failures.json").write_text("{not json", encoding="utf-8")
+    baseline = load_accepted_baseline(tmp_path)
+
+    # `malformed` is the honesty signal — the caller can SAY the list was
+    # unreadable instead of silently reporting "nothing is accepted".
+    assert baseline.malformed is True
+    assert baseline.present is True
+    assert baseline.baseline_failure_count == 0
+    assert baseline.entries == ()
+
+
+@pytest.mark.covers("FR-01.06")
+def test_a_non_object_payload_is_malformed_not_a_crash(tmp_path):
+    _write(tmp_path, ["not", "an", "object"])
+    assert load_accepted_baseline(tmp_path).malformed is True
+
+
+@pytest.mark.covers("FR-01.06")
+def test_non_list_known_failures_key_is_malformed(tmp_path):
+    _write(tmp_path, {"known_failures": "oops"})
+    assert load_accepted_baseline(tmp_path).malformed is True
+
+
+@pytest.mark.covers("FR-01.06")
+def test_garbage_entries_are_skipped_without_losing_the_good_ones(tmp_path):
+    _write(tmp_path, {"known_failures": [{"test": "good"}, "junk", {"no_test_key": 1}]})
+    baseline = load_accepted_baseline(tmp_path)
+    assert [e.test for e in baseline.entries] == ["good"]
+    assert baseline.malformed is False
+
+
+@pytest.mark.covers("FR-01.06")
+def test_a_non_integer_count_falls_back_to_one(tmp_path):
+    _write(tmp_path, {"known_failures": [{"test": "a", "count": "three"}]})
+    assert load_accepted_baseline(tmp_path).baseline_failure_count == 1
+
+
+# ---------------------------------------------------------------------------
+# within_baseline — the arithmetic, mirrored from rtm_generator
+# ---------------------------------------------------------------------------
+
+@pytest.mark.covers("FR-01.06")
+@pytest.mark.parametrize(
+    ("passed", "total", "count", "expected"),
+    [
+        (10, 10, 0, True),    # no gap at all
+        (8, 10, 2, True),     # gap == baseline → within (rtm_generator:475-478)
+        (8, 10, 1, False),    # gap > baseline → genuinely failing
+        (8, 10, 0, False),    # no declared baseline → nothing is excused
+        (11, 10, 0, True),    # negative gap is not a failure
+    ],
+)
+def test_within_baseline_mirrors_the_audit_rule(passed, total, count, expected):
+    assert within_baseline(passed, total, count) is expected
+
+
+@pytest.mark.covers("FR-01.06")
+def test_genuine_failure_count_prefers_an_explicit_failed_number(tmp_path):
+    # A skipped test is NOT a failure. When the layer reports `failed`
+    # explicitly, that is the honest number — never total - passed.
+    assert genuine_failure_count(passed=90, total=100, failed=2, skipped=8) == 2
+
+
+@pytest.mark.covers("FR-01.06")
+def test_genuine_failure_count_subtracts_skips_when_failed_is_absent(tmp_path):
+    assert genuine_failure_count(passed=90, total=100, failed=None, skipped=8) == 2
+
+
+@pytest.mark.covers("FR-01.06")
+def test_genuine_failure_count_falls_back_to_the_bare_gap(tmp_path):
+    assert genuine_failure_count(passed=90, total=100, failed=None, skipped=None) == 10
+
+
+@pytest.mark.covers("FR-01.06")
+def test_genuine_failure_count_never_goes_negative(tmp_path):
+    assert genuine_failure_count(passed=100, total=100, failed=None, skipped=5) == 0
+
+
+# ---------------------------------------------------------------------------
+# split_accepted — identities, not arithmetic
+# ---------------------------------------------------------------------------
+
+@pytest.mark.covers("FR-01.06")
+def test_split_accepted_separates_declared_failures_from_genuine_ones(tmp_path):
+    _write(tmp_path, {"known_failures": [
+        {"test": "e2e/flows/01-auth.spec.ts › should login"},
+    ]})
+    baseline = load_accepted_baseline(tmp_path)
+
+    accepted, genuine = split_accepted(
+        ["e2e/flows/01-auth.spec.ts › should login", "checkout blows up"], baseline,
+    )
+    assert accepted == ["e2e/flows/01-auth.spec.ts › should login"]
+    assert genuine == ["checkout blows up"]
+
+
+@pytest.mark.covers("FR-01.06")
+def test_split_accepted_matches_a_declared_substring_of_the_reported_name(tmp_path):
+    # The declared entry is a test id; the reported failure often carries a
+    # suite prefix. A declared id contained in the reported name is a match.
+    _write(tmp_path, {"known_failures": [{"test": "test_old_thing"}]})
+    baseline = load_accepted_baseline(tmp_path)
+
+    accepted, genuine = split_accepted(["tests/test_legacy.py::test_old_thing"], baseline)
+    assert accepted == ["tests/test_legacy.py::test_old_thing"]
+    assert genuine == []
+
+
+@pytest.mark.covers("FR-01.06")
+def test_split_accepted_does_not_match_on_a_partial_word(tmp_path):
+    _write(tmp_path, {"known_failures": [{"test": "a"}]})
+    baseline = load_accepted_baseline(tmp_path)
+    # A one-character declared id must not swallow every failure that
+    # happens to contain that letter.
+    _, genuine = split_accepted(["test_catalog_shape"], baseline)
+    assert genuine == ["test_catalog_shape"]
+
+
+@pytest.mark.covers("FR-01.06")
+def test_a_declared_failure_that_did_not_fire_does_not_excuse_a_different_one(tmp_path):
+    # External review R4: the divergent case. The declared failure is ABSENT
+    # from this run and an unrelated one appeared. Counting alone would say
+    # "1 failure, baseline 1, all fine". Identity matching must not.
+    _write(tmp_path, {"known_failures": [{"test": "test_declared"}]})
+    baseline = load_accepted_baseline(tmp_path)
+
+    accepted, genuine = split_accepted(["test_something_new"], baseline)
+    assert accepted == []
+    assert genuine == ["test_something_new"]
+
+
+@pytest.mark.covers("FR-01.06")
+def test_split_accepted_with_no_baseline_calls_everything_genuine(tmp_path):
+    accepted, genuine = split_accepted(["a", "b"], load_accepted_baseline(tmp_path))
+    assert accepted == []
+    assert genuine == ["a", "b"]
+
+
+@pytest.mark.covers("FR-01.06")
+def test_split_accepted_tolerates_non_string_failure_names(tmp_path):
+    baseline = AcceptedBaseline(entries=(), baseline_failure_count=0,
+                                present=False, malformed=False)
+    accepted, genuine = split_accepted([None, 42, "real"], baseline)  # type: ignore[list-item]
+    assert accepted == []
+    assert genuine == ["real"]
+
+
+# ---------------------------------------------------------------------------
+# project_facts.is_adopted_project — the greenfield / brownfield signal
+# ---------------------------------------------------------------------------
+
+@pytest.mark.covers("FR-01.06")
+def test_a_project_with_an_adoption_block_is_brownfield(tmp_path):
+    (tmp_path / "shipwright_run_config.json").write_text(
+        json.dumps({"adoption": {"adopted_at": "2026-01-01", "commit_at_adoption": "abc"}}),
+        encoding="utf-8",
+    )
+    assert is_adopted_project(tmp_path) is True
+
+
+@pytest.mark.covers("FR-01.06")
+def test_an_empty_adoption_block_is_not_adoption(tmp_path):
+    (tmp_path / "shipwright_run_config.json").write_text(
+        json.dumps({"adoption": {}}), encoding="utf-8")
+    assert is_adopted_project(tmp_path) is False
+
+
+@pytest.mark.covers("FR-01.06")
+def test_scope_is_not_the_adoption_signal(tmp_path):
+    # Iterate B.1 chose `adoption` over `scope` empirically — `scope` carries
+    # "library" / "full_app", orthogonal to how the project was onboarded.
+    (tmp_path / "shipwright_run_config.json").write_text(
+        json.dumps({"scope": "library"}), encoding="utf-8")
+    assert is_adopted_project(tmp_path) is False
+
+
+@pytest.mark.covers("FR-01.06")
+def test_a_missing_or_broken_run_config_reads_as_greenfield(tmp_path):
+    assert is_adopted_project(tmp_path) is False
+    (tmp_path / "shipwright_run_config.json").write_text("{broken", encoding="utf-8")
+    assert is_adopted_project(tmp_path) is False

--- a/shared/tests/test_known_failures_audit_parity.py
+++ b/shared/tests/test_known_failures_audit_parity.py
@@ -1,0 +1,158 @@
+"""The test phase and the audit must not disagree about what counts as failing.
+
+Two pieces of arithmetic answer the same question from different sides:
+
+* ``tests_block.progression_result`` — what the AUDIT renders in the Test
+  Progression cell (a string: PASS / PASS (baseline) / FAIL (n failed, ...)).
+* ``known_failures.genuine_failure_count`` + ``within_baseline`` — what the TEST
+  PHASE validator decides (a verdict: is this run failing?).
+
+One returns a cell, the other a number, so neither can call the other. This
+pins their agreement instead: for the same inputs, the audit's PASS/FAIL and
+the test phase's ok/not-ok must match.
+
+Caught by external code review, which flagged the validator as diverging from
+the audit's rule. It does not — but nothing was stopping it from drifting there
+later, and "two components hold different truths about one run" is the exact
+defect iterate-2026-07-27-test-phase-record-honesty exists to close. FR-01.06.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from known_failures import (  # noqa: E402
+    genuine_failure_count,
+    has_exact_failure_count,
+    within_baseline,
+)
+from tests_block import progression_result  # noqa: E402
+
+
+def _audit_says_failing(passed: int, total: int, skipped, baseline: int) -> bool:
+    return progression_result(passed, total, skipped, baseline).startswith("FAIL")
+
+
+def _test_phase_says_failing(
+    passed: int, total: int, skipped, baseline: int, failed=None,
+) -> bool:
+    """The validator's decision, reduced to a boolean (see ``test_checks``)."""
+    exact = has_exact_failure_count(failed, skipped)
+    genuine = genuine_failure_count(
+        passed=passed, total=total, failed=failed,
+        skipped=skipped if isinstance(skipped, int) else None,
+    )
+    if genuine <= 0:
+        return False
+    # The aggregate allowance is charity for an un-broken-down gap only.
+    return exact or not (baseline > 0 and genuine <= baseline)
+
+
+@pytest.mark.covers("FR-01.06")
+@pytest.mark.parametrize(
+    ("passed", "total", "skipped", "baseline"),
+    [
+        (10, 10, None, 0),      # clean run, no skip field
+        (10, 10, 0, 0),         # clean run, explicit zero skips
+        (90, 100, 10, 0),       # gap is entirely skips
+        (90, 100, 10, 1),       # ...and a baseline exists but is untouched
+        (90, 100, 9, 0),        # 9 skips + 1 genuine failure
+        (90, 100, 0, 0),        # 10 genuine failures
+        (95, 100, 5, 5),        # skips equal to the baseline — still not failures
+        (100, 100, 5, 0),       # more passes than the gap allows; never negative
+        (0, 0, None, 0),        # nothing ran
+        (0, 10, 0, 0),          # everything failed
+    ],
+)
+def test_the_audit_and_the_test_phase_agree_on_failing(passed, total, skipped, baseline):
+    assert _audit_says_failing(passed, total, skipped, baseline) == \
+        _test_phase_says_failing(passed, total, skipped, baseline)
+
+
+@pytest.mark.covers("FR-01.06")
+@pytest.mark.parametrize(
+    ("passed", "total", "baseline"),
+    [(8, 10, 2), (8, 10, 3), (9, 10, 1), (828, 830, 2)],
+)
+def test_a_gap_the_declared_baseline_covers_is_failing_to_neither(passed, total, baseline):
+    """No skip field → the charitable branch, where the baseline DOES apply.
+
+    The audit spells it "PASS (baseline)"; the validator returns ok. This is the
+    card's motivating case — an onboarded project reporting bare counts.
+    """
+    assert _audit_says_failing(passed, total, None, baseline) is False
+    assert _test_phase_says_failing(passed, total, None, baseline) is False
+
+
+@pytest.mark.covers("FR-01.06")
+def test_a_gap_beyond_the_baseline_is_where_the_two_deliberately_differ():
+    """Not a divergence to fix — they are answering different questions.
+
+    With no breakdown and a gap larger than the baseline, the audit renders
+    ``PASS (n skipped)``: it is describing *merged historical* work, which was
+    green at merge by the Iron Law, so a later gap is read as skips. The
+    validator is gating the *current* run, where an unexplained gap may well be
+    failures; downgrading it to "assume skips" would be precisely the dishonest
+    green this iterate removes.
+
+    Pinned so the difference stays deliberate and nobody "fixes" it into
+    agreement in either direction.
+    """
+    assert _audit_says_failing(8, 10, None, 1) is False       # PASS (2 skipped)
+    assert _test_phase_says_failing(8, 10, None, 1) is True   # WARNING
+    # The pre-existing validator behaviour, unchanged by this iterate:
+    assert _test_phase_says_failing(8, 10, None, 0) is True
+
+
+@pytest.mark.covers("FR-01.06")
+@pytest.mark.parametrize(
+    ("passed", "total", "skipped", "baseline"),
+    [(8, 10, 0, 2), (8, 10, 0, 1), (9, 10, 0, 1), (90, 100, 8, 5)],
+)
+def test_they_agree_that_an_exact_residual_is_not_waived_by_the_baseline(
+    passed, total, skipped, baseline,
+):
+    """Explicit skip count → the exact branch, where the baseline does NOT apply.
+
+    This is the case the parity test was written for and immediately caught:
+    the validator originally applied the allowance here while the audit did not
+    — a two-truths divergence in exactly the projects that carry a baseline
+    file. The audit's side is the deliberate one (compliance's
+    ``test_explicit_residual_ignores_baseline_charity``: an exactly-counted
+    failure must not be waived by a count, or the rendered cell contradicts the
+    D4 detective), so the validator moved.
+    """
+    assert _audit_says_failing(passed, total, skipped, baseline) is True
+    assert _test_phase_says_failing(passed, total, skipped, baseline) is True
+
+
+@pytest.mark.covers("FR-01.06")
+def test_an_explicit_failed_count_matches_the_audits_derived_one():
+    """The one extra signal the test phase has must not change the answer.
+
+    The validator prefers ``unit.failed`` when the layer reports it; the audit
+    derives the same number from ``total - passed - skipped``. Where both are
+    available and consistent, the verdict is identical.
+    """
+    for passed, total, skipped in [(90, 100, 10), (90, 100, 9), (90, 100, 0)]:
+        derived = max(0, total - passed - skipped)
+        assert genuine_failure_count(
+            passed=passed, total=total, failed=derived, skipped=skipped,
+        ) == genuine_failure_count(
+            passed=passed, total=total, failed=None, skipped=skipped,
+        ) == derived
+
+
+@pytest.mark.covers("FR-01.06")
+def test_within_baseline_still_mirrors_the_audits_no_skip_field_branch():
+    """With no skip count, the audit reads the whole gap charitably and the
+    ``within_baseline`` helper reproduces its baseline arm exactly."""
+    assert within_baseline(8, 10, 2) is True
+    assert progression_result(8, 10, None, 2) == "PASS (baseline)"
+    assert within_baseline(8, 10, 1) is False
+    assert progression_result(8, 10, None, 1) == "PASS (2 skipped)"

--- a/shared/tests/test_test_checks_accepted_baseline.py
+++ b/shared/tests/test_test_checks_accepted_baseline.py
@@ -1,0 +1,196 @@
+"""The test-phase validator reads the same accepted-baseline list the audit reads.
+
+Before this, ``check_test_results_file_fresh`` compared ``unit.passed`` against
+``unit.total`` and knew nothing about ``shipwright_known_failures.json``. On an
+onboarded project that meant a permanently WARNING test phase while the audit
+reported the same run as within baseline — two components, two truths.
+
+It also read every passed<total gap as failures, so a run with host-gated
+*skips* consumed accepted-failure allowance it never should have.
+
+iterate-2026-07-27-test-phase-record-honesty, FR-01.06.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.verifiers.common import Severity
+from tools.verifiers.test_checks import check_test_results_file_fresh
+
+
+def _results(root: Path, unit: dict) -> None:
+    (root / "shipwright_test_results.json").write_text(
+        json.dumps({"unit": unit}), encoding="utf-8")
+
+
+def _baseline(root: Path, payload: dict) -> None:
+    (root / "shipwright_known_failures.json").write_text(
+        json.dumps(payload), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Unchanged behaviour — no declared baseline means nothing is excused
+# ---------------------------------------------------------------------------
+
+@pytest.mark.covers("FR-01.06")
+def test_a_gap_with_no_declared_baseline_still_warns(tmp_path: Path):
+    _results(tmp_path, {"passed": 3, "total": 5})
+    r = check_test_results_file_fresh(tmp_path)
+    assert r.ok is False
+    assert r.severity == Severity.WARNING.value
+
+
+@pytest.mark.covers("FR-01.06")
+def test_a_green_run_still_passes(tmp_path: Path):
+    _results(tmp_path, {"passed": 10, "total": 10})
+    assert check_test_results_file_fresh(tmp_path).ok is True
+
+
+@pytest.mark.covers("FR-01.06")
+def test_an_empty_run_is_still_never_a_pass(tmp_path: Path):
+    _results(tmp_path, {"passed": 0, "total": 0})
+    r = check_test_results_file_fresh(tmp_path)
+    assert r.ok is False
+    assert r.severity == Severity.ERROR.value
+
+
+# ---------------------------------------------------------------------------
+# AC4 — accepted baseline failures are not reported as a failing run
+# ---------------------------------------------------------------------------
+
+@pytest.mark.covers("FR-01.06")
+def test_an_unbroken_gap_within_the_declared_baseline_does_not_fail_the_check(tmp_path: Path):
+    """The card's motivating case: an onboarded project reporting bare counts.
+
+    No `failed` / `skipped` breakdown, so all we have is a gap — the audit reads
+    that charitably against the declared baseline, and so must this.
+    """
+    _results(tmp_path, {"passed": 828, "total": 830})
+    _baseline(tmp_path, {"known_failures": [
+        {"test": "test_a"}, {"test": "test_b"},
+    ]})
+    r = check_test_results_file_fresh(tmp_path)
+
+    assert r.ok is True
+    # And it SAYS so — an operator must be able to tell "within baseline"
+    # from "everything passed".
+    assert "baseline" in r.detail.lower()
+    assert "2" in r.detail
+    # ...and it does not overclaim: the allowance is aggregate, not per-failure.
+    assert "aggregate allowance" in r.detail
+
+
+@pytest.mark.covers("FR-01.06")
+def test_an_exactly_counted_failure_is_not_waived_by_the_baseline(tmp_path: Path):
+    """The audit made this call deliberately; the test phase must match it.
+
+    `tests_block.progression_result` renders FAIL for an explicit residual even
+    when the baseline would cover it — pinned compliance-side by
+    `test_explicit_residual_ignores_baseline_charity`, because the D4 detective
+    keys on genuine failures and a PASS (baseline) render would contradict it.
+    Waiving an exactly-counted failure on a count is precisely the dishonest
+    green this iterate exists to remove.
+    """
+    _results(tmp_path, {"passed": 828, "total": 830, "failed": 2})
+    _baseline(tmp_path, {"known_failures": [{"test": "test_a"}, {"test": "test_b"}]})
+    r = check_test_results_file_fresh(tmp_path)
+
+    assert r.ok is False
+    assert r.severity == Severity.WARNING.value
+    assert "2 failing" in r.detail
+    assert "declared in the baseline" in r.detail
+    # It points at the honest resolution rather than at arithmetic.
+    assert "by name" in r.detail
+
+
+@pytest.mark.covers("FR-01.06")
+def test_a_gap_beyond_the_baseline_still_warns_and_names_both_numbers(tmp_path: Path):
+    _results(tmp_path, {"passed": 827, "total": 830})
+    _baseline(tmp_path, {"known_failures": [{"test": "a"}, {"test": "b"}]})
+    r = check_test_results_file_fresh(tmp_path)
+
+    assert r.ok is False
+    assert r.severity == Severity.WARNING.value
+    # The whole point of the card: genuine failures must not hide inside a
+    # single red number.
+    assert "3" in r.detail and "2" in r.detail
+
+
+@pytest.mark.covers("FR-01.06")
+def test_an_unreadable_baseline_file_never_widens_what_is_excused(tmp_path: Path):
+    _results(tmp_path, {"passed": 3, "total": 5, "failed": 2})
+    (tmp_path / "shipwright_known_failures.json").write_text("{broken", encoding="utf-8")
+    r = check_test_results_file_fresh(tmp_path)
+
+    assert r.ok is False
+    # ...and it says the list could not be read, rather than silently
+    # reporting "nothing is accepted".
+    assert "unreadable" in r.detail.lower() or "malformed" in r.detail.lower()
+
+
+# ---------------------------------------------------------------------------
+# External review R3 — skips are not failures
+# ---------------------------------------------------------------------------
+
+@pytest.mark.covers("FR-01.06")
+def test_an_explicit_failed_count_is_preferred_over_the_bare_gap(tmp_path: Path):
+    # 10 of the gap are skips, 0 are failures. Nothing is wrong with this run.
+    _results(tmp_path, {"passed": 90, "total": 100, "failed": 0, "skipped": 10})
+    assert check_test_results_file_fresh(tmp_path).ok is True
+
+
+@pytest.mark.covers("FR-01.06")
+def test_skips_are_subtracted_when_no_failed_count_is_recorded(tmp_path: Path):
+    _results(tmp_path, {"passed": 90, "total": 100, "skipped": 10})
+    assert check_test_results_file_fresh(tmp_path).ok is True
+
+
+@pytest.mark.covers("FR-01.06")
+def test_skips_plus_a_real_failure_still_warns(tmp_path: Path):
+    _results(tmp_path, {"passed": 90, "total": 100, "failed": 1, "skipped": 9})
+    r = check_test_results_file_fresh(tmp_path)
+    assert r.ok is False
+    assert r.severity == Severity.WARNING.value
+
+
+@pytest.mark.covers("FR-01.06")
+def test_a_skip_only_gap_does_not_consume_accepted_failure_allowance(tmp_path: Path):
+    # Baseline of 1 exists, but the run has 5 skips and 0 failures. The
+    # allowance must be left untouched — and the check must pass.
+    _results(tmp_path, {"passed": 95, "total": 100, "skipped": 5})
+    _baseline(tmp_path, {"known_failures": [{"test": "a"}]})
+    r = check_test_results_file_fresh(tmp_path)
+    assert r.ok is True
+    assert "baseline" not in r.detail.lower()
+
+
+@pytest.mark.covers("FR-01.06")
+def test_an_explicit_skip_count_also_makes_the_residual_exact(tmp_path: Path):
+    # `skipped` alone pins the residual, so the allowance does not apply here
+    # either — same rule, same reason.
+    _results(tmp_path, {"passed": 90, "total": 100, "skipped": 8})
+    _baseline(tmp_path, {"known_failures": [{"test": "a"}, {"test": "b"}]})
+    r = check_test_results_file_fresh(tmp_path)
+
+    assert r.ok is False
+    assert "2 failing" in r.detail
+
+
+@pytest.mark.covers("FR-01.06")
+def test_a_malformed_results_file_is_still_an_error(tmp_path: Path):
+    (tmp_path / "shipwright_test_results.json").write_text("{nope", encoding="utf-8")
+    r = check_test_results_file_fresh(tmp_path)
+    assert r.ok is False
+    assert r.severity == Severity.ERROR.value
+
+
+@pytest.mark.covers("FR-01.06")
+def test_a_non_integer_failed_field_falls_back_rather_than_crashing(tmp_path: Path):
+    _results(tmp_path, {"passed": 3, "total": 5, "failed": "two"})
+    r = check_test_results_file_fresh(tmp_path)
+    assert r.ok is False
+    assert r.severity == Severity.WARNING.value


### PR DESCRIPTION
**Part 1 of 2**, split out of #446 so each half fits the automated reviewer's window and passes on its own merits rather than around the gate. Part 2 (the test-phase features) depends on this and follows once it merges.

FR-01.06 · `trg-12b4cf3f`

## The defect

`shipwright_known_failures.json` declares which failures predate a project's onboarding. It had exactly **one** consumer — the compliance audit. The test phase had zero mentions of the file.

So an onboarded project got its inherited failures excused by the audit and reported as fresh failures by the test phase: two components holding different truths about one run, and a permanently red test phase.

> The reason this matters more than any single failure: without it the operator learns to ignore red.

## What changed

The parse moves to one shared reader, `shared/scripts/known_failures.py`.

- **`collectors/test_evidence.collect_known_failures`** becomes a thin adapter over it. Signature, return types and every observable answer unchanged — pinned by a parity test across present / absent / malformed / partial input.
- **`verifiers/test_checks.check_test_results_file_fresh`** now reads the same list, so the test-phase gate stops calling a within-baseline run failing, and reports known-and-accepted separately from genuine.

### The arithmetic mirrors the audit's two branches, not a third

| Record shape | Branch | Baseline applies? |
|---|---|---|
| No `failed` / `skipped` breakdown | charitable | **yes** — this is the onboarded-project case |
| Explicit `failed` or `skipped` | exact | **no** — acceptance is per failure, by identity |

The second row matches `tests_block.progression_result`, which compliance pins deliberately (`test_explicit_residual_ignores_baseline_charity`: waiving an exactly-counted failure on a count would make the rendered cell contradict the D4 detective).

`test_known_failures_audit_parity.py` pins that agreement. **It failed on its first run** and exposed a real divergence — the validator was excusing exact residuals the audit calls FAIL, which is this card's own defect one layer down. It also pins the one place the two *deliberately* differ (a bare gap beyond the baseline: the audit describes merged history, the validator gates a live run), so nobody "fixes" it into agreement.

## Two supporting extractions

Both for the same reason: one fact answered twice is how components end up disagreeing.

- **`project_facts.py`** — the greenfield/brownfield signal (`run_config.adoption`). `compliance_report._is_adopted` delegates to it.
- **`shared_lib_loader.py`** — a *lazy* `from lib.X import` does **not** dodge the ADR-045 collision once a plugin's own `scripts/lib` owns `sys.modules['lib']`; the lazy import resolves against **it**. Latent all this time because every triage producer emits from a subprocess. `triage.py`'s three stdlib-only lib loaders now go through a path-based fallback, so an in-process append works from any plugin's test session.

## Verification

- **5,262** shared + **1,411** compliance + **156** shipwright-test passing. 62 new.
- Compliance behaviour unchanged by the delegation — the whole suite is green on this branch.
- `uvx ruff@0.15.15 check .` clean; bloat anti-ratchet clean.

`compliance_report.py` was also touched upstream by #448 (`iterate-2026-07-27-artifact-state-stamping`) while this was in flight; that change is preserved and mine is layered on top, not over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
