### PR TITLE
fix(adr): renumber the requirement-writeback ADR off a collided number

### DIFF
--- a/.shipwright/planning/adr/115-requirement-writeback-loop.md
+++ b/.shipwright/planning/adr/115-requirement-writeback-loop.md
@@ -1,4 +1,9 @@
-# ADR-113 — The requirement write-back loop: one declaration, two call sites
+# ADR-115 — The requirement write-back loop: one declaration, two call sites
+
+> Renumbered from 113 after merge: #438 took that number first and other
+> decision records already cite ADR-113 meaning
+> `113-override-the-verdict-not-the-check.md`. Two parallel iterates each
+> read the highest number before the other landed.
 
 - **Run ID:** iterate-2026-07-27-requirement-writeback-loop
 - **Date:** 2026-07-27


### PR DESCRIPTION
Two parallel iterates each read the highest ADR number before the other landed,
so both took **113**:

| ADR | From | Merged |
|---|---|---|
| `113-override-the-verdict-not-the-check.md` | #438 | first |
| `113-requirement-writeback-loop.md` | #463 | second |

Other decision records already cite "ADR-113" meaning the first one — e.g. the
`phase-gate-override-evidence` and `handoff-tally-and-gate-honesty` drops, and
the `architecture.md` / `conventions.md` bullets. So renaming the **later
arrival** is what keeps every existing citation correct. 114 is taken, so this
one becomes **115**.

Also corrected in the same pass: the (gitignored) decision-drop for
`iterate-2026-07-27-requirement-writeback-loop`, whose `spec_ref` and two body
references pointed at the old filename. That drop feeds release aggregation, so
leaving it would have produced an aggregated entry pointing at an ADR that does
not exist.

Found while verifying that every part of #463/#464/#465 had actually landed on
`main` — the file was there, but so was another with the same number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
