### PR TITLE
docs: document npx bootstrapper as the recommended plugins+WebUI install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,15 @@ A five-step path from zero to a self-merging pipeline. Each step links to the fu
 
 ### 1. Install the plugins
 
-The recommended, cross-platform path (Windows PowerShell, macOS, Linux, VS Code Extension terminal): register the marketplace, then install all 13 plugins.
+**Want the plugins *and* the [Command Center WebUI](https://github.com/svenroth-ai/shipwright-webui)?** Run one command — it installs/updates both, first run and every run after:
+
+```bash
+npx @svenroth-ai/shipwright@latest
+```
+
+Skip to [Step 2](#2-run-your-first-command) if you used this.
+
+**Plugins only, no WebUI:** register the marketplace, then install all 14 plugins directly with `claude plugin`. The recommended, cross-platform path (Windows PowerShell, macOS, Linux, VS Code Extension terminal):
 
 **bash / zsh / Git Bash:**
 
@@ -226,7 +234,7 @@ foreach ($p in @('shipwright-run','shipwright-project','shipwright-design',
 Verify, then **restart Claude Code** (freshly installed plugins activate only in a new session):
 
 ```bash
-claude plugin list   # all 13 should show ✔ enabled
+claude plugin list   # all 14 should show ✔ enabled
 ```
 
 > **Alternatives:** a bash all-in-one installer (`./scripts/install.sh`, creates a `shipwright` shell alias), see [§2.4](docs/guide.md#24-plugin-install--option-b-scriptsinstallsh-macos-linux-git-bash-on-windows); or a manual `settings.json` edit, see [§2.6](docs/guide.md#26-plugin-install--option-d-manual-settingsjson-edit-advanced).
@@ -242,6 +250,14 @@ claude plugin list   # all 13 should show ✔ enabled
 See [Chapter 3](docs/guide.md#3-your-first-project) (greenfield) and [Chapter 3.5](docs/guide.md#35-adopting-an-existing-repo) (brownfield).
 
 ### 3. Keep Shipwright updated
+
+Installed via `npx`? Re-run the same command — it updates the plugins and the WebUI together:
+
+```bash
+npx @svenroth-ai/shipwright@latest
+```
+
+Installed via marketplace instead:
 
 ```bash
 claude plugin marketplace update shipwright

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -217,7 +217,7 @@ The shipwright-webui repo carries its own Acknowledgments block referencing the 
 
 ### 2.1 Fresh-machine baseline
 
-Pick the block matching your OS, paste it into a terminal, then continue with §2.3 (Marketplace install). Each block installs the runtimes Shipwright needs and points you at Anthropic's installer for Claude Code itself.
+Pick the block matching your OS, paste it into a terminal, then continue with §2.3 (installing Shipwright). Each block installs the runtimes Shipwright needs and points you at Anthropic's installer for Claude Code itself.
 
 **Windows 11 (PowerShell, no admin needed):**
 
@@ -279,9 +279,17 @@ The baseline above already installed everything in this table. It stays here as 
 | Supabase CLI | Supabase migrations |
 | Mermaid Preview (VSCode) | Rendering compliance Mermaid diagrams |
 
-### 2.3 Plugin install — Option A: Marketplace via `claude plugin` CLI (recommended, cross-platform)
+### 2.3 Installing Shipwright: npx (recommended) or Marketplace (plugins only)
 
-This is the modern, idiomatic path. It works identically on Windows PowerShell, macOS, Linux, and inside the VSCode Extension's terminal.
+**Want the plugins *and* the [Command Center WebUI](#13-command-center-webui)?** Run one command — it verifies prerequisites, installs/updates every plugin from the marketplace manifest (and syncs the plugin cache so hooks resolve), then boots the Command Center and opens it, first run and every run after:
+
+```bash
+npx @svenroth-ai/shipwright@latest
+```
+
+Always include `@latest` — a bare `npx` can silently reuse a stale cached copy. Flags: `--plugins-only` (skip the Command Center), `--webui-only` (skip the plugin phase), `--no-open`, `--port <n>`. If this is your path, skip ahead to [§2.9](#29-connect-github) — the rest of this chapter (Options B-D, verification) covers the plugins-only Marketplace/manual routes below.
+
+**Plugins only, no Command Center — Marketplace via `claude plugin` CLI:** works identically on Windows PowerShell, macOS, Linux, and inside the VSCode Extension's terminal.
 
 ```bash
 # End-users: install from GitHub
@@ -464,7 +472,9 @@ You should see the SHIPWRIGHT-RUN banner.
 
 ### 2.8 Command Center WebUI
 
-The Command Center WebUI lives in its own repo: [shipwright-webui](https://github.com/svenroth-ai/shipwright-webui). Clone it separately and follow its README:
+The Command Center WebUI lives in its own repo: [shipwright-webui](https://github.com/svenroth-ai/shipwright-webui). If you didn't already install it via §2.3's `npx @svenroth-ai/shipwright@latest`, that same command installs and boots it (add `--webui-only` to skip re-checking the plugins).
+
+Building from source instead (contributors, or an unpublished checkout)?
 
 ```bash
 git clone https://github.com/svenroth-ai/shipwright-webui.git ~/shipwright-webui
@@ -2605,6 +2615,15 @@ The Command Center lives in its own repo:
 ### Quick start
 
 ```bash
+npx @svenroth-ai/shipwright@latest
+```
+
+One command installs/updates the `/shipwright-*` plugins **and** the Command Center, then boots it on **:3847** and opens it in your browser — re-running the same command later is how you update. Add `--webui-only` to boot the Command Center without touching the plugins.
+
+<details>
+<summary>Building from source instead (contributors, or an unpublished checkout)</summary>
+
+```bash
 git clone https://github.com/svenroth-ai/shipwright-webui.git ~/shipwright-webui
 cd ~/shipwright-webui
 make install       # npm install in server/ + client/
@@ -2612,7 +2631,10 @@ make dev-server    # Terminal 1 — backend on :3847
 make dev-client    # Terminal 2 — frontend on :5173
 ```
 
-Then open <http://localhost:5173>. The full user guide (installation,
+Then open <http://localhost:5173>.
+</details>
+
+The full user guide (installation,
 daily workflow, recommended terminal setup, custom actions for your
 own slash skills, Windows autostart) lives at
 **[docs/guide.md](https://github.com/svenroth-ai/shipwright-webui/blob/main/docs/guide.md)**

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,15 +94,10 @@ echo ""
 
 # ── Command Center WebUI (separate repo since v0.4.0) ──
 
-echo "Command Center WebUI:"
-echo "  The WebUI lives in its own repository since v0.4.0:"
-echo "    https://github.com/svenroth-ai/shipwright-webui"
-echo ""
-echo "  To install it alongside Shipwright:"
-echo "    git clone https://github.com/svenroth-ai/shipwright-webui.git ~/shipwright-webui"
-echo "    cd ~/shipwright-webui && make install"
-echo "    make dev-server   # Terminal 1 (Hono :3847)"
-echo "    make dev-client   # Terminal 2 (Vite :5173)"
+echo "Command Center WebUI (optional):"
+echo "  One command installs/updates the plugins AND the WebUI together:"
+echo "    npx @svenroth-ai/shipwright@latest"
+echo "  (Building from source instead? See https://github.com/svenroth-ai/shipwright-webui)"
 echo ""
 
 # ── Create shell alias ──
@@ -202,6 +197,5 @@ echo " Then run:           shipwright"
 echo " Then type:          /shipwright-run"
 echo ""
 echo " WebUI (Command Center):"
-echo "   Lives at https://github.com/svenroth-ai/shipwright-webui"
-echo "   See above for standalone install commands."
+echo "   npx @svenroth-ai/shipwright@latest"
 echo "========================================"


### PR DESCRIPTION
## Summary
- README.md / docs/guide.md only documented the Marketplace CLI path for plugins, and a stale `git clone` + `make dev-server`/`make dev-client` flow for the Command Center WebUI — neither mentioned the `npx @svenroth-ai/shipwright` bootstrapper, which is now the recommended one-command install/update for **both** plugins and WebUI together.
- Reframes the install sections: `npx @svenroth-ai/shipwright@latest` first (plugins + Command Center), Marketplace via `claude plugin` kept as the "plugins only, no WebUI" alternative.
- Demotes the `git clone` + `make` WebUI flow to a "from source / contributors" note in both guide.md WebUI sections (§2.8 and §13), matching how shipwright-webui's own docs already present it.
- Fixes a stray "13 plugins" undercount in README (all install lists actually enumerate 14).
- Syncs `scripts/install.sh`'s printed WebUI hint to point at `npx` instead of the old clone+make instructions.

Companion PR in shipwright-webui adds the missing `--plugins-only`/`--webui-only` flag documentation to its own README/guide.md for full cross-repo consistency.

## Test plan
- [x] Docs-only change; no code/behavior touched.
- [ ] Skim rendered README.md / docs/guide.md on GitHub for formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TivmkzjUFoQG91n87Yfdb8