### PR TITLE
fix(main): update PR-review canary literal for the new backtick-wrapped render shape

### DIFF
--- a/plugins/shipwright-security/tests/test_pr_review_render_convergence_canary.py
+++ b/plugins/shipwright-security/tests/test_pr_review_render_convergence_canary.py
@@ -11,6 +11,16 @@ original canary pinned only the first three). Split into its own file
 (rather than folded into `test_pr_review_render.py`) to keep that file under
 the source-size guideline while this one-test canary stays easy to find from
 either side.
+
+The bullet literal was updated (main-repair of 106c01c69986, same day as the
+canary's own iterate) when `_finding_text`/`_finding_span`
+(iterate-2026-09-09-pr-review-dict-finding-render, PR #694) started wrapping
+every blocking item's rendered text in a backtick code span — `- {bullet}`
+became `` - `{bullet}` ``. `_BULLET_RE` (``^-\\s+(.*)``) and `_FILE_RE`'s
+optional leading backtick already tolerate the extra wrapping, proven by
+`shared/tests/test_pr_review_convergence.py::test_extract_blocking_findings_tolerates_the_backtick_wrapped_render_shape`
+— this file only pins the literal shape, the sibling test proves parsing
+still works on it.
 """
 
 from __future__ import annotations
@@ -31,4 +41,4 @@ def test_block_verdict_marker_and_heading_are_the_literals_convergence_depends_o
     assert "Shipwright PR Review" in body
     assert "🔴 BLOCK" in body
     assert "Blocking issues" in body
-    assert "\n- a.py:1 — x" in body  # the `- {bullet}` shape _BULLET_RE parses
+    assert "\n- `a.py:1 — x`" in body  # the `- {bullet}` shape _BULLET_RE parses

--- a/shared/tests/test_pr_review_convergence.py
+++ b/shared/tests/test_pr_review_convergence.py
@@ -73,6 +73,25 @@ def test_extract_blocking_findings_empty_on_approve():
     assert extract_blocking_findings(APPROVE_BODY) == []
 
 
+def test_extract_blocking_findings_tolerates_the_backtick_wrapped_render_shape():
+    """`pr_review_render.render_comment` (PR #694, iterate-2026-09-09-pr-review-dict-finding-render)
+    now wraps every blocking item's rendered text in a code span — `- {bullet}`
+    became `` - `{bullet}` `` — after this predicate's own canary was written
+    against the older, unwrapped shape (main-repair of 106c01c69986). `_BULLET_RE`
+    captures the whole rest of the line including the wrapping backticks, and
+    `_FILE_RE`'s optional leading backtick still finds the path inside it, so
+    parsing must be unaffected — this is the proof, not an assumption."""
+    body = (
+        "## \U0001F916 Shipwright PR Review\n\n**Decision: \U0001F534 BLOCK**\n\nSummary.\n\n"
+        "### \U0001F6AB Blocking issues\n"
+        "- `foo/bar.py:10 — missing null check on x, add a guard`\n"
+    )
+    findings = extract_blocking_findings(body)
+    assert len(findings) == 1
+    assert findings[0]["files"] == frozenset({"foo/bar.py"})
+    assert "guard" in findings[0]["tokens"]
+
+
 def test_normalized_tokens_strips_file_paths_digits_and_stopwords():
     tokens = normalized_tokens(
         "shared/scripts/tools/foo.py:12-19 — the fingerprint is not bound to the "


### PR DESCRIPTION
## Summary
- `main` went red at `106c01c69986` (PR #696's merge) because PR #694's render-format change and PR #696's new drift canary crossed: each was green on its own, but PR #696's canary pinned a literal `render_comment` no longer produces post-#694.
- Updated the canary's literal to the current, real output shape and added a regression test proving `extract_blocking_findings` still parses it correctly — the underlying non-converging predicate was never actually broken, only the canary's pinned literal was stale.

## Test plan
- [x] `uv run pytest plugins/shipwright-security/tests -q` — 993 passed, 7 skipped
- [x] `uv run pytest shared/tests -q` — 9929 passed, 32 skipped
- [x] `uvx ruff@0.15.15 check` on both touched files — clean
- [x] `check_repair_safety.py` — exit 0, verdict `review` (an assertion's expectation legitimately changed, no coverage removed)

Repairs-Commit: 106c01c69986cfcb2a5c4686ccfbf07015452840
Red run: https://github.com/svenroth-ai/shipwright/actions/runs/34373414428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnQqmnZUhAGqHY7N2m6JyP
