### PR TITLE
chore(external-review): route the GPT review leg through Codex CLI

### DIFF
--- a/shipwright_iterate_config.json
+++ b/shipwright_iterate_config.json
@@ -1,6 +1,9 @@
 {
   "external_review": {
-    "feedback_iterations": 1
+    "feedback_iterations": 1,
+    "gpt_leg": {
+      "provider": "codex"
+    }
   },
   "external_code_review": {
     "enabled": true


### PR DESCRIPTION
## Summary
- Sets `external_review.gpt_leg.provider: "codex"` in this repo's `shipwright_iterate_config.json`, opting this repo into the Codex CLI GPT-review path added in #672.
- Shipped plugin default stays `"api"` — this is a per-project override, not a change to what other Shipwright consumers get.

## Test plan
- [x] JSON validated
- [x] `codex login status` confirmed authenticated locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yHc7ArL6QgrujydQV3bA6