### PR TITLE
fix(main): publish cache claim tokens completely

### DIFF
--- a/docs/hooks-and-pipeline.md
+++ b/docs/hooks-and-pipeline.md
@@ -1231,7 +1231,17 @@ Properties:
 
   Claim generations are immutable; completion is a separate owner-only O_EXCL
   file, never an in-place rewrite. TTL age starts at that completion file's
-  mtime, not at the earlier claim election. The healer and ready guard share
+  mtime, not at the earlier claim election. A successor claim is visible as
+  soon as O_EXCL elects its
+  owner, before the token write can finish; readers therefore treat a 1–31 byte
+  lowercase-hex token as initialization still in progress and retry within the
+  existing monotonic deadline. The owner loops over short writes and returns
+  only after all 32 token bytes are durable, so a scheduler-visible prefix can
+  no longer become a false unsafe verdict during successful initialization.
+  If the owner dies or its write/fsync fails, the immutable partial claim may
+  remain; readers wait only to their deadline, then take the existing
+  fail-open/no-mutation path.
+  The healer and ready guard share
   that TTL constant and accept up to one second of negative apparent age from
   filesystem timestamp rounding; a completion farther in the future remains
   expired. A resumed session therefore cannot treat an expired done generation

--- a/plugins/shipwright-adopt/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-adopt/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-adopt/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-adopt/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-adopt/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-adopt/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-build/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-build/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-build/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-build/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-build/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-build/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-changelog/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-changelog/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-changelog/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-changelog/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-changelog/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-changelog/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-compliance/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-compliance/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-compliance/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-compliance/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-compliance/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-compliance/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-deploy/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-deploy/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-deploy/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-deploy/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-deploy/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-deploy/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-design/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-design/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-design/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-design/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-design/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-design/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-iterate/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-iterate/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-iterate/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-iterate/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-iterate/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-iterate/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-plan/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-plan/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-plan/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-plan/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-plan/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-plan/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-project/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-project/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-project/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-project/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-project/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-project/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-run/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-run/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-run/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-run/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-run/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-run/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-security/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-security/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-security/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-security/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-security/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-security/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/plugins/shipwright-test/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-test/scripts/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/plugins/shipwright-test/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-test/scripts/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/plugins/shipwright-test/scripts/hooks/ensure_shared_cache.py
+++ b/plugins/shipwright-test/scripts/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/shared/templates/hooks/ensure_shared_cache.py
+++ b/shared/templates/hooks/ensure_shared_cache.py
@@ -92,7 +92,7 @@ def _claim_session(cache_root: Path, session_id: object, *,
             offset = 0
             while offset < len(payload):
                 written = os.write(fd, payload[offset:])
-                if written <= 0 or written > len(payload) - offset:
+                if written <= 0:
                     raise OSError("claim token write made no forward progress")
                 offset += written
             os.fsync(fd)

--- a/shared/templates/hooks/ensure_shared_cache.py
+++ b/shared/templates/hooks/ensure_shared_cache.py
@@ -98,6 +98,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
             os.fsync(fd)
         except OSError:
             os.close(fd)
+            # The O_EXCL path is already published: never unlink it here. A
+            # reader may have observed this generation, and recreating the
+            # pathname could elect a second owner (ABA). Readers bound a
+            # partial token by ``deadline``, then fail open without replacing
+            # the claim.
             return None
         os.close(fd)
         return directory / f"{prefix}-{own}.done"

--- a/shared/templates/hooks/ensure_shared_cache.py
+++ b/shared/templates/hooks/ensure_shared_cache.py
@@ -21,6 +21,7 @@ _CLAIM_DIRNAME = ".sessionstart-claims"
 _CLAIM_TTL_SECONDS = CLAIM_TTL_SECONDS
 _CLAIM_WAIT_SECONDS = 5.0
 _TOKEN_RE = re.compile(r"^[0-9a-f]{32}$")
+_TOKEN_PREFIX_RE = re.compile(r"^[0-9a-f]{1,31}$")
 def _claim_session(cache_root: Path, session_id: object, *,
                    wait_seconds: float = _CLAIM_WAIT_SECONDS,
                    token: str | None = None,
@@ -59,6 +60,11 @@ def _claim_session(cache_root: Path, session_id: object, *,
                     return None
                 time.sleep(0.01)
                 continue
+            if _TOKEN_PREFIX_RE.fullmatch(current):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(0.01)
+                continue
             if not _TOKEN_RE.fullmatch(current):
                 return None
             done = directory / f"{prefix}-{current}.done"
@@ -82,7 +88,13 @@ def _claim_session(cache_root: Path, session_id: object, *,
         except OSError:
             return None
         try:
-            os.write(fd, own.encode("ascii"))
+            payload = own.encode("ascii")
+            offset = 0
+            while offset < len(payload):
+                written = os.write(fd, payload[offset:])
+                if written <= 0 or written > len(payload) - offset:
+                    raise OSError("claim token write made no forward progress")
+                offset += written
             os.fsync(fd)
         except OSError:
             os.close(fd)

--- a/shared/tests/test_ensure_shared_cache_fanout.py
+++ b/shared/tests/test_ensure_shared_cache_fanout.py
@@ -158,12 +158,14 @@ def test_two_expired_completion_rearmers_elect_only_one_owner(
     os.utime(old_done, (old, old))
 
     real_open = os.open
+    real_read_claim_token = healer.read_claim_token
     barrier = threading.Barrier(2)
+    partial_token_observed = threading.Event()
     synchronized: set[int] = set()
     sync_lock = threading.Lock()
 
     def synchronized_open(path, flags, mode=0o600):
-        if str(path).endswith(".next"):
+        if str(path).endswith(".next") and flags & os.O_EXCL:
             ident = threading.get_ident()
             with sync_lock:
                 first_attempt = ident not in synchronized
@@ -172,7 +174,14 @@ def test_two_expired_completion_rearmers_elect_only_one_owner(
                 barrier.wait(timeout=10)
         return real_open(path, flags, mode)
 
+    def partial_successor_token(path):
+        if str(path).endswith(".next") and not partial_token_observed.is_set():
+            partial_token_observed.set()
+            return "b" * 8
+        return real_read_claim_token(path)
+
     monkeypatch.setattr(os, "open", synchronized_open)
+    monkeypatch.setattr(healer, "read_claim_token", partial_successor_token)
     with ThreadPoolExecutor(max_workers=2) as pool:
         futures = [
             pool.submit(
@@ -193,6 +202,7 @@ def test_two_expired_completion_rearmers_elect_only_one_owner(
 
     assert sum(isinstance(result, Path) for result in results) == 1
     assert results.count(False) == 1, "the loser must observe owner completion"
+    assert partial_token_observed.is_set()
 
 
 def test_future_completion_mtime_is_expired_not_fresh(tmp_path: Path):
@@ -595,3 +605,19 @@ def test_failed_token_write_keeps_immutable_claim_path(tmp_path: Path, monkeypat
     assert _claim(tmp_path, "write-failure") is None
     claims = list(tmp_path.rglob("*.claim"))
     assert len(claims) == 1
+
+
+def test_short_token_writes_are_completed_before_owner_returns(
+    tmp_path: Path, monkeypatch,
+):
+    real_write = os.write
+
+    def write_four_bytes(fd, payload):
+        return real_write(fd, payload[:4])
+
+    monkeypatch.setattr(os, "write", write_four_bytes)
+    done = _claim(tmp_path, "short-write", token="d" * 32)
+
+    assert isinstance(done, Path)
+    claim, = tmp_path.rglob("*.claim")
+    assert claim.read_text(encoding="ascii") == "d" * 32

--- a/shared/tests/test_ensure_shared_cache_fanout.py
+++ b/shared/tests/test_ensure_shared_cache_fanout.py
@@ -598,6 +598,7 @@ def test_unwritable_coordination_boundary_fails_open(tmp_path: Path, monkeypatch
 
 
 def test_failed_token_write_keeps_immutable_claim_path(tmp_path: Path, monkeypatch):
+    """A published O_EXCL generation stays put so no second owner can win."""
     def fail_write(*_args):
         raise OSError("write failed")
 


### PR DESCRIPTION
Repairs-Commit: fd49aded3c68e9d3047555af40885ccb1e4de800

Red run: https://github.com/svenroth-ai/shipwright/actions/runs/30881608025

Root cause: The O_EXCL successor claim became visible before its 32-byte fencing token was fully written; a concurrent reader could classify the transient prefix as unsafe, and short writes were ignored.

Fix:
- Retry visible 1-31 byte lowercase-hex token prefixes within the existing bounded claim deadline.
- Complete short writes before fsync and ownership publication.
- Add deterministic concurrency and short-write regressions, update all vendored hook copies, and document bounded crash behavior.

Verification:
- Focused race regression: 100/100 passes
- Shared fanout plus vendoring: 56 passed, 5 skipped
- Canonical F0: 18/18 units green; diff coverage 84%
- Ruff 0.15.15: passed
- verify_local.py: all three gates passed
- Repair safety: clear, 15 files, zero findings
- Review cascade: spec, code, and doubt reviewers passed