### PR TITLE
test(shared): fix Windows worktree path alias assertion

### DIFF
--- a/shared/tests/test_audit_compliance_lifecycle_worktree_reclaim.py
+++ b/shared/tests/test_audit_compliance_lifecycle_worktree_reclaim.py
@@ -96,7 +96,11 @@ def test_leaves_a_fresh_same_prefix_worktree_alone(git_origin_repo):
     lifecycle_tool._reclaim_orphaned_merge_worktrees(work)
 
     paths = _worktree_paths(work)
-    assert live in paths
+    # Windows' ``tempfile`` can return an 8.3 path (``RUNNER~1``), while
+    # ``git worktree list`` expands it to the long user-profile path.  They
+    # identify the same directory, so compare filesystem identity rather than
+    # the two spellings.
+    assert any(live.samefile(path) for path in paths)
     assert live.exists()
 
 


### PR DESCRIPTION
Fixes the red Windows Tests run on main. GitHub-hosted Windows can return a short 8.3 path from tempfile while `git worktree list --porcelain` reports the same directory with its long profile path. The test now compares filesystem identity via `Path.samefile()` rather than path spelling.

Validation:
- `uv run pytest shared/tests/test_audit_compliance_lifecycle_worktree_reclaim.py -q`
- `uv tool run ruff@0.15.15 check shared/tests/test_audit_compliance_lifecycle_worktree_reclaim.py`
- `uv run scripts/verify_local.py`