### PR TITLE
fix(compliance): H2 must not suggest tightening below what trunk already has

### DIFF
--- a/plugins/shipwright-compliance/scripts/audit/_group_h_default_branch.py
+++ b/plugins/shipwright-compliance/scripts/audit/_group_h_default_branch.py
@@ -1,0 +1,41 @@
+"""H2 support — default-branch LOC lookup (webui incident 2026-09-09).
+
+Split out of ``group_h.py`` to keep it under the 300-LOC guideline.
+
+PRs #450/#453/#456: a Group-H2 suggestion tightened
+``shipwright_bloat_baseline.json`` to a value measured on ONE tree at ONE
+instant. A concurrent, already-in-flight branch landed the same file bigger,
+and after both merged trunk's own anti-ratchet broke on a zero-diff PR. H2
+must not suggest a tightening the shared trunk itself already exceeds.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.audit.audit_adapters import load_shared_lib
+
+_branch_base = load_shared_lib("branch_base")
+
+
+def default_branch_lines(project_root: Path, rel_path: str) -> int | None:
+    """LOC of ``rel_path`` on ``origin/<default>``, or ``None`` when it
+    cannot be determined (no repo, no such remote ref, path absent there).
+
+    ``None`` means "unknown" — callers must not treat it as zero. This is
+    what keeps a bare-directory fixture (no ``.git`` at all) behaving
+    exactly as before this check was added.
+    """
+    try:
+        default_branch = _branch_base.resolve_default_branch()
+        result = subprocess.run(
+            ["git", "-C", str(project_root), "show",
+             f"origin/{default_branch}:{rel_path}"],
+            capture_output=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.count(b"\n")

--- a/plugins/shipwright-compliance/scripts/audit/group_h.py
+++ b/plugins/shipwright-compliance/scripts/audit/group_h.py
@@ -1,11 +1,11 @@
 """Group H — Bloat-policy detective audit (Campaign A.review).
 
 H0 baseline meta (skip absent / fail malformed); H1 drift (oversize file
-not in baseline); H2 ratchet-suggestion (current > on-disk LOC); H3
-anti-ratchet bypass (state=anti-ratchet); H4 exception without ADR; H5
-deferred-plan without plan_ref; H6 stale-entry (path missing on disk OR
-escapes project_root). H1/H2 reuse the producer's ``bloat_baseline.scan``
-+ ``_file_newlines`` so audit semantics cannot drift from writer
+not in baseline); H2 ratchet-suggestion (current > on-disk LOC, gated by
+``_group_h_default_branch`` — webui #450/#453/#456); H3 anti-ratchet
+bypass; H4 exception without ADR; H5 deferred-plan without plan_ref; H6
+stale-entry. H1/H2 reuse the producer's ``bloat_baseline.scan`` +
+``_file_newlines`` so audit semantics cannot drift from writer
 (external-review OpenAI #2/#3). All Findings: source=detective-only.
 """
 
@@ -15,12 +15,12 @@ import json
 from pathlib import Path
 from typing import Any
 
+from scripts.audit import _group_h_default_branch as _default_branch
 from scripts.audit.audit_adapters import (
     SOURCE_DETECTIVE_ONLY,
     Finding,
     load_shared_lib,
 )
-
 
 _bb = load_shared_lib("bloat_baseline")
 
@@ -191,20 +191,24 @@ def _check_h6(stale: list[tuple[dict, str]]) -> Finding:
                           "shipwright_bloat_baseline.json\""))
 
 
-# ---------------------------------------------------------------------------
 # H2 / H3 / H4 / H5 — entry-shape audits. All scoped to resolvable entries.
-# ---------------------------------------------------------------------------
 
 
-def _check_h2(resolvable: list[tuple[dict, Path]]) -> Finding:
+def _check_h2(project_root: Path, resolvable: list[tuple[dict, Path]]) -> Finding:
     suggestions: list[tuple[str, int, int]] = []  # path, recorded, actual
     for entry, path in resolvable:
         recorded = entry.get("current")
         if not isinstance(recorded, int):
             continue
         actual = _bb._file_newlines(path)
-        if actual < recorded:
-            suggestions.append((entry["path"], recorded, actual))
+        if actual >= recorded:
+            continue
+        # webui #450/#453/#456: don't suggest below what trunk already has.
+        origin_main = _default_branch.default_branch_lines(
+            project_root, entry["path"])
+        if origin_main is not None and origin_main >= actual:
+            continue
+        suggestions.append((entry["path"], recorded, actual))
     if not suggestions:
         return _mk("H2", "pass",
                    "baseline current matches on-disk LOC for all entries")
@@ -256,9 +260,7 @@ def _check_state_with_required(
     return _mk(check_id, "fail", detail, evidence=list(offenders))
 
 
-# ---------------------------------------------------------------------------
 # Top-level run()
-# ---------------------------------------------------------------------------
 
 
 def run(
@@ -283,7 +285,7 @@ def run(
     }
 
     out.append(_check_h1(project_root, baseline_paths))
-    out.append(_check_h2(resolvable))
+    out.append(_check_h2(project_root, resolvable))
     out.append(_check_state_with_required(
         "H3", "anti-ratchet", "", resolvable,
     ))

--- a/plugins/shipwright-compliance/tests/test_audit_group_h_default_branch.py
+++ b/plugins/shipwright-compliance/tests/test_audit_group_h_default_branch.py
@@ -1,0 +1,144 @@
+"""H2 default-branch guard (webui incident 2026-09-09, PRs #450/#453/#456).
+
+A Group-H2 ratchet-suggestion tightened ``shipwright_bloat_baseline.json``
+to a value measured on one tree at one instant while a concurrent,
+already-in-flight branch landed the same file bigger; after both merged,
+trunk's own anti-ratchet broke on every later zero-diff PR. H2 must not
+suggest a tightening the shared trunk (``origin/<default>``) already
+exceeds — see ``scripts.audit._group_h_default_branch``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+from scripts.audit import group_h  # noqa: E402
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args],
+                   check=True, capture_output=True)
+
+
+def _mktree(root: Path, entries: bytes) -> str:
+    # Raw bytes, NOT text=True: on Windows a text-mode stdin pipe translates
+    # "\n" to "\r\n", which corrupts mktree's "<mode> <type> <sha>\t<name>\n"
+    # line format (the stray \r lands inside the entry name) and silently
+    # produces a tree that doesn't contain the path we asked for.
+    return subprocess.run(
+        ["git", "-C", str(root), "mktree"],
+        input=entries, capture_output=True, check=True,
+    ).stdout.decode().strip()
+
+
+def _build_tree(root: Path, rel: str, blob: str) -> str:
+    """Build a (possibly nested) tree containing ``blob`` at ``rel``.
+
+    ``git mktree`` only builds one flat level per call, so a nested path
+    (``src/foo.py``) is built bottom-up: innermost directory first, then
+    each parent wraps the previous tree as a ``040000 tree`` entry.
+    """
+    parts = rel.split("/")
+    tree = _mktree(root, f"100644 blob {blob}\t{parts[-1]}\n".encode())
+    for name in reversed(parts[:-1]):
+        tree = _mktree(root, f"040000 tree {tree}\t{name}\n".encode())
+    return tree
+
+
+def _seed_origin_main(root: Path, rel: str, n_lines: int) -> None:
+    """Simulate a shared trunk: commit ``rel`` at ``n_lines`` on a throwaway
+    commit and point ``refs/remotes/origin/main`` at it, WITHOUT touching the
+    caller's own on-disk working-tree copy of ``rel`` or HEAD/any branch."""
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "test")
+    content = ("x = 1\n" * n_lines).encode()
+    blob = subprocess.run(
+        ["git", "-C", str(root), "hash-object", "-w", "--stdin"],
+        input=content, capture_output=True, check=True,
+    ).stdout.decode().strip()
+    tree = _build_tree(root, rel, blob)
+    commit = subprocess.run(
+        ["git", "-C", str(root), "commit-tree", tree, "-m", "trunk"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    _git(root, "update-ref", "refs/remotes/origin/main", commit)
+
+
+def _write_py(root: Path, rel: str, n_lines: int) -> Path:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("x = 1\n" * n_lines, encoding="utf-8")
+    return p
+
+
+def _write_baseline(root: Path, entries: list[dict]) -> None:
+    (root / "shipwright_bloat_baseline.json").write_text(
+        json.dumps({"version": 1, "entries": entries}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _findings_by(findings, check_id: str):
+    return [f for f in findings if f.check_id == check_id]
+
+
+def test_h2_suppressed_when_default_branch_already_at_or_above_proposed(tmp_path):
+    # recorded=447, on-disk actual=445 (would normally suggest tightening to
+    # 445) — but origin/main already carries the file at 446, i.e. >= the
+    # proposed value. The entry isn't stale, it's larger elsewhere: no H2
+    # finding for this path.
+    _seed_origin_main(tmp_path, "src/foo.py", 446)
+    _write_py(tmp_path, "src/foo.py", 445)
+    _write_baseline(tmp_path, entries=[{
+        "path": "src/foo.py", "limit": 300, "current": 447,
+        "state": "grandfathered", "adr": None,
+    }])
+
+    findings = group_h.run(tmp_path, None, None)
+    h2 = _findings_by(findings, "H2")
+    assert h2 and h2[0].status == "pass", \
+        f"expected H2 pass (suppressed); got {h2[0].detail if h2 else None!r}"
+    assert "src/foo.py" not in "".join(h2[0].evidence)
+
+
+def test_h2_still_suggests_when_default_branch_is_smaller_still(tmp_path):
+    # origin/main is genuinely smaller than the proposed value everywhere —
+    # nothing is racing ahead of the audited tree, so the suggestion still
+    # fires normally.
+    _seed_origin_main(tmp_path, "src/foo.py", 300)
+    _write_py(tmp_path, "src/foo.py", 380)
+    _write_baseline(tmp_path, entries=[{
+        "path": "src/foo.py", "limit": 300, "current": 500,
+        "state": "grandfathered", "adr": None,
+    }])
+
+    findings = group_h.run(tmp_path, None, None)
+    h2 = _findings_by(findings, "H2")
+    assert h2 and h2[0].status == "fail", \
+        f"expected H2 fail (still suggested); got {h2[0].status if h2 else None!r}"
+    assert "src/foo.py" in h2[0].detail
+    assert "380" in h2[0].detail
+
+
+def test_h2_suggests_normally_when_no_git_repo_present(tmp_path):
+    # No ``.git`` at all — default_branch_lines() must fail closed to
+    # "unknown" and NOT suppress, matching pre-fix behavior exactly (this
+    # is the shape every other Group-H test's tmp_path fixture already is).
+    _write_py(tmp_path, "src/foo.py", 380)
+    _write_baseline(tmp_path, entries=[{
+        "path": "src/foo.py", "limit": 300, "current": 500,
+        "state": "grandfathered", "adr": None,
+    }])
+
+    findings = group_h.run(tmp_path, None, None)
+    h2 = _findings_by(findings, "H2")
+    assert h2 and h2[0].status == "fail"
+    assert "src/foo.py" in h2[0].detail


### PR DESCRIPTION
## Summary
- webui incident 2026-09-09 (PRs #450/#453/#456): a Group-H2 ratchet-suggestion tightened `shipwright_bloat_baseline.json` to a value measured on one tree at one instant, while an already-in-flight branch landed the same file bigger — once both merged, trunk's own Anti-ratchet (`--worktree` mode, diff-agnostic) broke for every later zero-diff PR on that file until a hand-written repair PR + admin override unblocked it.
- Before emitting an H2 finding, `group_h.py` now compares the proposed new `current` against `origin/<default>`'s own content for that path (new `scripts/audit/_group_h_default_branch.py`, split out to keep `group_h.py` under the 300-LOC guideline). If trunk already carries the file at or above the proposal, the suggestion is suppressed — the entry isn't stale, it's merely larger elsewhere.
- A missing repo, remote, or path resolves to "unknown" and falls back to today's behavior unchanged (verified by a dedicated no-git-repo regression test alongside the two new guard tests).

## Scope guard
- Changes only when H2 **emits** a suggestion. Anti-ratchet itself, H2's severity, and `shared/scripts/lib/anti_ratchet.py` are untouched.
- Cross-repo: the generator is monorepo-owned (`plugins/shipwright-compliance`) but the damage landed in shipwright-webui, which vendors the gates — this fix reaches every consumer repo.
- Closes webui incident card `trg-e893ed97`.

## Test plan
- [x] New `tests/test_audit_group_h_default_branch.py` (3 tests): suppresses when trunk is at/above the proposal, still suggests when trunk is genuinely smaller everywhere, and falls back to unchanged behavior with no git repo present.
- [x] Full `plugins/shipwright-compliance` suite: 1682 passed, 5 skipped (pre-existing, unrelated).
- [x] `uv run scripts/verify_local.py`: all 3 mirrored CI gates green.
- [x] `uvx ruff@0.15.15 check` on touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nTB6xnU1WV1oeBAzsWSgq