### PR TITLE
fix(main): tighten, don't reject, host-lease paths a caller creates

### DIFF
--- a/.shipwright/planning/adr/129-bloat-exception-host-resource-locking-tighten-not-reject.md
+++ b/.shipwright/planning/adr/129-bloat-exception-host-resource-locking-tighten-not-reject.md
@@ -1,0 +1,108 @@
+# ADR-129: Bloat exception — `shared/scripts/lib/_host_resource_locking.py` raised to 308-LOC
+
+- **Status:** accepted
+- **Date:** 2026-09-05
+- **Re-Review-Date:** 2026-12-05
+- **Incident Reference:** `iterate-2026-09-03-review-scratch-path` PR #676,
+  round-13 CI failure (`Python (lint + test)`, run 33929960597) — the first
+  time this module's POSIX permission checks ran anywhere but a Windows job.
+
+## Context
+
+`_safe_file`/`_safe_dir` (the private-root hardening `review_scratch.py`
+reuses from `host_resource_lease.py`) reject any existing file or directory
+whose POSIX mode carries group/other bits, on the theory that a private
+lease path must never be world- or group-readable. That check is right for
+paths *this module itself creates* (it already `chmod(0o700)`s a directory
+it just made) but wrong for paths a **caller** creates through its own I/O:
+`iteration-reviews.md` Branch A does `git diff HEAD > "$DIFF_FILE"`, a plain
+bash redirect that honors the process umask (typically 022 → mode 644), not
+this module's threat model. `resolve()` is then called a **second** time
+from the Python read site — that is the documented contract, "both the bash
+write site and the python read site call it independently and land on the
+identical path" — and the second call's `_safe_file` rejected the very file
+the first call's contract expects to exist.
+
+This was invisible locally and in the Windows CI job: `os.name == "nt"`
+skips this whole branch in favor of `_windows_private` (an ACL check with
+different semantics). PR #676 merged with this defect live on `main` for a
+few minutes before the Linux `Python (lint + test)` Required Check reported
+it — three tests failed with `HostLeaseError: host lease file/directory is
+not private`, reproducing exactly the round-trip pattern described above.
+This is not a test-only artifact: the identical failure would have hit the
+real `iteration-reviews.md`/`sub-iterate-runner.md` pipeline on any Linux or
+macOS contributor host, silently breaking every external code review this PR
+exists to make reliable.
+
+## Ousterhout Argument
+
+The fix is narrow and stays inside the module's existing interface: neither
+`_safe_file` nor `_safe_dir` changes its signature or its callers' contract.
+What changes is the *response* to one specific, previously-unreached state
+(mode bits loose, ownership trusted) — from "reject" to "tighten," via one
+new private helper (`_tighten`, 8 lines) shared by both call sites so the
+fix is not duplicated. Ownership was always the real trust boundary here
+(the file's own docstring: "the private, ACL-hardened root defends against
+another OS user planting a reparse point here"); the mode-bit check was
+only ever a proxy for "did something outside our control touch this," and
+tightening is the correct response to that state, not rejection.
+
+## YAGNI Check
+
+No new responsibility was added. The module still does exactly what it did
+— validate a path is safe before a caller reads/writes/removes it — for
+exactly the same three primitives (`_safe_file`, `_safe_runtime_root`,
+`_safe_dir`). The change corrects the POSIX branch's behavior at one
+already-existing decision point per primitive; nothing speculative was
+introduced (no new path kinds, no new callers, no new config).
+
+## Chesterton-Fence Check
+
+The reject-on-loose-bits behavior was not a documented, deliberate fence —
+it was an oversight: the module's own tests (`test_review_scratch.py`) only
+ever exercised the round-trip pattern on Windows-shaped CI, so the gap
+between "we created it" (already tightened) and "a caller created it, we
+inspect it" (never tightened) was never exercised on POSIX until this PR's
+own Linux CI run. No prior ADR or comment defended the reject behavior on
+its own terms; the file's docstring already states the intended trust
+boundary is ownership, which the reject behavior did not actually implement
+consistently. Torn down, not exception-allowed.
+
+## Decision
+
+Raise `current` for `shared/scripts/lib/_host_resource_locking.py` from
+**298 to 308**, `state: "exception"`, `adr: "ADR-129"`, in the same commit
+as the fix.
+
+## Consequences
+
+- `_safe_file`/`_safe_dir` now silently tighten a loose-but-owned path to
+  `0o600`/`0o700` instead of raising `HostLeaseError`. A path owned by
+  another user is still a hard reject — that boundary is unchanged.
+- The round-trip contract `review_scratch.py`'s own docstring describes
+  (bash writes, Python reads, both via independent `resolve()` calls) is now
+  actually exercised end-to-end by `test_resolve_round_trips_content` and
+  `test_resolve_survives_a_space_in_the_temp_root` on every OS CI runs on,
+  not just Windows.
+- If a future primitive needs a *third* mode-bit response (neither tighten
+  nor reject), `_tighten`'s two call sites are the place to look — it is not
+  yet generalized beyond "chmod or raise."
+
+## Rejected alternatives
+
+- **Compress comments/whitespace elsewhere in the file to stay under 300.**
+  Attempted first: consolidating the two duplicated tighten-or-raise blocks
+  into the shared `_tighten` helper already recovered 8 of the 18 lines the
+  naive fix would have cost (316 → 308). Compressing further would mean
+  cutting the docstrings that explain *why* ownership is the boundary — the
+  exact context a future reader needs to avoid re-introducing the reject
+  behavior. Rejected on the same reasoning as ADR-119's "shallow refactor"
+  rejection: the explanation cannot be cut to zero lines.
+- **Split the module instead of exceeding 300.** The three primitives
+  (`_safe_file`, `_safe_runtime_root`, `_safe_dir`) share the reparse-point
+  and ownership-check idioms tightly enough that splitting them into
+  separate files would either duplicate those idioms or introduce a shared
+  sub-helper module for a net gain of essentially zero lines, while
+  scattering one coherent security primitive across multiple files makes it
+  harder, not easier, to audit as a unit — the opposite of what a
+  correctness-sensitive module wants.

--- a/.shipwright/planning/adr/INDEX.md
+++ b/.shipwright/planning/adr/INDEX.md
@@ -63,6 +63,7 @@ _Regenerate:_ `uv run {shared_root}/scripts/tools/rebuild_adr_index.py --project
 - [ADR-127 — Run-id pointer lifecycle: retirement + stale-verdict re-audit](127-run-id-lifecycle-fixes.md)
 - [ADR-128 — Split coverage.fields.<key>.unavailable into not_applicable / missing](128-coverage-envelope-not-applicable-missing-split.md)
 - [ADR-128 — Track decision-drops in git; redirect the write path into the calling worktree](128-track-decision-drops.md)
+- [ADR-129 — Bloat exception — `shared/scripts/lib/_host_resource_locking.py` raised to 308-LOC](129-bloat-exception-host-resource-locking-tighten-not-reject.md)
 - [Archive — Agent-Doc Update Backlog (verbatim)](_archive-agent-doc-updates.md)
 - [ADR spec-folder files are named by run_id, never a guessed number](iterate-2026-08-08-index-readers-adr-lock-spec-folder-naming.md)
 - [A third append-only event kind for the triage store](iterate-2026-08-08-triage-amend-event-third-event-kind.md)

--- a/shared/scripts/lib/_host_resource_locking.py
+++ b/shared/scripts/lib/_host_resource_locking.py
@@ -77,6 +77,17 @@ def _windows_private(path: Path) -> tuple[bool, str]:
     return path_acl_is_private(path)
 
 
+def _tighten(path: Path, mode: int, *, kind: str) -> None:
+    """POSIX only: owned by us but loosened by something outside our control
+    (a bash `>` redirect honors the process umask) — tighten rather than
+    reject. Ownership, checked by the caller, is the trust boundary, not the
+    mode bits, once _is_reparse has ruled out a planted link."""
+    try:
+        path.chmod(mode)
+    except OSError as exc:
+        raise HostLeaseError(f"could not tighten host lease {kind} permissions {path}: {exc}") from exc
+
+
 def _reject_linked_components(path: Path) -> None:
     target = path.absolute()
     current = Path(target.anchor)
@@ -107,7 +118,7 @@ def _safe_file(path: Path, *, allow_missing: bool = False) -> None:
         if hasattr(os, "getuid") and stat.st_uid != os.getuid():
             raise HostLeaseError(f"host lease file is owned by another user: {path}")
         if stat.st_mode & 0o077:
-            raise HostLeaseError(f"host lease file is not private: {path}")
+            _tighten(path, 0o600, kind="file")
 
 
 def _safe_runtime_root(path: Path, *, allow_sticky_shared: bool) -> None:
@@ -189,8 +200,7 @@ def _safe_dir(path: Path, *, trusted_parent: Path) -> None:
                 raise HostLeaseError(
                     f"host lease directory is owned by another user: {current}")
             if stat.st_mode & 0o077:
-                raise HostLeaseError(
-                    f"host lease directory is not private: {current}")
+                _tighten(current, 0o700, kind="directory")
 
 
 def _lock_byte(handle, *, blocking: bool) -> bool:

--- a/shared/scripts/tools/tests/test_host_resource_locking.py
+++ b/shared/scripts/tools/tests/test_host_resource_locking.py
@@ -136,6 +136,20 @@ def test_posix_private_dir_tightens_group_or_world_access(tmp_path):
     assert loose.stat().st_mode & 0o077 == 0
 
 
+@pytest.mark.skipif(os.name == "nt", reason="native POSIX permission proof")
+def test_posix_tighten_wraps_a_chmod_failure_in_host_lease_error(tmp_path, monkeypatch):
+    path = tmp_path / "state.json"
+    path.write_text("{}", encoding="utf-8")
+    path.chmod(0o644)
+
+    def _boom(self, mode):
+        raise OSError("simulated chmod failure")
+
+    monkeypatch.setattr(Path, "chmod", _boom)
+    with pytest.raises(lease.HostLeaseError, match="could not tighten"):
+        locking._safe_file(path)
+
+
 @pytest.mark.skipif(os.name == "nt", reason="native POSIX ownership proof")
 def test_posix_private_file_owned_by_another_user_still_rejects(tmp_path, monkeypatch):
     path = tmp_path / "state.json"

--- a/shared/scripts/tools/tests/test_host_resource_locking.py
+++ b/shared/scripts/tools/tests/test_host_resource_locking.py
@@ -110,12 +110,16 @@ def test_posix_byte_lock_blocks_an_independent_process(tmp_path):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="native POSIX permission proof")
-def test_posix_private_file_tightens_group_or_world_access(tmp_path):
-    # PR #676 round-13: a bash `>` redirect creates the file under the
-    # process umask (e.g. 644), not this module's own hardened mode — the
-    # real production write path, not just a test artifact. Ownership, not
-    # the mode bits, is the trust boundary, so _safe_file must tighten a
-    # loose-but-owned file rather than reject it outright.
+def test_posix_private_file_rejects_group_or_world_access(tmp_path):
+    # PR #676 round-13 repair: a bash `>` redirect creates the file under
+    # the process umask (e.g. 644), not this module's own hardened mode —
+    # the real production write path, not just a test artifact, and the
+    # original version of this test (asserting `_safe_file` raises here)
+    # is exactly what that regression exposed on Linux CI. Ownership, not
+    # the mode bits, is the trust boundary, so `_safe_file` now tightens a
+    # loose-but-owned file rather than reject it outright — this test's
+    # name is unchanged; only its assertion is, from "raises" to
+    # "tightens", to match.
     path = tmp_path / "state.json"
     path.write_text("{}", encoding="utf-8")
     path.chmod(0o644)

--- a/shared/scripts/tools/tests/test_host_resource_locking.py
+++ b/shared/scripts/tools/tests/test_host_resource_locking.py
@@ -110,14 +110,36 @@ def test_posix_byte_lock_blocks_an_independent_process(tmp_path):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="native POSIX permission proof")
-def test_posix_private_file_rejects_group_or_world_access(tmp_path):
+def test_posix_private_file_tightens_group_or_world_access(tmp_path):
+    # PR #676 round-13: a bash `>` redirect creates the file under the
+    # process umask (e.g. 644), not this module's own hardened mode — the
+    # real production write path, not just a test artifact. Ownership, not
+    # the mode bits, is the trust boundary, so _safe_file must tighten a
+    # loose-but-owned file rather than reject it outright.
     path = tmp_path / "state.json"
     path.write_text("{}", encoding="utf-8")
     path.chmod(0o644)
-    with pytest.raises(lease.HostLeaseError, match="file is not private"):
-        locking._safe_file(path)
-    path.chmod(0o600)
     locking._safe_file(path)
+    assert path.stat().st_mode & 0o077 == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="native POSIX permission proof")
+def test_posix_private_dir_tightens_group_or_world_access(tmp_path):
+    trusted_parent = tmp_path
+    loose = tmp_path / "loose"
+    loose.mkdir(mode=0o755)
+    locking._safe_dir(loose, trusted_parent=trusted_parent)
+    assert loose.stat().st_mode & 0o077 == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="native POSIX ownership proof")
+def test_posix_private_file_owned_by_another_user_still_rejects(tmp_path, monkeypatch):
+    path = tmp_path / "state.json"
+    path.write_text("{}", encoding="utf-8")
+    path.chmod(0o600)
+    monkeypatch.setattr(os, "getuid", lambda: os.getuid() + 1, raising=False)
+    with pytest.raises(lease.HostLeaseError, match="owned by another user"):
+        locking._safe_file(path)
 
 
 def test_posix_fallback_uses_sticky_shared_root_and_private_child(tmp_path, monkeypatch):

--- a/shared/scripts/tools/tests/test_host_resource_locking.py
+++ b/shared/scripts/tools/tests/test_host_resource_locking.py
@@ -141,7 +141,8 @@ def test_posix_private_file_owned_by_another_user_still_rejects(tmp_path, monkey
     path = tmp_path / "state.json"
     path.write_text("{}", encoding="utf-8")
     path.chmod(0o600)
-    monkeypatch.setattr(os, "getuid", lambda: os.getuid() + 1, raising=False)
+    real_getuid = os.getuid
+    monkeypatch.setattr(os, "getuid", lambda: real_getuid() + 1, raising=False)
     with pytest.raises(lease.HostLeaseError, match="owned by another user"):
         locking._safe_file(path)
 

--- a/shipwright_bloat_baseline.json
+++ b/shipwright_bloat_baseline.json
@@ -592,6 +592,13 @@
       "adr": "ADR-090"
     },
     {
+      "path": "shared/scripts/lib/_host_resource_locking.py",
+      "limit": 300,
+      "current": 308,
+      "state": "exception",
+      "adr": "ADR-129"
+    },
+    {
       "path": "shared/scripts/lib/artifact_migrations.py",
       "limit": 300,
       "current": 641,


### PR DESCRIPTION
## What broke

`main`'s `Python (lint + test)` Required Check failed
(https://github.com/svenroth-ai/shipwright/actions/runs/33947503316) right
after PR #676 merged. `Repairs-Commit: 66c671d538f1026f79b6064565bd19e4267f74a9`.

## Root cause

`_safe_file`/`_safe_dir` in `shared/scripts/lib/_host_resource_locking.py`
reject any existing lease path whose POSIX mode carries group/other bits.
That's correct for paths the module itself creates (already chmod'd
0o700/0o600), but wrong for a path a **caller** creates through its own I/O:
`iteration-reviews.md` Branch A does `git diff HEAD > "$DIFF_FILE"` — a bash
redirect that honors the process umask (typically 022 → mode 644) — and then
`resolve()` is called a *second* time from the Python read site, which is
`review_scratch.py`'s own documented round-trip contract. That second call's
`_safe_file` rejected the very file the first call's contract expects to
exist. This was invisible on Windows (the whole POSIX branch is skipped
there for an ACL-based check instead), so it only surfaced on the Linux CI
runner — not an overlap with another PR, this is a single-PR defect that
the sensitive-path admin-override merge shipped before CI caught it.

## Fix

When a lease path exists, is owned by the current user, and is not a
reparse point, tighten its mode (`0o600` file / `0o700` dir) instead of
raising. Ownership was already the module's stated trust boundary; the
mode-bit check was only ever a proxy for "did something outside our control
touch this," and tightening is the correct response, not rejection. The
"owned by another user" rejection is unchanged and now has a direct
regression test that didn't exist before.

## Why the changed assertion is the new truth

`check_repair_safety.py` flags `test_posix_private_file_rejects_group_or_world_access`
as `assertion_changed` (verdict `review`, non-blocking). The old assertion
(`_safe_file` raises on loose bits) is exactly the behavior this PR proves
wrong — it's what broke `main`. The new assertion (mode gets tightened to
`0o600`, no raise) is the behavior the module's own round-trip contract
requires. Two new tests were added alongside it: the directory analogue,
and a direct test that a file owned by another user still hard-rejects
(the actual security boundary, now tested explicitly for the first time).

## Verification

- `uv run pytest shared/scripts/tools/tests/` — 673 passed, 18 skipped
  (POSIX-only tests skip on this Windows dev machine; they'll run for real
  on the Linux CI job this repairs).
- `uvx ruff@0.15.15 check` — clean.
- `uv run scripts/verify_local.py` — all 3 mirrored gates green.
- `check_repair_safety.py --base origin/main` — `verdict: review` (the
  allowed, justified case above), no blocking findings.

`shared/scripts/lib/_host_resource_locking.py` crosses 300 LOC (298 → 308)
for the shared `_tighten` helper both call sites use; `ADR-129` records the
bloat exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiTLYGR7G1b4T8Gz6jFsJF
