### PR TITLE
fix(iterate): warn on individually-unread spec paths in keystone AC gate

### DIFF
--- a/shared/scripts/tools/tests/test_keystone_ac_digest_never_silent.py
+++ b/shared/scripts/tools/tests/test_keystone_ac_digest_never_silent.py
@@ -166,6 +166,40 @@ def test_a_named_spec_path_absent_from_git_at_both_commits_also_suppresses_arm_2
     assert any("none resolved to any content" in w for w in cs.warnings)
 
 
+def test_one_stale_path_among_several_warns_even_though_a_sibling_was_read(repo):
+    """Code robustness follow-up (P4.4 triage card). ``spec_text_was_read`` is
+    computed ONCE across ALL named spec paths, so with multiple spec paths where
+    one resolves to no content at either commit and another has real content,
+    the aggregate flag stays True -- correctly, per design, so arm 2's
+    suppression does NOT apply to a head-only FR anchored to the good path (it
+    is judged against text that WAS read). But the stale path itself used to get
+    NO warning at all, because the aggregate-empty branch above is keyed on
+    ``not spec_text_was_read`` and never fires once a sibling path succeeds --
+    the exact silence the module docstring calls the one failure worse than
+    over-firing, one layer deeper than the all-paths-stale case already
+    covered above."""
+    good_path = "docs/spec.md"  # already committed by `make_repo`
+    stale_path = "Spec/design/does-not-exist.md"
+    head = _git("rev-parse", "HEAD", cwd=repo)
+    base_manifest = {"requirements": {
+        "ns::FR-01.01": {"id": "FR-01.01", "status": "active", "spec_path": good_path},
+    }}
+    head_manifest = {"requirements": {
+        "ns::FR-01.01": {"id": "FR-01.01", "status": "active", "spec_path": good_path},
+        "ns::FR-03.01": {"id": "FR-03.01", "status": "active", "spec_path": stale_path},
+    }}
+    cs = kd.ac_change_set(repo, head, head, head_manifest, base_manifest)
+    # The suppression stays keyed on the aggregate flag (unchanged by design):
+    # FR-03.01 is a new active FR at head with no minted criteria anywhere, and
+    # `spec_text_was_read` is True because `good_path` was read -- so it DOES
+    # fire, exactly as the aggregate design intends.
+    assert cs.new_frs_without_criteria == ["FR-03.01"]
+    assert any(
+        stale_path in w and good_path not in w and "even though another" in w
+        for w in cs.warnings
+    ), cs.warnings
+
+
 # --------------------------------------------------------------------------
 # Cross-spec-path collision (Stage-3 doubt review, medium)
 # --------------------------------------------------------------------------

--- a/shared/scripts/tools/verifiers/_keystone_ac_digest.py
+++ b/shared/scripts/tools/verifiers/_keystone_ac_digest.py
@@ -132,6 +132,16 @@ def ac_change_set(
     # from git at either sha -- must not count as read, on pain of arm 2
     # (below) firing from a document nobody actually read.
     spec_text_was_read = False
+    # Per-path counterpart to the aggregate flag above (found during build,
+    # code review). With MULTIPLE spec paths, `spec_text_was_read` goes True
+    # the moment ANY one of them has content -- correct for arm 2's own
+    # suppression (design scopes it to the aggregate, unchanged below), but it
+    # means a path that individually resolved to no content at either commit
+    # gets no warning of its own once a sibling path was read: the aggregate
+    # warning at the end of this function is keyed on `not spec_text_was_read`
+    # and cannot fire once one path succeeds. Collected here, warned on below,
+    # regardless of the aggregate outcome.
+    unread_paths: list[str] = []
 
     spec_paths = _spec_paths(head_manifest, base_manifest)
     if not spec_paths:
@@ -155,6 +165,8 @@ def ac_change_set(
             raise ReadError(f"could not read {rel_path} at the {side} commit")
         if base_text or head_text:
             spec_text_was_read = True
+        else:
+            unread_paths.append(rel_path)
 
         h_minted, h_unminted = ac_criteria_digests(head_text)
         for key in h_minted:
@@ -215,6 +227,22 @@ def ac_change_set(
             f"{len(spec_paths)} spec_path(s) named ({', '.join(spec_paths)}) but none resolved "
             "to any content at either commit; the per-AC change set is trivially empty because "
             "there is nothing to compare, not because nothing changed."
+        )
+    elif unread_paths:
+        # A SIBLING spec path was read (else the branch above would have fired
+        # instead), so `spec_text_was_read` is True and arm 2's suppression --
+        # correctly, per design -- does NOT apply: any FR anchored to one of
+        # THESE paths is still judged against text nobody actually read. That
+        # is not a suppression bug (the flag is deliberately aggregate, per
+        # design's scope), but it must not be silent either -- naming the
+        # stale path(s) here is what lets an operator connect a later
+        # `new_frs_without_criteria` finding back to "was this path even
+        # read?" instead of taking the finding at face value.
+        result.warnings.append(
+            f"{len(unread_paths)} of {len(spec_paths)} spec_path(s) resolved to no content at "
+            f"either commit ({', '.join(unread_paths)}) even though another named spec_path was "
+            "read; any FR anchored to the unread path(s) is judged against text that was never "
+            "actually scanned."
         )
 
     for key, head_digest in head_minted.items():


### PR DESCRIPTION
## Summary
- `_keystone_ac_digest.ac_change_set` computed `spec_text_was_read` once across ALL named spec paths, so with multiple spec paths where one resolves to no content at either commit and another has real content, the aggregate flag stays True and the stale path got no warning of its own.
- The new-FR-without-criteria suppression stays keyed on the aggregate flag, unchanged, matching the design doc exactly (this is a code robustness gap, not a spec violation — low real-world likelihood since CI always regenerates the head manifest).
- Fix: collect the per-path unread set inside the read loop and warn on it directly, so an operator can trace a later `new_frs_without_criteria` finding back to "was this specific path even read?"

## Test plan
- [x] New test `test_one_stale_path_among_several_warns_even_though_a_sibling_was_read` pins both halves: suppression still correctly fires (unaffected), and the stale path now gets its own named warning
- [x] Full keystone test suite green (58/58): `uv run pytest shared/scripts/tools/tests/ -k keystone -q`
- [x] `uvx ruff@0.15.15 check` clean on changed files
- [x] `uv run scripts/verify_local.py` — all 3 mirrored CI gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhLBC5X4HP2WtRDBCeduHv